### PR TITLE
Refactor document layout management and clean up unused code

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Helpers/WindowStateHelper.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/WindowStateHelper.cs
@@ -205,10 +205,10 @@ public sealed class WindowStateHelper
         var minimumSize = ComposeMinimumWindowSize();
 
         _logger.LogDebug(
-            "Applying minimum window size {Width} x {Height} at rasterization scale {Scale}, window sizes in physical pixels: {UsesPhysicalPixels}",
+            "Applying minimum window size {Width} x {Height} at scale {Scale}, window sizes in physical pixels: {UsesPhysicalPixels}",
             minimumSize.Width,
             minimumSize.Height,
-            _mainWindow?.Content?.XamlRoot?.RasterizationScale ?? 0,
+            WindowSizeScale,
             _platformInfo.WindowSizesUsePhysicalPixels);
 
         _windowSizeConstraints.ApplyMinimumSize(_appWindow, minimumSize);

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentAreaLayout.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentAreaLayout.cs
@@ -1,0 +1,801 @@
+using Celbridge.Documents.Helpers;
+using Celbridge.Documents.Services;
+using Celbridge.UserInterface.Helpers;
+using Celbridge.UserInterface.Views.Controls;
+using Celbridge.Workspace;
+using Celbridge.WorkspaceUI.Helpers;
+using Celbridge.WorkspaceUI.Views;
+using Windows.Foundation;
+
+namespace Celbridge.Documents.Views;
+
+/// <summary>
+/// The geometry of the three document areas inside the grids the workspace surface container provides:
+/// which areas are presented, how each one is split, the splitter that divides a split area, the floors its
+/// sections are held at, and the chrome they draw. The sections and the documents in them belong to
+/// DocumentSectionContainer, which this asks for a section view whenever it needs one.
+/// </summary>
+public sealed class DocumentAreaLayout
+{
+    private const double MinDragDistance = 5.0; // Minimum pixels to count as a real drag
+
+    private readonly WorkspaceSurfaceContainer _surfaceContainer;
+    private readonly Func<DocumentSection, DocumentSectionView> _sectionLookup;
+    private readonly Action<DocumentArea> _migrateSecondarySection;
+    private readonly AreaLayoutState _layoutState = new();
+    private readonly SectionChromeCalculator _chromeCalculator;
+    private readonly Dictionary<DocumentArea, Splitter> _splitSplitters = new();
+    private readonly Dictionary<DocumentArea, SplitterHelper> _splitHelpers = new();
+    private readonly Dictionary<DocumentArea, UIElement> _areaToolbars = new();
+
+    private double _totalDragDelta = 0;
+
+    /// <summary>
+    /// Event raised when an area's split state or split position changes.
+    /// </summary>
+    public event Action<DocumentArea, bool, double>? AreaLayoutChanged;
+
+    /// <summary>
+    /// The sections that are currently mounted, in reading order.
+    /// </summary>
+    public IReadOnlyList<DocumentSection> VisibleSections => _layoutState.VisibleSections;
+
+    /// <summary>
+    /// The sections a document can be selected from, which ignores any isolation so closing the last
+    /// document in an isolated area can move to one elsewhere.
+    /// </summary>
+    public IEnumerable<DocumentSection> SelectableSections => _layoutState.SelectableSections;
+
+    /// <summary>
+    /// The area currently shown on its own, or null when the areas are laid out normally.
+    /// </summary>
+    public DocumentArea? IsolatedArea => _layoutState.IsolatedArea;
+
+    // Folding an area migrates its secondary section's tabs into its primary one before the area is rebuilt,
+    // so no tab is left in an unmounted section. That is the section container's work, so it is passed in.
+    public DocumentAreaLayout(
+        WorkspaceSurfaceContainer surfaceContainer,
+        Func<DocumentSection, DocumentSectionView> sectionLookup,
+        Action<DocumentArea> migrateSecondarySection)
+    {
+        _surfaceContainer = surfaceContainer;
+        _sectionLookup = sectionLookup;
+        _migrateSecondarySection = migrateSecondarySection;
+
+        _surfaceContainer.BottomAreaSplitterSnapTargets = ResolveBottomAreaSnapTargets;
+
+        // An area's minimum derives from the sections inside its grid, which this class lays out, so the
+        // surface container asks for it rather than naming a size of its own.
+        _surfaceContainer.AreaMinimumSizes = GetAreaMinimumSize;
+
+        _chromeCalculator = new SectionChromeCalculator(_layoutState);
+
+        foreach (var area in DocumentLayoutHelper.AllAreas)
+        {
+            RebuildArea(area);
+            WatchAreaSize(area);
+        }
+
+        ApplyWorkspaceLayout();
+
+        _sectionLookup(DocumentArea.Main.GetPrimarySection()).Loaded += OnPrimarySectionLoaded;
+    }
+
+    /// <summary>
+    /// Whether the section is currently in the visual tree: its area is presented and, for a secondary
+    /// section, that area is split.
+    /// </summary>
+    public bool IsSectionMounted(DocumentSection section)
+    {
+        return _layoutState.IsSectionMounted(section);
+    }
+
+    /// <summary>
+    /// Whether the area is currently showing both of its sections.
+    /// </summary>
+    public bool IsAreaSplit(DocumentArea area)
+    {
+        return _layoutState.IsAreaSplit(area);
+    }
+
+    /// <summary>
+    /// Whether the area is currently visible. Main is always visible.
+    /// </summary>
+    public bool IsAreaVisible(DocumentArea area)
+    {
+        return _layoutState.IsAreaVisible(area);
+    }
+
+    /// <summary>
+    /// Gets the share of a split area taken by its primary section.
+    /// </summary>
+    public double GetAreaSplitRatio(DocumentArea area)
+    {
+        return _layoutState.GetAreaSplitRatio(area);
+    }
+
+    /// <summary>
+    /// The smallest size the area can be laid out at, or zero while it is not presented. A split area holds
+    /// two sections along its split axis, with a gutter between them.
+    /// </summary>
+    public Size GetAreaMinimumSize(DocumentArea area)
+    {
+        if (!_layoutState.IsAreaPresented(area))
+        {
+            return new Size(0, 0);
+        }
+
+        return WorkspaceMinimumSize.ComposeArea(
+            SectionMinimumSize,
+            isSplit: _layoutState.IsAreaSplit(area),
+            splitsHorizontally: area.SplitsHorizontally(),
+            gutterSize: GutterSize);
+    }
+
+    /// <summary>
+    /// Whether a document in the area can be moved into a new split: the area must be unsplit, have room
+    /// for two sections, and hold more than one document so the split does not empty its primary section.
+    /// </summary>
+    public bool CanStartAreaSplit(DocumentArea area)
+    {
+        int primaryTabCount = _sectionLookup(area.GetPrimarySection()).TabCount;
+
+        return _layoutState.CanStartSplit(area, CanSplitArea(area), primaryTabCount);
+    }
+
+    /// <summary>
+    /// Shows a single area filling the whole panel, hiding the other two, or restores the normal layout
+    /// when passed null. The isolated area keeps its own split, and every area's visibility, size and
+    /// split state are left untouched underneath, so clearing the isolation restores what the user had.
+    /// </summary>
+    public void SetIsolatedArea(DocumentArea? area)
+    {
+        if (_layoutState.SetIsolatedArea(area))
+        {
+            ApplyWorkspaceLayout();
+        }
+    }
+
+    /// <summary>
+    /// Sets whether the Utility Panel is showing alongside the document areas, which decides whether the
+    /// areas draw their left edge or leave it flush against the application border.
+    /// </summary>
+    public void SetUtilityPanelPresented(bool isPresented)
+    {
+        if (_layoutState.SetUtilityPanelPresented(isPresented))
+        {
+            ApplyWorkspaceLayout();
+        }
+    }
+
+    /// <summary>
+    /// Sets how far the Bottom area spans across the workspace: the Main area only, or across the Utility
+    /// Panel, the Side area, or both. The surfaces it runs across stop above it.
+    /// </summary>
+    public void SetBottomAreaAlignment(BottomAreaAlignment alignment)
+    {
+        if (_layoutState.SetBottomAreaAlignment(alignment))
+        {
+            ApplyWorkspaceLayout();
+        }
+    }
+
+    /// <summary>
+    /// Shows or hides an area. Hiding leaves its sections and their tabs intact, so the documents in a
+    /// collapsed area stay open and reappear where they were. Main is always visible.
+    /// </summary>
+    public void SetAreaVisible(DocumentArea area, bool isVisible)
+    {
+        if (_layoutState.SetAreaVisible(area, isVisible))
+        {
+            ApplyWorkspaceLayout();
+        }
+    }
+
+    /// <summary>
+    /// Splits the area into two sections, or folds its secondary section back into the primary one.
+    /// Folding migrates the secondary section's tabs rather than closing them.
+    /// </summary>
+    public void SetAreaSplit(DocumentArea area, bool isSplit)
+    {
+        if (!_layoutState.SetAreaSplit(area, isSplit))
+        {
+            return;
+        }
+
+        if (!isSplit)
+        {
+            _migrateSecondarySection(area);
+        }
+
+        RebuildArea(area);
+
+        // A split area needs room for two sections, so its minimum grows, and the workspace floors the
+        // surface container composes from it are re-applied by pushing the presentation again.
+        ApplyWorkspaceLayout();
+
+        AreaLayoutChanged?.Invoke(area, isSplit, _layoutState.GetAreaSplitRatio(area));
+    }
+
+    /// <summary>
+    /// Sets the share of a split area taken by its primary section.
+    /// </summary>
+    public void SetAreaSplitRatio(DocumentArea area, double ratio)
+    {
+        if (!_layoutState.SetAreaSplitRatio(area, ratio))
+        {
+            return;
+        }
+
+        if (_layoutState.IsAreaSplit(area))
+        {
+            ApplySplitRatio(area);
+        }
+    }
+
+    /// <summary>
+    /// Folds a split area back when either of its sections has run out of documents, so a split section is
+    /// never left empty. The surviving documents always end up in the primary section.
+    /// </summary>
+    public void ReconcileAreaSplit(DocumentArea area)
+    {
+        int primaryTabCount = _sectionLookup(area.GetPrimarySection()).TabCount;
+        int secondaryTabCount = _sectionLookup(area.GetSecondarySection()).TabCount;
+
+        // Unsplitting migrates the secondary section's tabs into the primary one, which covers both
+        // cases: an empty secondary migrates nothing, an empty primary receives everything.
+        if (_layoutState.ShouldFoldSplit(area, primaryTabCount, secondaryTabCount))
+        {
+            SetAreaSplit(area, false);
+        }
+    }
+
+    /// <summary>
+    /// Sets the toolbar hosted in an area's tab strip footer. The toolbar is re-placed on the section
+    /// nearest the area's top-right corner whenever that area is rebuilt.
+    /// </summary>
+    public void SetAreaToolbar(DocumentArea area, UIElement toolbar)
+    {
+        _areaToolbars[area] = toolbar;
+        PlaceAreaToolbar(area);
+    }
+
+    /// <summary>
+    /// Folds every area back to a single section and restores equal split positions.
+    /// </summary>
+    public async Task ResetAreaLayoutAsync()
+    {
+        foreach (var area in DocumentLayoutHelper.AllAreas)
+        {
+            _layoutState.SetAreaSplitRatio(area, AreaLayoutState.DefaultSplitRatio);
+            SetAreaSplit(area, false);
+        }
+
+        var tcs = new TaskCompletionSource<bool>();
+
+        // Wait for layout to complete so callers that persist the result read settled state.
+        GetAreaGrid(DocumentArea.Main).DispatcherQueue.TryEnqueue(() =>
+        {
+            foreach (var area in DocumentLayoutHelper.AllAreas)
+            {
+                AreaLayoutChanged?.Invoke(area, false, AreaLayoutState.DefaultSplitRatio);
+            }
+
+            tcs.SetResult(true);
+        });
+
+        await tcs.Task;
+    }
+
+    // The section chrome is measured from the tab strip the section template builds, which has no size until
+    // the section has laid out, so every minimum composed above stands on an unmeasured strip. Re-applies them
+    // on the cycle after the load, by which point the strip has been measured.
+    private void OnPrimarySectionLoaded(object sender, RoutedEventArgs e)
+    {
+        var primarySectionView = _sectionLookup(DocumentArea.Main.GetPrimarySection());
+        primarySectionView.Loaded -= OnPrimarySectionLoaded;
+
+        _ = primarySectionView.DispatcherQueue.TryEnqueue(() =>
+        {
+            foreach (var area in DocumentLayoutHelper.AllAreas)
+            {
+                ApplySectionTrackMinimums(area);
+            }
+
+            ApplyWorkspaceLayout();
+        });
+    }
+
+    // An area that shrinks below the room for two sections can no longer be split, which the tab context
+    // menu reflects.
+    private void WatchAreaSize(DocumentArea area)
+    {
+        var areaGrid = GetAreaGrid(area);
+        areaGrid.SizeChanged += (s, e) =>
+        {
+            UpdateSectionMoveTargets(area);
+        };
+    }
+
+    // Whether the area currently has room for two sections at their minimum size.
+    private bool CanSplitArea(DocumentArea area)
+    {
+        var areaGrid = GetAreaGrid(area);
+        var splitMinimum = WorkspaceMinimumSize.ComposeArea(
+            SectionMinimumSize,
+            isSplit: true,
+            splitsHorizontally: area.SplitsHorizontally(),
+            gutterSize: GutterSize);
+
+        if (area.SplitsHorizontally())
+        {
+            return areaGrid.ActualWidth >= splitMinimum.Width;
+        }
+
+        return areaGrid.ActualHeight >= splitMinimum.Height;
+    }
+
+    // Every section is built from the same template, so the Main area's primary section, the one section that
+    // is always mounted, measures the chrome on behalf of all of them.
+    private Size SectionMinimumSize => _sectionLookup(DocumentArea.Main.GetPrimarySection()).MinimumSize;
+
+    // The channel between two surfaces. The splitter in it takes this size, which is what holds the gap open.
+    private static double GutterSize => (double)Application.Current.Resources["GutterSize"];
+
+    // The floor a split area's sections are held at, along the axis its split splitter moves.
+    private double ResolveSplitSectionMinimum(DocumentArea area)
+    {
+        if (area.SplitsHorizontally())
+        {
+            return SectionMinimumSize.Width;
+        }
+
+        return SectionMinimumSize.Height;
+    }
+
+    private Grid GetAreaGrid(DocumentArea area)
+    {
+        return _surfaceContainer.GetAreaGrid(area);
+    }
+
+    // Rebuilds an area's internal grid for its current split state. Sections that stay mounted are left
+    // attached: reparenting a section resets its TabView measurement and leaves the tab strip stuck in
+    // an overflow-scroll state until the next real resize.
+    private void RebuildArea(DocumentArea area)
+    {
+        var areaGrid = GetAreaGrid(area);
+        bool isSplit = _layoutState.IsAreaSplit(area);
+        bool isHorizontal = area.SplitsHorizontally();
+
+        var primarySectionView = _sectionLookup(area.GetPrimarySection());
+        var secondarySectionView = _sectionLookup(area.GetSecondarySection());
+
+        if (_splitSplitters.TryGetValue(area, out var existingSplitter))
+        {
+            existingSplitter.DragStarted -= Splitter_DragStarted;
+            existingSplitter.DragDelta -= Splitter_DragDelta;
+            existingSplitter.DragCompleted -= Splitter_DragCompleted;
+            existingSplitter.DoubleClicked -= Splitter_DoubleClicked;
+            areaGrid.Children.Remove(existingSplitter);
+            _splitSplitters.Remove(area);
+            _splitHelpers.Remove(area);
+        }
+
+        if (!isSplit &&
+            areaGrid.Children.Contains(secondarySectionView))
+        {
+            areaGrid.Children.Remove(secondarySectionView);
+        }
+
+        areaGrid.ColumnDefinitions.Clear();
+        areaGrid.RowDefinitions.Clear();
+
+        double ratio = _layoutState.GetAreaSplitRatio(area);
+
+        if (isHorizontal)
+        {
+            areaGrid.ColumnDefinitions.Add(new ColumnDefinition
+            {
+                Width = new GridLength(isSplit ? ratio : 1, GridUnitType.Star)
+            });
+        }
+        else
+        {
+            areaGrid.RowDefinitions.Add(new RowDefinition
+            {
+                Height = new GridLength(isSplit ? ratio : 1, GridUnitType.Star)
+            });
+        }
+
+        SetSectionPosition(primarySectionView, isHorizontal, 0);
+        if (!areaGrid.Children.Contains(primarySectionView))
+        {
+            areaGrid.Children.Add(primarySectionView);
+        }
+
+        if (isSplit)
+        {
+            if (isHorizontal)
+            {
+                areaGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                areaGrid.ColumnDefinitions.Add(new ColumnDefinition
+                {
+                    Width = new GridLength(1 - ratio, GridUnitType.Star)
+                });
+            }
+            else
+            {
+                areaGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+                areaGrid.RowDefinitions.Add(new RowDefinition
+                {
+                    Height = new GridLength(1 - ratio, GridUnitType.Star)
+                });
+            }
+
+            var splitter = CreateSplitSplitter(area, isHorizontal);
+            SetSectionPosition(splitter, isHorizontal, 1);
+            areaGrid.Children.Add(splitter);
+            _splitSplitters[area] = splitter;
+
+            SetSectionPosition(secondarySectionView, isHorizontal, 2);
+            if (!areaGrid.Children.Contains(secondarySectionView))
+            {
+                areaGrid.Children.Add(secondarySectionView);
+            }
+        }
+
+        ApplySectionTrackMinimums(area);
+        UpdateSectionMoveTargets(area);
+        PlaceAreaToolbar(area);
+        ApplyAreaSectionChrome(area);
+    }
+
+    // Puts the composed section minimum on the tracks the area's sections sit in. The gutter track between
+    // them is auto sized and carries none of its own.
+    private void ApplySectionTrackMinimums(DocumentArea area)
+    {
+        var areaGrid = GetAreaGrid(area);
+        var sectionMinimum = SectionMinimumSize;
+
+        if (area.SplitsHorizontally())
+        {
+            foreach (var columnDefinition in areaGrid.ColumnDefinitions)
+            {
+                if (columnDefinition.Width.IsStar)
+                {
+                    columnDefinition.MinWidth = sectionMinimum.Width;
+                }
+            }
+
+            return;
+        }
+
+        foreach (var rowDefinition in areaGrid.RowDefinitions)
+        {
+            if (rowDefinition.Height.IsStar)
+            {
+                rowDefinition.MinHeight = sectionMinimum.Height;
+            }
+        }
+    }
+
+    private static void SetSectionPosition(FrameworkElement element, bool isHorizontal, int index)
+    {
+        if (isHorizontal)
+        {
+            Grid.SetColumn(element, index);
+            Grid.SetRow(element, 0);
+        }
+        else
+        {
+            Grid.SetRow(element, index);
+            Grid.SetColumn(element, 0);
+        }
+    }
+
+    private Splitter CreateSplitSplitter(DocumentArea area, bool isHorizontal)
+    {
+        var splitter = new Splitter
+        {
+            // A horizontally split area is divided by a vertical splitter, and the reverse.
+            Orientation = isHorizontal ? Orientation.Vertical : Orientation.Horizontal,
+            Tag = area
+        };
+
+        splitter.DragStarted += Splitter_DragStarted;
+        splitter.DragDelta += Splitter_DragDelta;
+        splitter.DragCompleted += Splitter_DragCompleted;
+        splitter.DoubleClicked += Splitter_DoubleClicked;
+
+        return splitter;
+    }
+
+    // Places an area's toolbar on the section nearest that area's top-right corner: the right-hand
+    // section of a horizontally split area, and the top section of the Side area.
+    private void PlaceAreaToolbar(DocumentArea area)
+    {
+        if (!_areaToolbars.TryGetValue(area, out var toolbar))
+        {
+            return;
+        }
+
+        var primarySectionView = _sectionLookup(area.GetPrimarySection());
+        var secondarySectionView = _sectionLookup(area.GetSecondarySection());
+
+        bool toolbarOnSecondary = area.SplitsHorizontally() && _layoutState.IsAreaSplit(area);
+
+        primarySectionView.SetTabStripFooter(toolbarOnSecondary ? null : toolbar);
+        secondarySectionView.SetTabStripFooter(toolbarOnSecondary ? toolbar : null);
+    }
+
+    // Pushes the area state the tab context menu needs down onto its tabs: whether the area is split, and
+    // whether it has room to be.
+    private void UpdateSectionMoveTargets(DocumentArea area)
+    {
+        bool isSplit = _layoutState.IsAreaSplit(area);
+        bool canSplit = CanSplitArea(area);
+
+        foreach (var section in area.GetSections())
+        {
+            var sectionView = _sectionLookup(section);
+            sectionView.IsAreaSplit = isSplit;
+            sectionView.CanSplitArea = canSplit;
+        }
+    }
+
+    private void ApplySplitRatio(DocumentArea area)
+    {
+        var areaGrid = GetAreaGrid(area);
+        double ratio = _layoutState.GetAreaSplitRatio(area);
+
+        if (area.SplitsHorizontally())
+        {
+            if (areaGrid.ColumnDefinitions.Count == 3)
+            {
+                areaGrid.ColumnDefinitions[0].Width = new GridLength(ratio, GridUnitType.Star);
+                areaGrid.ColumnDefinitions[2].Width = new GridLength(1 - ratio, GridUnitType.Star);
+            }
+        }
+        else
+        {
+            if (areaGrid.RowDefinitions.Count == 3)
+            {
+                areaGrid.RowDefinitions[0].Height = new GridLength(ratio, GridUnitType.Star);
+                areaGrid.RowDefinitions[2].Height = new GridLength(1 - ratio, GridUnitType.Star);
+            }
+        }
+    }
+
+    // Pushes the current presentation to the surface container, then re-applies the section chrome,
+    // which depends on which surfaces the sections now face.
+    private void ApplyWorkspaceLayout()
+    {
+        var presentation = new WorkspaceSurfacePresentation(
+            IsMainAreaPresented: _layoutState.IsAreaPresented(DocumentArea.Main),
+            IsBottomAreaPresented: _layoutState.IsAreaPresented(DocumentArea.Bottom),
+            IsSideAreaPresented: _layoutState.IsAreaPresented(DocumentArea.Side),
+            IsUtilityPanelPresented: _layoutState.IsUtilityPanelPresented,
+            BottomAreaSpansUtilityPanel: _layoutState.BottomAreaSpansUtilityPanel,
+            BottomAreaSpansSideArea: _layoutState.BottomAreaSpansSideArea);
+
+        _surfaceContainer.ApplyPresentation(presentation);
+
+        ApplySectionChrome();
+    }
+
+    // A section is the rectangle a document actually sits in, so the chrome is drawn per section rather than
+    // per area: the gutter splitting one area into two divides two such rectangles, exactly as the gutter
+    // between two areas does.
+    private void ApplySectionChrome()
+    {
+        foreach (var area in DocumentLayoutHelper.AllAreas)
+        {
+            ApplyAreaSectionChrome(area);
+        }
+    }
+
+    // Splitting an area moves an inner edge onto a section that did not have one, so this runs on every
+    // rebuild rather than only when the root grid layout changes.
+    private void ApplyAreaSectionChrome(DocumentArea area)
+    {
+        double cornerRadius = (double)Application.Current.Resources["PanelCornerRadius"];
+        var areaChrome = _chromeCalculator.CalculateAreaChrome(area, cornerRadius);
+
+        var primarySectionView = _sectionLookup(area.GetPrimarySection());
+        primarySectionView.SetGutterChrome(areaChrome.Primary.Edges, areaChrome.Primary.Corners);
+
+        if (areaChrome.Secondary is SectionChrome secondaryChrome)
+        {
+            var secondarySectionView = _sectionLookup(area.GetSecondarySection());
+            secondarySectionView.SetGutterChrome(secondaryChrome.Edges, secondaryChrome.Corners);
+        }
+    }
+
+    private void Splitter_DragStarted(object? sender, EventArgs e)
+    {
+        if (sender is not Splitter splitter || splitter.Tag is not DocumentArea area)
+        {
+            return;
+        }
+
+        _totalDragDelta = 0;
+
+        if (!_splitHelpers.TryGetValue(area, out var helper))
+        {
+            var areaGrid = GetAreaGrid(area);
+            var mode = area.SplitsHorizontally() ? GridResizeMode.Columns : GridResizeMode.Rows;
+            helper = new SplitterHelper(areaGrid, mode, 0, 2, minSizeFunc: () => ResolveSplitSectionMinimum(area))
+            {
+                SnapTargets = () => ResolveSplitSnapTargets(area)
+            };
+            _splitHelpers[area] = helper;
+        }
+
+        helper.OnDragStarted();
+    }
+
+    // The size an area's primary section takes when its split divider lines up with the one it pairs with.
+    // Main and Bottom share a grid column, so their dividers align when their primary sections are the same
+    // width. The Side area starts at the same row as Main, so its divider is measured from the same origin
+    // as the Main/Bottom boundary and aligns when its primary section matches the Main area's height. An
+    // alignment that runs the Bottom area under the Side area leaves nothing to line up with, so it has no
+    // target.
+    private IReadOnlyList<double> ResolveSplitSnapTargets(DocumentArea area)
+    {
+        if (area == DocumentArea.Side)
+        {
+            if (!_layoutState.IsAreaPresented(DocumentArea.Main) ||
+                !_layoutState.IsAreaPresented(DocumentArea.Bottom) ||
+                _layoutState.BottomAreaSpansSideArea)
+            {
+                return Array.Empty<double>();
+            }
+
+            return new[]
+            {
+                GetAreaGrid(DocumentArea.Main).ActualHeight
+            };
+        }
+
+        var partnerArea = area == DocumentArea.Main ? DocumentArea.Bottom : DocumentArea.Main;
+
+        if (!_layoutState.IsAreaPresented(partnerArea) ||
+            !_layoutState.IsAreaSplit(partnerArea))
+        {
+            return Array.Empty<double>();
+        }
+
+        var partnerGrid = GetAreaGrid(partnerArea);
+
+        if (partnerGrid.ColumnDefinitions.Count == 0)
+        {
+            return Array.Empty<double>();
+        }
+
+        return new[]
+        {
+            partnerGrid.ColumnDefinitions[0].ActualWidth
+        };
+    }
+
+    // The Bottom area height that puts the Main/Bottom boundary level with the Side area's split divider.
+    // That divider is measured down from the top of the Main area while the Bottom splitter sizes the
+    // Bottom area up from the base, so the target is the two areas' height less the Side area's primary
+    // section. An alignment that runs the Bottom area under the Side area leaves nothing to line up with.
+    // Supplied to the surface container, whose splitter owns the snapping.
+    private IReadOnlyList<double> ResolveBottomAreaSnapTargets()
+    {
+        if (!_layoutState.IsAreaPresented(DocumentArea.Side) ||
+            !_layoutState.IsAreaSplit(DocumentArea.Side) ||
+            _layoutState.BottomAreaSpansSideArea)
+        {
+            return Array.Empty<double>();
+        }
+
+        var sideAreaGrid = GetAreaGrid(DocumentArea.Side);
+
+        if (sideAreaGrid.RowDefinitions.Count == 0)
+        {
+            return Array.Empty<double>();
+        }
+
+        double sidePrimaryHeight = sideAreaGrid.RowDefinitions[0].ActualHeight;
+        double documentRowsHeight = GetAreaGrid(DocumentArea.Main).ActualHeight +
+            GetAreaGrid(DocumentArea.Bottom).ActualHeight;
+        double alignedBottomHeight = documentRowsHeight - sidePrimaryHeight;
+
+        return new[]
+        {
+            alignedBottomHeight
+        };
+    }
+
+    private void Splitter_DragDelta(object? sender, double delta)
+    {
+        if (sender is not Splitter splitter || splitter.Tag is not DocumentArea area)
+        {
+            return;
+        }
+
+        _totalDragDelta += Math.Abs(delta);
+
+        if (_splitHelpers.TryGetValue(area, out var helper))
+        {
+            helper.OnDragDelta(delta);
+        }
+    }
+
+    private void Splitter_DragCompleted(object? sender, EventArgs e)
+    {
+        if (sender is not Splitter splitter || splitter.Tag is not DocumentArea area)
+        {
+            return;
+        }
+
+        // Skip if no significant drag occurred (e.g., just a click without dragging)
+        if (_totalDragDelta < MinDragDistance)
+        {
+            return;
+        }
+
+        double ratio = MeasureSplitRatio(area);
+        if (ratio > 0 && ratio < 1)
+        {
+            _layoutState.SetAreaSplitRatio(area, ratio);
+
+            // Convert back to proportional Star sizing so the split holds its share as the area resizes.
+            ApplySplitRatio(area);
+
+            AreaLayoutChanged?.Invoke(area, true, ratio);
+        }
+    }
+
+    private void Splitter_DoubleClicked(object? sender, EventArgs e)
+    {
+        if (sender is not Splitter splitter || splitter.Tag is not DocumentArea area)
+        {
+            return;
+        }
+
+        _layoutState.SetAreaSplitRatio(area, AreaLayoutState.DefaultSplitRatio);
+        ApplySplitRatio(area);
+
+        AreaLayoutChanged?.Invoke(area, true, AreaLayoutState.DefaultSplitRatio);
+    }
+
+    // The share of the area currently taken by its primary section, measured from the settled grid.
+    private double MeasureSplitRatio(DocumentArea area)
+    {
+        var areaGrid = GetAreaGrid(area);
+
+        double primarySize;
+        double secondarySize;
+
+        if (area.SplitsHorizontally())
+        {
+            if (areaGrid.ColumnDefinitions.Count != 3)
+            {
+                return 0;
+            }
+            primarySize = areaGrid.ColumnDefinitions[0].ActualWidth;
+            secondarySize = areaGrid.ColumnDefinitions[2].ActualWidth;
+        }
+        else
+        {
+            if (areaGrid.RowDefinitions.Count != 3)
+            {
+                return 0;
+            }
+            primarySize = areaGrid.RowDefinitions[0].ActualHeight;
+            secondarySize = areaGrid.RowDefinitions[2].ActualHeight;
+        }
+
+        double total = primarySize + secondarySize;
+        if (total <= 0)
+        {
+            return 0;
+        }
+
+        return primarySize / total;
+    }
+}

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentAreaLayout.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentAreaLayout.cs
@@ -82,28 +82,11 @@ public sealed class DocumentAreaLayout
     }
 
     /// <summary>
-    /// Whether the section is currently in the visual tree: its area is presented and, for a secondary
-    /// section, that area is split.
-    /// </summary>
-    public bool IsSectionMounted(DocumentSection section)
-    {
-        return _layoutState.IsSectionMounted(section);
-    }
-
-    /// <summary>
     /// Whether the area is currently showing both of its sections.
     /// </summary>
     public bool IsAreaSplit(DocumentArea area)
     {
         return _layoutState.IsAreaSplit(area);
-    }
-
-    /// <summary>
-    /// Whether the area is currently visible. Main is always visible.
-    /// </summary>
-    public bool IsAreaVisible(DocumentArea area)
-    {
-        return _layoutState.IsAreaVisible(area);
     }
 
     /// <summary>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.cs
@@ -1,11 +1,4 @@
-using Celbridge.Documents.Helpers;
-using Celbridge.Documents.Services;
-using Celbridge.UserInterface.Helpers;
-using Celbridge.UserInterface.Views.Controls;
-using Celbridge.Workspace;
-using Celbridge.WorkspaceUI.Helpers;
 using Celbridge.WorkspaceUI.Views;
-using Windows.Foundation;
 
 namespace Celbridge.Documents.Views;
 
@@ -15,24 +8,14 @@ namespace Celbridge.Documents.Views;
 public record DocumentTabLocation(DocumentSectionView SectionView, DocumentTab Tab);
 
 /// <summary>
-/// Manages the document sections inside the area grids the workspace surface container provides: which
-/// sections are mounted, per-area splits, section chrome, and the active document. Surface geometry
-/// (visibility, sizes, the Bottom area's alignment spans) is pushed to the surface container as a
-/// presentation snapshot rather than applied here.
+/// Owns the document sections and the documents in them: which section holds which tab, which document is
+/// active, what takes over when one closes, and moving tabs between sections. The geometry of the areas the
+/// sections are laid out in belongs to DocumentAreaLayout, which this creates and exposes.
 /// </summary>
 public sealed partial class DocumentSectionContainer
 {
-    private const double MinDragDistance = 5.0; // Minimum pixels to count as a real drag
-
-    private readonly WorkspaceSurfaceContainer _surfaceContainer;
-    private readonly AreaLayoutState _layoutState = new();
-    private readonly SectionChromeCalculator _chromeCalculator;
+    private readonly DocumentAreaLayout _areaLayout;
     private readonly Dictionary<DocumentSection, DocumentSectionView> _sections = new();
-    private readonly Dictionary<DocumentArea, Splitter> _splitSplitters = new();
-    private readonly Dictionary<DocumentArea, SplitterHelper> _splitHelpers = new();
-    private readonly Dictionary<DocumentArea, UIElement> _areaToolbars = new();
-
-    private double _totalDragDelta = 0;
 
     private DocumentSection _activeSection = DocumentSection.MainLeft;
     private ResourceKey _activeDocument = ResourceKey.Empty;
@@ -64,20 +47,16 @@ public sealed partial class DocumentSectionContainer
     public event Action<DocumentSectionView, DocumentTab, DocumentTabMenuAction>? ContextMenuActionRequested;
 
     /// <summary>
-    /// Event raised when an area's split state or split position changes.
-    /// </summary>
-    public event Action<DocumentArea, bool, double>? AreaLayoutChanged;
-
-    /// <summary>
     /// Event raised when resource files are dropped into a section from the ResourceTree, with the
     /// insertion slot in the tab order the drop point maps to.
     /// </summary>
     public event Action<DocumentSectionView, List<IResource>, int>? FilesDropped;
 
     /// <summary>
-    /// The sections that are currently mounted, in reading order.
+    /// The geometry of the areas the sections are laid out in: area visibility, splits and their splitters,
+    /// the section floors and the section chrome.
     /// </summary>
-    public IReadOnlyList<DocumentSection> VisibleSections => _layoutState.VisibleSections;
+    public DocumentAreaLayout Areas => _areaLayout;
 
     /// <summary>
     /// Gets the active document - the document being inspected.
@@ -91,117 +70,15 @@ public sealed partial class DocumentSectionContainer
 
     public DocumentSectionContainer(WorkspaceSurfaceContainer surfaceContainer)
     {
-        _surfaceContainer = surfaceContainer;
-        _surfaceContainer.BottomAreaSplitterSnapTargets = ResolveBottomAreaSnapTargets;
-
-        // An area's minimum derives from the sections inside its grid, which this container owns, so the
-        // surface container asks for it rather than naming a size of its own.
-        _surfaceContainer.AreaMinimumSizes = GetAreaMinimumSize;
-
-        _chromeCalculator = new SectionChromeCalculator(_layoutState);
-
         // Every section exists for the lifetime of the container: a collapsed area keeps its tabs while
-        // its sections are unmounted from the visual tree.
+        // its sections are unmounted from the visual tree. They are created before the area layout so it
+        // has a section to lay out in every grid it builds.
         foreach (var section in DocumentLayoutHelper.AllSections)
         {
             CreateSection(section);
         }
 
-        foreach (var area in DocumentLayoutHelper.AllAreas)
-        {
-            RebuildArea(area);
-            WatchAreaSize(area);
-        }
-
-        ApplyWorkspaceLayout();
-
-        _sections[DocumentArea.Main.GetPrimarySection()].Loaded += OnPrimarySectionLoaded;
-    }
-
-    // The section chrome is measured from the tab strip the section template builds, which has no size until
-    // the section has laid out, so every minimum composed above stands on an unmeasured strip. Re-applies them
-    // on the cycle after the load, by which point the strip has been measured.
-    private void OnPrimarySectionLoaded(object sender, RoutedEventArgs e)
-    {
-        var primarySectionView = _sections[DocumentArea.Main.GetPrimarySection()];
-        primarySectionView.Loaded -= OnPrimarySectionLoaded;
-
-        _ = primarySectionView.DispatcherQueue.TryEnqueue(() =>
-        {
-            foreach (var area in DocumentLayoutHelper.AllAreas)
-            {
-                ApplySectionTrackMinimums(area);
-            }
-
-            ApplyWorkspaceLayout();
-        });
-    }
-
-    // An area that shrinks below the room for two sections can no longer be split, which the tab context
-    // menu reflects.
-    private void WatchAreaSize(DocumentArea area)
-    {
-        var areaGrid = GetAreaGrid(area);
-        areaGrid.SizeChanged += (s, e) =>
-        {
-            UpdateSectionMoveTargets(area);
-        };
-    }
-
-    /// <summary>
-    /// Whether the area currently has room for two sections at their minimum size.
-    /// </summary>
-    public bool CanSplitArea(DocumentArea area)
-    {
-        var areaGrid = GetAreaGrid(area);
-        var splitMinimum = WorkspaceMinimumSize.ComposeArea(
-            SectionMinimumSize,
-            isSplit: true,
-            splitsHorizontally: area.SplitsHorizontally(),
-            gutterSize: GutterSize);
-
-        if (area.SplitsHorizontally())
-        {
-            return areaGrid.ActualWidth >= splitMinimum.Width;
-        }
-
-        return areaGrid.ActualHeight >= splitMinimum.Height;
-    }
-
-    /// <summary>
-    /// The smallest size the area can be laid out at, or zero while it is not presented. A split area holds
-    /// two sections along its split axis, with a gutter between them.
-    /// </summary>
-    public Size GetAreaMinimumSize(DocumentArea area)
-    {
-        if (!_layoutState.IsAreaPresented(area))
-        {
-            return new Size(0, 0);
-        }
-
-        return WorkspaceMinimumSize.ComposeArea(
-            SectionMinimumSize,
-            isSplit: _layoutState.IsAreaSplit(area),
-            splitsHorizontally: area.SplitsHorizontally(),
-            gutterSize: GutterSize);
-    }
-
-    // Every section is built from the same template, so the Main area's primary section, the one section that
-    // is always mounted, measures the chrome on behalf of all of them.
-    private Size SectionMinimumSize => _sections[DocumentArea.Main.GetPrimarySection()].MinimumSize;
-
-    // The channel between two surfaces. The splitter in it takes this size, which is what holds the gap open.
-    private static double GutterSize => (double)Application.Current.Resources["GutterSize"];
-
-    // The floor a split area's sections are held at, along the axis its split splitter moves.
-    private double ResolveSplitSectionMinimum(DocumentArea area)
-    {
-        if (area.SplitsHorizontally())
-        {
-            return SectionMinimumSize.Width;
-        }
-
-        return SectionMinimumSize.Height;
+        _areaLayout = new DocumentAreaLayout(surfaceContainer, GetSection, MigrateSecondarySection);
     }
 
     /// <summary>
@@ -217,7 +94,7 @@ public sealed partial class DocumentSectionContainer
     /// </summary>
     public IEnumerable<DocumentSectionView> GetMountedSections()
     {
-        foreach (var section in VisibleSections)
+        foreach (var section in _areaLayout.VisibleSections)
         {
             yield return _sections[section];
         }
@@ -232,172 +109,6 @@ public sealed partial class DocumentSectionContainer
         {
             yield return _sections[section];
         }
-    }
-
-    /// <summary>
-    /// Whether the section is currently in the visual tree: its area is presented and, for a secondary
-    /// section, that area is split.
-    /// </summary>
-    public bool IsSectionMounted(DocumentSection section)
-    {
-        return _layoutState.IsSectionMounted(section);
-    }
-
-    /// <summary>
-    /// The area currently shown on its own, or null when the areas are laid out normally.
-    /// </summary>
-    public DocumentArea? IsolatedArea => _layoutState.IsolatedArea;
-
-    /// <summary>
-    /// Shows a single area filling the whole panel, hiding the other two, or restores the normal layout
-    /// when passed null. The isolated area keeps its own split, and every area's visibility, size and
-    /// split state are left untouched underneath, so clearing the isolation restores what the user had.
-    /// </summary>
-    public void SetIsolatedArea(DocumentArea? area)
-    {
-        if (_layoutState.SetIsolatedArea(area))
-        {
-            ApplyWorkspaceLayout();
-        }
-    }
-
-    /// <summary>
-    /// Sets whether the Utility Panel is showing alongside the document areas, which decides whether the
-    /// areas draw their left edge or leave it flush against the application border.
-    /// </summary>
-    public void SetUtilityPanelPresented(bool isPresented)
-    {
-        if (_layoutState.SetUtilityPanelPresented(isPresented))
-        {
-            ApplyWorkspaceLayout();
-        }
-    }
-
-    /// <summary>
-    /// Sets how far the Bottom area spans across the workspace: the Main area only, or across the Utility
-    /// Panel, the Side area, or both. The surfaces it runs across stop above it.
-    /// </summary>
-    public void SetBottomAreaAlignment(BottomAreaAlignment alignment)
-    {
-        if (_layoutState.SetBottomAreaAlignment(alignment))
-        {
-            ApplyWorkspaceLayout();
-        }
-    }
-
-    /// <summary>
-    /// Whether the area is currently showing both of its sections.
-    /// </summary>
-    public bool IsAreaSplit(DocumentArea area)
-    {
-        return _layoutState.IsAreaSplit(area);
-    }
-
-    /// <summary>
-    /// Whether the area is currently visible. Main is always visible.
-    /// </summary>
-    public bool IsAreaVisible(DocumentArea area)
-    {
-        return _layoutState.IsAreaVisible(area);
-    }
-
-    /// <summary>
-    /// Gets the share of a split area taken by its primary section.
-    /// </summary>
-    public double GetAreaSplitRatio(DocumentArea area)
-    {
-        return _layoutState.GetAreaSplitRatio(area);
-    }
-
-    /// <summary>
-    /// Splits the area into two sections, or folds its secondary section back into the primary one.
-    /// Folding migrates the secondary section's tabs rather than closing them.
-    /// </summary>
-    public void SetAreaSplit(DocumentArea area, bool isSplit)
-    {
-        if (!_layoutState.SetAreaSplit(area, isSplit))
-        {
-            return;
-        }
-
-        if (!isSplit)
-        {
-            MigrateSecondarySection(area);
-        }
-
-        RebuildArea(area);
-
-        // A split area needs room for two sections, so its minimum grows, and the workspace floors the
-        // surface container composes from it are re-applied by pushing the presentation again.
-        ApplyWorkspaceLayout();
-
-        AreaLayoutChanged?.Invoke(area, isSplit, _layoutState.GetAreaSplitRatio(area));
-    }
-
-    /// <summary>
-    /// Whether a document in the area can be moved into a new split: the area must be unsplit, have room
-    /// for two sections, and hold more than one document so the split does not empty its primary section.
-    /// </summary>
-    public bool CanStartAreaSplit(DocumentArea area)
-    {
-        int primaryTabCount = _sections[area.GetPrimarySection()].TabCount;
-
-        return _layoutState.CanStartSplit(area, CanSplitArea(area), primaryTabCount);
-    }
-
-    /// <summary>
-    /// Folds a split area back when either of its sections has run out of documents, so a split section is
-    /// never left empty. The surviving documents always end up in the primary section.
-    /// </summary>
-    public void ReconcileAreaSplit(DocumentArea area)
-    {
-        int primaryTabCount = _sections[area.GetPrimarySection()].TabCount;
-        int secondaryTabCount = _sections[area.GetSecondarySection()].TabCount;
-
-        // Unsplitting migrates the secondary section's tabs into the primary one, which covers both
-        // cases: an empty secondary migrates nothing, an empty primary receives everything.
-        if (_layoutState.ShouldFoldSplit(area, primaryTabCount, secondaryTabCount))
-        {
-            SetAreaSplit(area, false);
-        }
-    }
-
-    /// <summary>
-    /// Sets the share of a split area taken by its primary section.
-    /// </summary>
-    public void SetAreaSplitRatio(DocumentArea area, double ratio)
-    {
-        if (!_layoutState.SetAreaSplitRatio(area, ratio))
-        {
-            return;
-        }
-
-        if (_layoutState.IsAreaSplit(area))
-        {
-            ApplySplitRatio(area);
-        }
-    }
-
-    /// <summary>
-    /// Shows or hides an area. Hiding leaves its sections and their tabs intact, so the documents in a
-    /// collapsed area stay open and reappear where they were. Main is always visible.
-    /// </summary>
-    public void SetAreaVisible(DocumentArea area, bool isVisible)
-    {
-        if (_layoutState.SetAreaVisible(area, isVisible))
-        {
-            ApplyWorkspaceLayout();
-        }
-    }
-
-    /// <summary>
-    /// Sets the toolbar hosted in an area's tab strip footer. The toolbar is re-placed on the section
-    /// nearest the area's top-right corner whenever that area is rebuilt.
-    /// </summary>
-    public void SetAreaToolbar(DocumentArea area, UIElement toolbar)
-    {
-        _areaToolbars[area] = toolbar;
-        PlaceAreaToolbar(area);
     }
 
     /// <summary>
@@ -545,7 +256,7 @@ public sealed partial class DocumentSectionContainer
         }
 
         // No documents left in the same section, so scan the other selectable sections in reading order.
-        foreach (var section in _layoutState.SelectableSections)
+        foreach (var section in _areaLayout.SelectableSections)
         {
             if (section == closingSection)
             {
@@ -609,7 +320,7 @@ public sealed partial class DocumentSectionContainer
     /// </summary>
     private DocumentTabLocation? FindFallbackActiveDocument()
     {
-        foreach (var section in _layoutState.SelectableSections)
+        foreach (var section in _areaLayout.SelectableSections)
         {
             var sectionView = _sections[section];
             var selectedResource = sectionView.GetSelectedDocument();
@@ -626,28 +337,6 @@ public sealed partial class DocumentSectionContainer
         }
 
         return null;
-    }
-
-    /// <summary>
-    /// Updates tab strip visibility across all sections for presenter mode.
-    /// </summary>
-    public void UpdateTabStripVisibility(bool showTabStrip)
-    {
-        foreach (var sectionView in GetAllSections())
-        {
-            sectionView.UpdateTabStripVisibility(showTabStrip);
-        }
-    }
-
-    /// <summary>
-    /// Shuts down all sections.
-    /// </summary>
-    public void Shutdown()
-    {
-        foreach (var sectionView in GetAllSections())
-        {
-            sectionView.Shutdown();
-        }
     }
 
     /// <summary>
@@ -701,7 +390,7 @@ public sealed partial class DocumentSectionContainer
         // Emptying the source section folds its area back, which can migrate the moved tab straight back
         // out of the target section. Reconcile before reporting the active document, so the fold's own
         // correction to the active section is the one that is broadcast.
-        ReconcileAreaSplit(sourceSectionView.Section.GetArea());
+        _areaLayout.ReconcileAreaSplit(sourceSectionView.Section.GetArea());
 
         UpdateTabSelectionIndicators();
         ActiveDocumentChanged?.Invoke(_activeDocument);
@@ -713,30 +402,25 @@ public sealed partial class DocumentSectionContainer
     }
 
     /// <summary>
-    /// Folds every area back to a single section and restores equal split positions.
+    /// Updates tab strip visibility across all sections for presenter mode.
     /// </summary>
-    public async Task ResetAreaLayoutAsync()
+    public void UpdateTabStripVisibility(bool showTabStrip)
     {
-        foreach (var area in DocumentLayoutHelper.AllAreas)
+        foreach (var sectionView in GetAllSections())
         {
-            _layoutState.SetAreaSplitRatio(area, AreaLayoutState.DefaultSplitRatio);
-            SetAreaSplit(area, false);
+            sectionView.UpdateTabStripVisibility(showTabStrip);
         }
+    }
 
-        var tcs = new TaskCompletionSource<bool>();
-
-        // Wait for layout to complete so callers that persist the result read settled state.
-        GetAreaGrid(DocumentArea.Main).DispatcherQueue.TryEnqueue(() =>
+    /// <summary>
+    /// Shuts down all sections.
+    /// </summary>
+    public void Shutdown()
+    {
+        foreach (var sectionView in GetAllSections())
         {
-            foreach (var area in DocumentLayoutHelper.AllAreas)
-            {
-                AreaLayoutChanged?.Invoke(area, false, AreaLayoutState.DefaultSplitRatio);
-            }
-
-            tcs.SetResult(true);
-        });
-
-        await tcs.Task;
+            sectionView.Shutdown();
+        }
     }
 
     private void CreateSection(DocumentSection section)
@@ -794,458 +478,6 @@ public sealed partial class DocumentSectionContainer
         {
             tab.FlashAttentionDeferred();
         }
-    }
-
-    private Grid GetAreaGrid(DocumentArea area)
-    {
-        return _surfaceContainer.GetAreaGrid(area);
-    }
-
-    /// <summary>
-    /// Rebuilds an area's internal grid for its current split state. Sections that stay mounted are left
-    /// attached: reparenting a section resets its TabView measurement and leaves the tab strip stuck in
-    /// an overflow-scroll state until the next real resize.
-    /// </summary>
-    private void RebuildArea(DocumentArea area)
-    {
-        var areaGrid = GetAreaGrid(area);
-        bool isSplit = _layoutState.IsAreaSplit(area);
-        bool isHorizontal = area.SplitsHorizontally();
-
-        var primarySectionView = _sections[area.GetPrimarySection()];
-        var secondarySectionView = _sections[area.GetSecondarySection()];
-
-        if (_splitSplitters.TryGetValue(area, out var existingSplitter))
-        {
-            existingSplitter.DragStarted -= Splitter_DragStarted;
-            existingSplitter.DragDelta -= Splitter_DragDelta;
-            existingSplitter.DragCompleted -= Splitter_DragCompleted;
-            existingSplitter.DoubleClicked -= Splitter_DoubleClicked;
-            areaGrid.Children.Remove(existingSplitter);
-            _splitSplitters.Remove(area);
-            _splitHelpers.Remove(area);
-        }
-
-        if (!isSplit &&
-            areaGrid.Children.Contains(secondarySectionView))
-        {
-            areaGrid.Children.Remove(secondarySectionView);
-        }
-
-        areaGrid.ColumnDefinitions.Clear();
-        areaGrid.RowDefinitions.Clear();
-
-        double ratio = _layoutState.GetAreaSplitRatio(area);
-
-        if (isHorizontal)
-        {
-            areaGrid.ColumnDefinitions.Add(new ColumnDefinition
-            {
-                Width = new GridLength(isSplit ? ratio : 1, GridUnitType.Star)
-            });
-        }
-        else
-        {
-            areaGrid.RowDefinitions.Add(new RowDefinition
-            {
-                Height = new GridLength(isSplit ? ratio : 1, GridUnitType.Star)
-            });
-        }
-
-        SetSectionPosition(primarySectionView, isHorizontal, 0);
-        if (!areaGrid.Children.Contains(primarySectionView))
-        {
-            areaGrid.Children.Add(primarySectionView);
-        }
-
-        if (isSplit)
-        {
-            if (isHorizontal)
-            {
-                areaGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-                areaGrid.ColumnDefinitions.Add(new ColumnDefinition
-                {
-                    Width = new GridLength(1 - ratio, GridUnitType.Star)
-                });
-            }
-            else
-            {
-                areaGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
-                areaGrid.RowDefinitions.Add(new RowDefinition
-                {
-                    Height = new GridLength(1 - ratio, GridUnitType.Star)
-                });
-            }
-
-            var splitter = CreateSplitSplitter(area, isHorizontal);
-            SetSectionPosition(splitter, isHorizontal, 1);
-            areaGrid.Children.Add(splitter);
-            _splitSplitters[area] = splitter;
-
-            SetSectionPosition(secondarySectionView, isHorizontal, 2);
-            if (!areaGrid.Children.Contains(secondarySectionView))
-            {
-                areaGrid.Children.Add(secondarySectionView);
-            }
-        }
-
-        ApplySectionTrackMinimums(area);
-        UpdateSectionMoveTargets(area);
-        PlaceAreaToolbar(area);
-        ApplyAreaSectionChrome(area);
-    }
-
-    // Puts the composed section minimum on the tracks the area's sections sit in. The gutter track between
-    // them is auto sized and carries none of its own.
-    private void ApplySectionTrackMinimums(DocumentArea area)
-    {
-        var areaGrid = GetAreaGrid(area);
-        var sectionMinimum = SectionMinimumSize;
-
-        if (area.SplitsHorizontally())
-        {
-            foreach (var columnDefinition in areaGrid.ColumnDefinitions)
-            {
-                if (columnDefinition.Width.IsStar)
-                {
-                    columnDefinition.MinWidth = sectionMinimum.Width;
-                }
-            }
-
-            return;
-        }
-
-        foreach (var rowDefinition in areaGrid.RowDefinitions)
-        {
-            if (rowDefinition.Height.IsStar)
-            {
-                rowDefinition.MinHeight = sectionMinimum.Height;
-            }
-        }
-    }
-
-    private static void SetSectionPosition(FrameworkElement element, bool isHorizontal, int index)
-    {
-        if (isHorizontal)
-        {
-            Grid.SetColumn(element, index);
-            Grid.SetRow(element, 0);
-        }
-        else
-        {
-            Grid.SetRow(element, index);
-            Grid.SetColumn(element, 0);
-        }
-    }
-
-    private Splitter CreateSplitSplitter(DocumentArea area, bool isHorizontal)
-    {
-        var splitter = new Splitter
-        {
-            // A horizontally split area is divided by a vertical splitter, and the reverse.
-            Orientation = isHorizontal ? Orientation.Vertical : Orientation.Horizontal,
-            Tag = area
-        };
-
-        splitter.DragStarted += Splitter_DragStarted;
-        splitter.DragDelta += Splitter_DragDelta;
-        splitter.DragCompleted += Splitter_DragCompleted;
-        splitter.DoubleClicked += Splitter_DoubleClicked;
-
-        return splitter;
-    }
-
-    /// <summary>
-    /// Places an area's toolbar on the section nearest that area's top-right corner: the right-hand
-    /// section of a horizontally split area, and the top section of the Side area.
-    /// </summary>
-    private void PlaceAreaToolbar(DocumentArea area)
-    {
-        if (!_areaToolbars.TryGetValue(area, out var toolbar))
-        {
-            return;
-        }
-
-        var primarySectionView = _sections[area.GetPrimarySection()];
-        var secondarySectionView = _sections[area.GetSecondarySection()];
-
-        bool toolbarOnSecondary = area.SplitsHorizontally() && _layoutState.IsAreaSplit(area);
-
-        primarySectionView.SetTabStripFooter(toolbarOnSecondary ? null : toolbar);
-        secondarySectionView.SetTabStripFooter(toolbarOnSecondary ? toolbar : null);
-    }
-
-    // Pushes the area state the tab context menu needs down onto its tabs: whether the area is split, and
-    // whether it has room to be.
-    private void UpdateSectionMoveTargets(DocumentArea area)
-    {
-        bool isSplit = _layoutState.IsAreaSplit(area);
-        bool canSplit = CanSplitArea(area);
-
-        foreach (var section in area.GetSections())
-        {
-            var sectionView = _sections[section];
-            sectionView.IsAreaSplit = isSplit;
-            sectionView.CanSplitArea = canSplit;
-        }
-    }
-
-    private void ApplySplitRatio(DocumentArea area)
-    {
-        var areaGrid = GetAreaGrid(area);
-        double ratio = _layoutState.GetAreaSplitRatio(area);
-
-        if (area.SplitsHorizontally())
-        {
-            if (areaGrid.ColumnDefinitions.Count == 3)
-            {
-                areaGrid.ColumnDefinitions[0].Width = new GridLength(ratio, GridUnitType.Star);
-                areaGrid.ColumnDefinitions[2].Width = new GridLength(1 - ratio, GridUnitType.Star);
-            }
-        }
-        else
-        {
-            if (areaGrid.RowDefinitions.Count == 3)
-            {
-                areaGrid.RowDefinitions[0].Height = new GridLength(ratio, GridUnitType.Star);
-                areaGrid.RowDefinitions[2].Height = new GridLength(1 - ratio, GridUnitType.Star);
-            }
-        }
-    }
-
-    // Pushes the current presentation to the surface container, then re-applies the section chrome,
-    // which depends on which surfaces the sections now face.
-    private void ApplyWorkspaceLayout()
-    {
-        var presentation = new WorkspaceSurfacePresentation(
-            IsMainAreaPresented: _layoutState.IsAreaPresented(DocumentArea.Main),
-            IsBottomAreaPresented: _layoutState.IsAreaPresented(DocumentArea.Bottom),
-            IsSideAreaPresented: _layoutState.IsAreaPresented(DocumentArea.Side),
-            IsUtilityPanelPresented: _layoutState.IsUtilityPanelPresented,
-            BottomAreaSpansUtilityPanel: _layoutState.BottomAreaSpansUtilityPanel,
-            BottomAreaSpansSideArea: _layoutState.BottomAreaSpansSideArea);
-
-        _surfaceContainer.ApplyPresentation(presentation);
-
-        ApplySectionChrome();
-    }
-
-    // A section is the rectangle a document actually sits in, so the chrome is drawn per section rather than
-    // per area: the gutter splitting one area into two divides two such rectangles, exactly as the gutter
-    // between two areas does.
-    private void ApplySectionChrome()
-    {
-        foreach (var area in DocumentLayoutHelper.AllAreas)
-        {
-            ApplyAreaSectionChrome(area);
-        }
-    }
-
-    // Splitting an area moves an inner edge onto a section that did not have one, so this runs on every
-    // rebuild rather than only when the root grid layout changes.
-    private void ApplyAreaSectionChrome(DocumentArea area)
-    {
-        double cornerRadius = (double)Application.Current.Resources["PanelCornerRadius"];
-        var areaChrome = _chromeCalculator.CalculateAreaChrome(area, cornerRadius);
-
-        var primarySectionView = _sections[area.GetPrimarySection()];
-        primarySectionView.SetGutterChrome(areaChrome.Primary.Edges, areaChrome.Primary.Corners);
-
-        if (areaChrome.Secondary is SectionChrome secondaryChrome)
-        {
-            var secondarySectionView = _sections[area.GetSecondarySection()];
-            secondarySectionView.SetGutterChrome(secondaryChrome.Edges, secondaryChrome.Corners);
-        }
-    }
-
-    private void Splitter_DragStarted(object? sender, EventArgs e)
-    {
-        if (sender is not Splitter splitter || splitter.Tag is not DocumentArea area)
-        {
-            return;
-        }
-
-        _totalDragDelta = 0;
-
-        if (!_splitHelpers.TryGetValue(area, out var helper))
-        {
-            var areaGrid = GetAreaGrid(area);
-            var mode = area.SplitsHorizontally() ? GridResizeMode.Columns : GridResizeMode.Rows;
-            helper = new SplitterHelper(areaGrid, mode, 0, 2, minSizeFunc: () => ResolveSplitSectionMinimum(area))
-            {
-                SnapTargets = () => ResolveSplitSnapTargets(area)
-            };
-            _splitHelpers[area] = helper;
-        }
-
-        helper.OnDragStarted();
-    }
-
-    // The size an area's primary section takes when its split divider lines up with the one it pairs with.
-    // Main and Bottom share a grid column, so their dividers align when their primary sections are the same
-    // width. The Side area starts at the same row as Main, so its divider is measured from the same origin
-    // as the Main/Bottom boundary and aligns when its primary section matches the Main area's height. An
-    // alignment that runs the Bottom area under the Side area leaves nothing to line up with, so it has no
-    // target.
-    private IReadOnlyList<double> ResolveSplitSnapTargets(DocumentArea area)
-    {
-        if (area == DocumentArea.Side)
-        {
-            if (!_layoutState.IsAreaPresented(DocumentArea.Main) ||
-                !_layoutState.IsAreaPresented(DocumentArea.Bottom) ||
-                _layoutState.BottomAreaSpansSideArea)
-            {
-                return Array.Empty<double>();
-            }
-
-            return new[]
-            {
-                GetAreaGrid(DocumentArea.Main).ActualHeight
-            };
-        }
-
-        var partnerArea = area == DocumentArea.Main ? DocumentArea.Bottom : DocumentArea.Main;
-
-        if (!_layoutState.IsAreaPresented(partnerArea) ||
-            !_layoutState.IsAreaSplit(partnerArea))
-        {
-            return Array.Empty<double>();
-        }
-
-        var partnerGrid = GetAreaGrid(partnerArea);
-
-        if (partnerGrid.ColumnDefinitions.Count == 0)
-        {
-            return Array.Empty<double>();
-        }
-
-        return new[]
-        {
-            partnerGrid.ColumnDefinitions[0].ActualWidth
-        };
-    }
-
-    // The Bottom area height that puts the Main/Bottom boundary level with the Side area's split divider.
-    // That divider is measured down from the top of the Main area while the Bottom splitter sizes the
-    // Bottom area up from the base, so the target is the two areas' height less the Side area's primary
-    // section. An alignment that runs the Bottom area under the Side area leaves nothing to line up with.
-    // Supplied to the surface container, whose splitter owns the snapping.
-    private IReadOnlyList<double> ResolveBottomAreaSnapTargets()
-    {
-        if (!_layoutState.IsAreaPresented(DocumentArea.Side) ||
-            !_layoutState.IsAreaSplit(DocumentArea.Side) ||
-            _layoutState.BottomAreaSpansSideArea)
-        {
-            return Array.Empty<double>();
-        }
-
-        var sideAreaGrid = GetAreaGrid(DocumentArea.Side);
-
-        if (sideAreaGrid.RowDefinitions.Count == 0)
-        {
-            return Array.Empty<double>();
-        }
-
-        double sidePrimaryHeight = sideAreaGrid.RowDefinitions[0].ActualHeight;
-        double documentRowsHeight = GetAreaGrid(DocumentArea.Main).ActualHeight +
-            GetAreaGrid(DocumentArea.Bottom).ActualHeight;
-        double alignedBottomHeight = documentRowsHeight - sidePrimaryHeight;
-
-        return new[]
-        {
-            alignedBottomHeight
-        };
-    }
-
-    private void Splitter_DragDelta(object? sender, double delta)
-    {
-        if (sender is not Splitter splitter || splitter.Tag is not DocumentArea area)
-        {
-            return;
-        }
-
-        _totalDragDelta += Math.Abs(delta);
-
-        if (_splitHelpers.TryGetValue(area, out var helper))
-        {
-            helper.OnDragDelta(delta);
-        }
-    }
-
-    private void Splitter_DragCompleted(object? sender, EventArgs e)
-    {
-        if (sender is not Splitter splitter || splitter.Tag is not DocumentArea area)
-        {
-            return;
-        }
-
-        // Skip if no significant drag occurred (e.g., just a click without dragging)
-        if (_totalDragDelta < MinDragDistance)
-        {
-            return;
-        }
-
-        double ratio = MeasureSplitRatio(area);
-        if (ratio > 0 && ratio < 1)
-        {
-            _layoutState.SetAreaSplitRatio(area, ratio);
-
-            // Convert back to proportional Star sizing so the split holds its share as the area resizes.
-            ApplySplitRatio(area);
-
-            AreaLayoutChanged?.Invoke(area, true, ratio);
-        }
-    }
-
-    private void Splitter_DoubleClicked(object? sender, EventArgs e)
-    {
-        if (sender is not Splitter splitter || splitter.Tag is not DocumentArea area)
-        {
-            return;
-        }
-
-        _layoutState.SetAreaSplitRatio(area, AreaLayoutState.DefaultSplitRatio);
-        ApplySplitRatio(area);
-
-        AreaLayoutChanged?.Invoke(area, true, AreaLayoutState.DefaultSplitRatio);
-    }
-
-    /// <summary>
-    /// The share of the area currently taken by its primary section, measured from the settled grid.
-    /// </summary>
-    private double MeasureSplitRatio(DocumentArea area)
-    {
-        var areaGrid = GetAreaGrid(area);
-
-        double primarySize;
-        double secondarySize;
-
-        if (area.SplitsHorizontally())
-        {
-            if (areaGrid.ColumnDefinitions.Count != 3)
-            {
-                return 0;
-            }
-            primarySize = areaGrid.ColumnDefinitions[0].ActualWidth;
-            secondarySize = areaGrid.ColumnDefinitions[2].ActualWidth;
-        }
-        else
-        {
-            if (areaGrid.RowDefinitions.Count != 3)
-            {
-                return 0;
-            }
-            primarySize = areaGrid.RowDefinitions[0].ActualHeight;
-            secondarySize = areaGrid.RowDefinitions[2].ActualHeight;
-        }
-
-        double total = primarySize + secondarySize;
-        if (total <= 0)
-        {
-            return 0;
-        }
-
-        return primarySize / total;
     }
 
     private void OnSectionSelectionChanged(DocumentSectionView sectionView, ResourceKey documentResource)

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.cs
@@ -21,11 +21,6 @@ public sealed partial class DocumentSectionContainer
     private ResourceKey _activeDocument = ResourceKey.Empty;
 
     /// <summary>
-    /// Event raised when the selected document changes in any section.
-    /// </summary>
-    public event Action<DocumentSectionView, ResourceKey>? SectionSelectionChanged;
-
-    /// <summary>
     /// Event raised when the active document changes.
     /// This is the document that should be inspected.
     /// </summary>
@@ -109,22 +104,6 @@ public sealed partial class DocumentSectionContainer
         {
             yield return _sections[section];
         }
-    }
-
-    /// <summary>
-    /// Finds the section containing a specific document, including sections in a collapsed area.
-    /// </summary>
-    public DocumentSectionView? FindSectionContaining(ResourceKey fileResource)
-    {
-        foreach (var sectionView in GetAllSections())
-        {
-            if (sectionView.ContainsDocument(fileResource))
-            {
-                return sectionView;
-            }
-        }
-
-        return null;
     }
 
     /// <summary>
@@ -430,7 +409,6 @@ public sealed partial class DocumentSectionContainer
             Section = section
         };
 
-        sectionView.SelectionChanged += OnSectionSelectionChanged;
         sectionView.DocumentsLayoutChanged += OnSectionDocumentsLayoutChanged;
         sectionView.CloseRequested += OnSectionCloseRequested;
         sectionView.ContextMenuActionRequested += OnSectionContextMenuActionRequested;
@@ -478,13 +456,6 @@ public sealed partial class DocumentSectionContainer
         {
             tab.FlashAttentionDeferred();
         }
-    }
-
-    private void OnSectionSelectionChanged(DocumentSectionView sectionView, ResourceKey documentResource)
-    {
-        // This handles section-level selection (which tab is selected within a section's TabView).
-        // This is distinct from the active document, which is updated via ActivateDocument/SetActiveDocument.
-        SectionSelectionChanged?.Invoke(sectionView, documentResource);
     }
 
     /// <summary>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml
@@ -38,7 +38,6 @@
              CanDragTabs="True"
              AllowDrop="True"
              TabCloseRequested="TabView_CloseRequested"
-             SelectionChanged="TabView_SelectionChanged"
              TabItemsChanged="TabView_TabItemsChanged"
              TabDroppedOutside="TabView_TabDroppedOutside"
              DragOver="TabView_DragOver"

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
@@ -50,11 +50,6 @@ public sealed partial class DocumentSectionView : UserControl
     public DocumentSection Section { get; set; }
 
     /// <summary>
-    /// Event raised when the selected document changes in this section.
-    /// </summary>
-    public event Action<DocumentSectionView, ResourceKey>? SelectionChanged;
-
-    /// <summary>
     /// Event raised when the open documents in this section change.
     /// </summary>
     public event Action<DocumentSectionView, List<ResourceKey>>? DocumentsLayoutChanged;
@@ -275,23 +270,6 @@ public sealed partial class DocumentSectionView : UserControl
             return documentTab.ViewModel.FileResource;
         }
         return ResourceKey.Empty;
-    }
-
-    /// <summary>
-    /// Checks if a document is open in this section.
-    /// </summary>
-    public bool ContainsDocument(ResourceKey fileResource)
-    {
-        EnsureUIThread();
-
-        foreach (var tabItem in TabView.TabItems)
-        {
-            if (tabItem is DocumentTab tab && fileResource == tab.ViewModel.FileResource)
-            {
-                return true;
-            }
-        }
-        return false;
     }
 
     /// <summary>
@@ -628,24 +606,6 @@ public sealed partial class DocumentSectionView : UserControl
         }
 
         TabView.TabItems.Clear();
-    }
-
-    private void TabView_SelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        if (_isShuttingDown)
-        {
-            return;
-        }
-
-        ResourceKey documentResource = ResourceKey.Empty;
-
-        var documentTab = TabView.SelectedItem as DocumentTab;
-        if (documentTab is not null)
-        {
-            documentResource = documentTab.ViewModel.FileResource;
-        }
-
-        SelectionChanged?.Invoke(this, documentResource);
     }
 
     private void TabView_TabItemsChanged(TabView sender, IVectorChangedEventArgs args)

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.TabMenu.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.TabMenu.cs
@@ -76,17 +76,17 @@ public sealed partial class WorkspacePanel
     {
         var area = tab.Section.GetArea();
 
-        if (!SectionContainer.IsAreaSplit(area))
+        if (!SectionContainer.Areas.IsAreaSplit(area))
         {
             // Only the split direction is on offer while unsplit, and only while the area has a document
             // to leave behind.
             if (!toSecondarySection ||
-                !SectionContainer.CanStartAreaSplit(area))
+                !SectionContainer.Areas.CanStartAreaSplit(area))
             {
                 return;
             }
 
-            SectionContainer.SetAreaSplit(area, true);
+            SectionContainer.Areas.SetAreaSplit(area, true);
         }
 
         var targetSection = toSecondarySection
@@ -104,12 +104,12 @@ public sealed partial class WorkspacePanel
     private void UnsplitArea(DocumentTab tab)
     {
         var area = tab.Section.GetArea();
-        if (!SectionContainer.IsAreaSplit(area))
+        if (!SectionContainer.Areas.IsAreaSplit(area))
         {
             return;
         }
 
-        SectionContainer.SetAreaSplit(area, false);
+        SectionContainer.Areas.SetAreaSplit(area, false);
 
         UpdateAllTabDisplayNames();
         NotifyLayoutChanged();

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -32,7 +32,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
     // Manages the document sections inside the surface container's area grids.
     private DocumentSectionContainer SectionContainer { get; }
 
-    public IReadOnlyList<DocumentSection> VisibleSections => SectionContainer.VisibleSections;
+    public IReadOnlyList<DocumentSection> VisibleSections => SectionContainer.Areas.VisibleSections;
 
     public ResourceKey ActiveDocument
     {
@@ -76,7 +76,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         SectionContainer.DocumentsLayoutChanged += OnSectionDocumentsLayoutChanged;
         SectionContainer.CloseRequested += OnSectionCloseRequested;
         SectionContainer.ContextMenuActionRequested += OnSectionContextMenuActionRequested;
-        SectionContainer.AreaLayoutChanged += OnAreaLayoutChanged;
+        SectionContainer.Areas.AreaLayoutChanged += OnAreaLayoutChanged;
         SectionContainer.FilesDropped += OnSectionFilesDropped;
 
         // Surface sizes are dragged on the surface container's splitters and persisted here.
@@ -107,9 +107,9 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
         // Closing the last document in an isolated area moves the active document to another area, so
         // the isolation follows it rather than leaving an empty panel on screen.
-        if (SectionContainer.IsolatedArea is not null)
+        if (SectionContainer.Areas.IsolatedArea is not null)
         {
-            SectionContainer.SetIsolatedArea(SectionContainer.ActiveSection.GetArea());
+            SectionContainer.Areas.SetIsolatedArea(SectionContainer.ActiveSection.GetArea());
         }
 
         ViewModel.OnActiveDocumentChanged(documentResource);
@@ -151,7 +151,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
             toolbar.CloseAreaRequested += OnToolbarCloseAreaRequested;
 
             _areaToolbars[area] = toolbar;
-            SectionContainer.SetAreaToolbar(area, toolbar);
+            SectionContainer.Areas.SetAreaToolbar(area, toolbar);
         }
     }
 
@@ -320,7 +320,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
         // Surface sizes are restored and reset through the workspace settings facade.
         ViewModel.SurfaceSizeChanged += OnStoredSurfaceSizeChanged;
-        SectionContainer.SetBottomAreaAlignment(ViewModel.BottomAreaAlignment);
+        SectionContainer.Areas.SetBottomAreaAlignment(ViewModel.BottomAreaAlignment);
         ApplyStoredSurfaceSizes();
         ApplyAreaVisibility();
 
@@ -415,7 +415,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         }
 
         // Fold every area back to a single section at its default split position
-        _ = SectionContainer.ResetAreaLayoutAsync();
+        _ = SectionContainer.Areas.ResetAreaLayoutAsync();
     }
 
     private void WorkspacePanel_Unloaded(object sender, RoutedEventArgs e)
@@ -452,11 +452,11 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
         if (isolateActiveArea)
         {
-            SectionContainer.SetIsolatedArea(SectionContainer.ActiveSection.GetArea());
+            SectionContainer.Areas.SetIsolatedArea(SectionContainer.ActiveSection.GetArea());
             return;
         }
 
-        SectionContainer.SetIsolatedArea(null);
+        SectionContainer.Areas.SetIsolatedArea(null);
         ApplyStoredSurfaceSizes();
     }
 
@@ -487,12 +487,12 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
     // leaves its tabs in place, so the documents reappear where they were when it is shown again.
     private void ApplyAreaVisibility()
     {
-        SectionContainer.SetAreaVisible(DocumentArea.Bottom, ViewModel.IsAreaVisible(DocumentArea.Bottom));
-        SectionContainer.SetAreaVisible(DocumentArea.Side, ViewModel.IsAreaVisible(DocumentArea.Side));
+        SectionContainer.Areas.SetAreaVisible(DocumentArea.Bottom, ViewModel.IsAreaVisible(DocumentArea.Bottom));
+        SectionContainer.Areas.SetAreaVisible(DocumentArea.Side, ViewModel.IsAreaVisible(DocumentArea.Side));
 
         // The areas draw a left edge only while the Utility Panel is there to face. Hiding it, whether from
         // the toolbar or by entering Focus, leaves that edge on the application border instead.
-        SectionContainer.SetUtilityPanelPresented(ViewModel.IsUtilityPanelVisible);
+        SectionContainer.Areas.SetUtilityPanelPresented(ViewModel.IsUtilityPanelVisible);
 
         ApplyStoredSurfaceSizes();
     }
@@ -528,7 +528,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
             return;
         }
 
-        SectionContainer.SetBottomAreaAlignment(message.Alignment);
+        SectionContainer.Areas.SetBottomAreaAlignment(message.Alignment);
     }
 
     // Mounts the section a document is about to open into. Naming an unsplit area's secondary section
@@ -538,9 +538,9 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
     {
         var area = section.GetArea();
         if (section.IsSecondarySection()
-            && !SectionContainer.IsAreaSplit(area))
+            && !SectionContainer.Areas.IsAreaSplit(area))
         {
-            SectionContainer.SetAreaSplit(area, true);
+            SectionContainer.Areas.SetAreaSplit(area, true);
         }
 
         return section;
@@ -548,32 +548,32 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
     public bool IsAreaSplit(DocumentArea area)
     {
-        return SectionContainer.IsAreaSplit(area);
+        return SectionContainer.Areas.IsAreaSplit(area);
     }
 
     public void SetAreaSplit(DocumentArea area, bool isSplit)
     {
-        SectionContainer.SetAreaSplit(area, isSplit);
+        SectionContainer.Areas.SetAreaSplit(area, isSplit);
     }
 
     public void ReconcileAreaSplit(DocumentArea area)
     {
-        SectionContainer.ReconcileAreaSplit(area);
+        SectionContainer.Areas.ReconcileAreaSplit(area);
     }
 
     public double GetAreaSplitRatio(DocumentArea area)
     {
-        return SectionContainer.GetAreaSplitRatio(area);
+        return SectionContainer.Areas.GetAreaSplitRatio(area);
     }
 
     public void SetAreaSplitRatio(DocumentArea area, double ratio)
     {
-        SectionContainer.SetAreaSplitRatio(area, ratio);
+        SectionContainer.Areas.SetAreaSplitRatio(area, ratio);
     }
 
     public async Task ResetAreaLayoutAsync()
     {
-        await SectionContainer.ResetAreaLayoutAsync();
+        await SectionContainer.Areas.ResetAreaLayoutAsync();
     }
 
     public IReadOnlyList<OpenDocumentInfo> GetOpenDocuments()
@@ -877,7 +877,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         var area = sectionView.Section.GetArea();
 
         sectionView.RemoveTab(documentTab);
-        SectionContainer.ReconcileAreaSplit(area);
+        SectionContainer.Areas.ReconcileAreaSplit(area);
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request primarily refactors how area-related operations are accessed within the document workspace UI, consolidating them under a new or existing `Areas` property of `SectionContainer`. Additionally, it removes some unused events and methods from the `DocumentSectionView` class and makes a minor logging improvement. These changes streamline the codebase, improve encapsulation, and remove unnecessary code.

**Refactoring area management:**

* All calls to area-related methods and properties (such as `IsAreaSplit`, `SetAreaSplit`, `SetAreaToolbar`, `SetAreaVisible`, etc.) are now accessed via `SectionContainer.Areas` instead of directly on `SectionContainer`. This affects methods and property access throughout `WorkspacePanel.xaml.cs` and `WorkspacePanel.TabMenu.cs`. [[1]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L35-R35) [[2]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L79-R79) [[3]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L110-R112) [[4]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L154-R154) [[5]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L323-R323) [[6]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L418-R418) [[7]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L455-R459) [[8]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L490-R495) [[9]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L531-R531) [[10]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L541-R576) [[11]](diffhunk://#diff-4f6fe441fddba587eefa52edf080442ec55c77b3a338932f689ecacbfef331a6L880-R880) [[12]](diffhunk://#diff-895f486804524a3e612daa8bbddfe841771d38ff6d0b57f195091e1843214be3L79-R89) [[13]](diffhunk://#diff-895f486804524a3e612daa8bbddfe841771d38ff6d0b57f195091e1843214be3L107-R112)

**Code cleanup and removal of unused events/methods:**

* The `SelectionChanged` event and the `TabView_SelectionChanged` handler, as well as the `ContainsDocument` method, have been removed from `DocumentSectionView.xaml` and `DocumentSectionView.xaml.cs` since they are no longer used. [[1]](diffhunk://#diff-653b67fc1e1111ac33543fbbe336209a80e3ab5bf8d4ab4a2e0064b73e14c160L41) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L52-L56) [[3]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L280-L296) [[4]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L633-L650)

**Logging improvement:**

* The debug log message in `ApplyMinimumWindowSize` has been clarified to use a more generic "scale" label, and now uses `WindowSizeScale` instead of the XAML rasterization scale property.