### PR TITLE
Add TabStripScrollIndicator and fix theme-scoped XAML brushes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ python run_tests.py
 
 Colours and the shared UI dimensions are held once in `Source/Core/Celbridge.DesignTokens/DesignTokens.json` and generated at build time into two files, so the native and web sides cannot disagree about a value:
 
-- `Celbridge.UserInterface/Resources/ColorTokens.xaml` — the theme dictionaries and the brushes declared straight over them
+- `Celbridge.UserInterface/Resources/ColorTokens.xaml` — the theme dictionaries, each holding its own colours and the brushes over them. A brush is emitted once per theme rather than once over the palette: a brush declared over the dictionaries is a single shared object whose colour resolves against the application theme, which follows the OS, so it ignores the `ElementTheme` the app applies to the window root and paints the wrong palette whenever the two disagree
 - `Celbridge.WebHost/Web/celbridge-client/celbridge-tokens.css` — the `--cel-*` custom properties served to WebView content
 
 Both are gitignored. Never edit them: change the token source and rebuild. `Celbridge.UserInterface` and `Celbridge.WebHost` each reference `Celbridge.DesignTokens` so the generator runs first, and each declares its generated file as an explicit build item so a clean checkout resolves.

--- a/Source/Celbridge/Celbridge.Application.csproj
+++ b/Source/Celbridge/Celbridge.Application.csproj
@@ -68,6 +68,30 @@
     <UnoImage Include="Assets\Images\title_icon.svg" />
   </ItemGroup>
 
+  <!-- A published macOS bundle keeps the app's content under Contents/Resources, and ms-appx asset lookups
+       go looking for it there. A plain build lays that content out beside the executable instead, so running
+       the built binary directly resolves no bundled asset: fonts included, which renders every icon as the
+       fallback glyph. Mirroring the published shape with a folder of links costs nothing and makes a build
+       that is run in place behave like the shipped one. Debug only, and only when building on macOS. -->
+  <Target Name="StageBundledAssetsForLocalRun"
+          AfterTargets="Build"
+          Condition="'$(TargetFramework)' == 'net10.0-desktop' AND '$(Configuration)' == 'Debug' AND $([MSBuild]::IsOSPlatform('OSX'))">
+    <PropertyGroup>
+      <LocalRunResourcesFolder>$(OutputPath)Resources</LocalRunResourcesFolder>
+    </PropertyGroup>
+    <ItemGroup>
+      <!-- Only the content folders are linked. The assemblies beside them are found by the runtime's own
+           probing, which does not consult this folder. -->
+      <LocalRunAssetFolder Include="$([System.IO.Directory]::GetDirectories('$(OutputPath)'))"
+                           Exclude="$(LocalRunResourcesFolder)" />
+    </ItemGroup>
+    <MakeDir Directories="$(LocalRunResourcesFolder)" />
+    <!-- Every link is made by one shell rather than one per folder, which keeps this off the critical path
+         of an incremental build. -->
+    <Exec Condition="'@(LocalRunAssetFolder)' != ''"
+          Command="@(LocalRunAssetFolder->'ln -sfn &quot;../%(Filename)%(Extension)&quot; &quot;$(LocalRunResourcesFolder)/%(Filename)%(Extension)&quot;', ' &amp;&amp; ')" />
+  </Target>
+
   <!-- Direct project dependencies -->
   <ItemGroup>
     <ProjectReference Include="..\Core\Celbridge.Server\Celbridge.Server.csproj" />

--- a/Source/Core/Celbridge.DesignTokens/XamlTokenWriter.cs
+++ b/Source/Core/Celbridge.DesignTokens/XamlTokenWriter.cs
@@ -3,14 +3,20 @@ using System.Text;
 namespace Celbridge.DesignTokens;
 
 /// <summary>
-/// Emits the theme dictionaries and the brushes declared over them as a WinUI resource dictionary.
-/// The WinUI system brush overrides are not emitted: they decide which native control keys redirect
-/// onto the palette, so they stay hand written in the dictionary that merges this one.
+/// Emits the theme dictionaries, each holding its own colors and the brushes over them, as a WinUI resource
+/// dictionary. The WinUI system brush overrides are not emitted: they decide which native control keys
+/// redirect onto the palette, so they stay hand written in the dictionary that merges this one.
 /// </summary>
 public static class XamlTokenWriter
 {
     private const string ThemeDictionaryIndent = "      ";
-    private const string BrushIndent = "  ";
+
+    // Emitted into the generated dictionary so a reader there is told why each brush is declared per theme
+    // rather than once over the palette.
+    private static readonly IReadOnlyList<string> BrushPlacementComment = new List<string>
+    {
+        "Each brush is declared in both theme dictionaries rather than once over the colors. A brush declared over them is one shared object whose color resolves against the application theme, which follows the operating system, so it would ignore an element asking for it under the opposite ElementTheme."
+    };
 
     public static string Write(DesignTokenSource source)
     {
@@ -31,8 +37,6 @@ public static class XamlTokenWriter
 
         builder.Append('\n');
         builder.Append("  </ResourceDictionary.ThemeDictionaries>\n");
-
-        AppendBrushes(builder, source);
 
         builder.Append('\n');
         builder.Append("</ResourceDictionary>\n");
@@ -74,6 +78,8 @@ public static class XamlTokenWriter
             }
         }
 
+        AppendBrushes(builder, source, theme);
+
         builder.Append("    </ResourceDictionary>\n");
     }
 
@@ -96,13 +102,34 @@ public static class XamlTokenWriter
         builder.Append('\n');
     }
 
-    private static void AppendBrushes(StringBuilder builder, DesignTokenSource source)
+    // A brush belongs to a theme, not to the palette as a whole. Declared once over the colors it would be a
+    // single shared object whose color resolves against the application theme, which follows the operating
+    // system, so an element asking for it under the opposite ElementTheme would still be handed the other
+    // theme's color. One brush per theme dictionary is what makes a brush key answer to the element's theme.
+    private static void AppendBrushes(StringBuilder builder, DesignTokenSource source, DesignTokenTheme theme)
     {
-        foreach (var token in source.Tokens.Where(token => token.XamlBrushKey is not null))
+        var brushTokens = source.Tokens
+            .Where(token => token.XamlBrushKey is not null)
+            .ToList();
+
+        if (brushTokens.Count == 0)
         {
-            builder.Append('\n');
-            builder.Append($"{BrushIndent}<SolidColorBrush x:Key=\"{token.XamlBrushKey}\"\n");
-            builder.Append($"{BrushIndent}                 Color=\"{{ThemeResource {token.XamlColorKey}}}\" />\n");
+            return;
+        }
+
+        builder.Append('\n');
+
+        if (theme == DesignTokenTheme.Light)
+        {
+            AppendComment(builder, BrushPlacementComment, ThemeDictionaryIndent);
+        }
+
+        foreach (var token in brushTokens)
+        {
+            // The color sits in this same dictionary and above this line, so the brush takes its own theme's
+            // value rather than asking the theme system a second time.
+            builder.Append($"{ThemeDictionaryIndent}<SolidColorBrush x:Key=\"{token.XamlBrushKey}\"\n");
+            builder.Append($"{ThemeDictionaryIndent}                 Color=\"{{StaticResource {token.XamlColorKey}}}\" />\n");
         }
     }
 

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/FileIcon.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/FileIcon.xaml.cs
@@ -111,11 +111,16 @@ public sealed partial class FileIcon : UserControl
     }
 
     // Draws the glyph at the host's size, folded with the icon's per-glyph scale so a glyph its font draws
-    // small can be enlarged to match its neighbours.
+    // small can be enlarged to match its neighbours. The layout box stays at the host's size whatever the
+    // glyph is drawn at: an icon font's line box already runs taller than its font size, and the scale can
+    // take it further still, so a box that followed the glyph would let one file type set the height of every
+    // row and tab strip it appears in. An enlarged glyph therefore overhangs its box rather than growing it.
     private void ApplySize()
     {
         var scale = ParseScale(IconDefinition?.FontSize);
         IconElement.FontSize = Size * scale;
+        IconElement.Width = Size;
+        IconElement.Height = Size;
     }
 
     private static double ParseScale(string? percent)

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml
@@ -3,7 +3,8 @@
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-  xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
+  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+  xmlns:local="using:Celbridge.Documents.Views">
 
   <!-- A section is carved out of the chrome field, so it takes the content background across its whole
        area, tab strip included, and draws the edges that face a channel. The thicknesses and corners depend
@@ -53,5 +54,13 @@
                           MinWidth="0"/>
       </TabView.TabStripFooter>
     </TabView>
+
+    <!-- Overlays the bottom edge of the tab strip rather than taking a row of its own, so an overflowing strip
+         gains a scroll affordance without changing the height the section composes its minimum from. Placed
+         over the tabs from code-behind, which is where the strip's geometry is known. -->
+    <local:TabStripScrollIndicator x:Name="ScrollIndicator"
+                                   HorizontalAlignment="Left"
+                                   VerticalAlignment="Top"
+                                   Visibility="Collapsed"/>
   </Grid>
 </UserControl>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
@@ -25,6 +25,7 @@ public sealed partial class DocumentSectionView : UserControl
     private readonly PointerEventHandler _tabStripWheelHandler;
     private bool _isShuttingDown = false;
     private bool _scrollButtonsHidden;
+    private bool _scrollIndicatorAttached;
 
     // The tab list template's two overflow arrows, named by their containers because that is what carries
     // the width each arrow costs the strip.
@@ -35,9 +36,8 @@ public sealed partial class DocumentSectionView : UserControl
     };
 
     // The tab strip band from the TabView template, resolved once so composing a minimum does not walk the
-    // section's visual tree on every query, and the tallest it has been measured at.
+    // section's visual tree on every query.
     private FrameworkElement? _tabStripContainer;
-    private double _measuredTabStripHeight;
 
     /// <summary>
     /// Static field to track the tab currently being dragged between sections.
@@ -97,13 +97,10 @@ public sealed partial class DocumentSectionView : UserControl
 
         TabView.Loaded += OnTabViewLoaded;
 
-        // On macOS the strip does not re-reveal the selected tab when it gets narrower, so a window resize
-        // or a change in the number of sections can leave the active tab clipped off-screen. Re-scroll it
-        // into view whenever the strip's width changes.
-        if (_platformInfo.RequiresMacOSTabScrollIntoView)
-        {
-            TabView.SizeChanged += OnTabViewSizeChanged;
-        }
+        // A narrower strip moves the scroll indicator and can change whether it is needed at all. It also
+        // leaves the active tab clipped off-screen on macOS, where the strip does not re-reveal the selection
+        // on its own, so a window resize or a change in the number of sections has to re-scroll it into view.
+        TabView.SizeChanged += OnTabViewSizeChanged;
 
         // On macOS the overflowing strip does not scroll in response to the mouse wheel, so translate the
         // wheel into horizontal scrolling ourselves. Subscribe for handled events too because the strip's
@@ -125,12 +122,16 @@ public sealed partial class DocumentSectionView : UserControl
         // once that list has laid out, so a section that starts empty is covered by applying now and again
         // on the next dispatcher cycle. The scroll arrows live in that same late template.
         UpdateTabStripBorderLines();
+        FixTabStripBandHeight();
         HideTabStripScrollButtons();
+        AttachTabStripScrollIndicator();
 
         _ = DispatcherQueue.TryEnqueue(() =>
         {
             UpdateTabStripBorderLines();
+            FixTabStripBandHeight();
             HideTabStripScrollButtons();
+            AttachTabStripScrollIndicator();
         });
     }
 
@@ -143,8 +144,11 @@ public sealed partial class DocumentSectionView : UserControl
 
         if (TabView.SelectedItem is DocumentTab selectedTab)
         {
+            // No-ops on the heads whose strip reveals the selection itself.
             ScrollTabIntoView(selectedTab);
         }
+
+        UpdateTabStripScrollIndicator();
     }
 
     /// <summary>
@@ -223,32 +227,20 @@ public sealed partial class DocumentSectionView : UserControl
     }
 
     // The band the TabView template lays the tab strip out in, which is the row above the document content, so
-    // its height is the whole vertical chrome. Only the height is taken from it: the band is inset from the
-    // section's edges by differing amounts per head, so its width says nothing about what the document has.
+    // its height is the whole vertical chrome. It is fixed at the authored height rather than measured, so a
+    // section's minimum does not move as its tabs open and close.
     private double MeasureTabStripHeight()
     {
         _tabStripContainer ??= VisualTree.FindDescendantByName(TabView, "TabContainerGrid") as FrameworkElement;
 
-        if (_tabStripContainer is null)
-        {
-            // The template has not been applied yet, so there is nothing to measure.
-            return WorkspaceConstants.SectionTabStripHeight;
-        }
-
         // Presentation mode collapses the band, so the section really does have no strip above its document.
-        if (_tabStripContainer.Visibility == Visibility.Collapsed)
+        if (_tabStripContainer is not null &&
+            _tabStripContainer.Visibility == Visibility.Collapsed)
         {
             return 0;
         }
 
-        // The band is sized by what it holds, so an empty section measures a flatter band than a populated one,
-        // and a band that has not laid out measures nothing at all. Only measurements that raise the height are
-        // taken: the authored height is the floor under all of them, and the tallest band the section has shown
-        // is kept. A section's minimum therefore never moves as its tabs open and close, which matters because
-        // the minimums composed from it are written onto grid tracks that are not recomposed on every change.
-        _measuredTabStripHeight = Math.Max(_measuredTabStripHeight, _tabStripContainer.ActualHeight);
-
-        return Math.Max(_measuredTabStripHeight, WorkspaceConstants.SectionTabStripHeight);
+        return WorkspaceConstants.SectionTabStripHeight;
     }
 
     /// <summary>
@@ -650,6 +642,14 @@ public sealed partial class DocumentSectionView : UserControl
         // tabs at the leading edge while showing a blank gap at the trailing edge. Re-clamp once
         // layout has settled.
         _ = DispatcherQueue.TryEnqueue(ClampTabStripScrollOffset);
+
+        // Opening or closing a tab changes how much there is to scroll, and the indicator is attached late
+        // enough that a section's first tabs can arrive before it exists.
+        _ = DispatcherQueue.TryEnqueue(() =>
+        {
+            AttachTabStripScrollIndicator();
+            UpdateTabStripScrollIndicator();
+        });
     }
 
 
@@ -661,6 +661,21 @@ public sealed partial class DocumentSectionView : UserControl
         {
             scrollViewer.ChangeView(scrollViewer.ScrollableWidth, null, null, disableAnimation: true);
         }
+    }
+
+    /// <summary>
+    /// Fixes the tab strip band at its authored height, so what a tab happens to contain cannot set the height
+    /// of the strip. Left to itself the band takes the tallest tab, which puts one file type's icon in charge
+    /// of the strip's height and of the section minimum composed from it.
+    /// </summary>
+    private void FixTabStripBandHeight()
+    {
+        if (VisualTree.FindDescendantByName(TabView, "TabContainerGrid") is not FrameworkElement band)
+        {
+            return;
+        }
+
+        band.Height = WorkspaceConstants.SectionTabStripHeight;
     }
 
     /// <summary>
@@ -697,6 +712,121 @@ public sealed partial class DocumentSectionView : UserControl
         }
 
         _scrollButtonsHidden = true;
+    }
+
+    // Wires the scroll indicator to the strip's own ScrollViewer, which only exists once the tab list's
+    // template has been applied.
+    private void AttachTabStripScrollIndicator()
+    {
+        if (_scrollIndicatorAttached)
+        {
+            return;
+        }
+
+        var scrollViewer = GetTabStripScrollViewer();
+        if (scrollViewer is null)
+        {
+            return;
+        }
+
+        scrollViewer.ViewChanged += OnTabStripViewChanged;
+        ScrollIndicator.ScrollRequested += OnScrollIndicatorScrollRequested;
+        _scrollIndicatorAttached = true;
+
+        UpdateTabStripScrollIndicator();
+    }
+
+    private void OnTabStripViewChanged(object? sender, ScrollViewerViewChangedEventArgs e)
+    {
+        UpdateTabStripScrollIndicator();
+    }
+
+    private void OnScrollIndicatorScrollRequested(double offset)
+    {
+        var scrollViewer = GetTabStripScrollViewer();
+        scrollViewer?.ChangeView(offset, null, null, disableAnimation: true);
+    }
+
+    /// <summary>
+    /// Places the scroll indicator inside the tab strip and hands it the strip's geometry.
+    /// </summary>
+    private void UpdateTabStripScrollIndicator()
+    {
+        if (_isShuttingDown)
+        {
+            return;
+        }
+
+        var scrollViewer = GetTabStripScrollViewer();
+        if (scrollViewer is null ||
+            scrollViewer.ActualWidth <= 0)
+        {
+            ScrollIndicator.Visibility = Visibility.Collapsed;
+
+            return;
+        }
+
+        var stripBounds = scrollViewer
+            .TransformToVisual(RootGrid)
+            .TransformBounds(new Rect(0, 0, scrollViewer.ActualWidth, scrollViewer.ActualHeight));
+
+        ScrollIndicator.Width = stripBounds.Width;
+        ScrollIndicator.Margin = new Thickness(stripBounds.Left, MeasureScrollIndicatorTop(stripBounds), 0, 0);
+
+        ScrollIndicator.Update(
+            MeasureTabStripContentWidth(scrollViewer),
+            scrollViewer.ViewportWidth,
+            scrollViewer.HorizontalOffset);
+
+    }
+
+    // The indicator sits one pixel under the active tab's selection bar, so the pair reads as stacked bars
+    // whatever height the strip band happens to take. It also keeps a pixel of band below itself: the document
+    // below the strip is drawn by a native web view that sits over managed content, and a thumb flush with the
+    // band's bottom edge has its lower edge clipped by it.
+    private double MeasureScrollIndicatorTop(Rect stripBounds)
+    {
+        double lowestTop = stripBounds.Bottom - ScrollIndicator.Height - 1;
+
+        if (TabView.SelectedItem is not DocumentTab selectedTab ||
+            VisualTree.FindDescendantByName(selectedTab, "SelectionIndicator") is not FrameworkElement selectionBar ||
+            selectionBar.ActualHeight <= 0)
+        {
+            // Nothing is selected, so there is no bar to sit under.
+            return lowestTop;
+        }
+
+        var barBounds = selectionBar
+            .TransformToVisual(RootGrid)
+            .TransformBounds(new Rect(0, 0, selectionBar.ActualWidth, selectionBar.ActualHeight));
+
+        return Math.Min(barBounds.Bottom, lowestTop);
+    }
+
+    // The strip's ExtentWidth under-reports the width it actually arranges its tabs in, so a thumb sized from
+    // it alone reaches the end of its track before the tabs reach the end of the strip. The trailing arranged
+    // tab's right edge is the accurate figure and it is available exactly where it matters, at the end of the
+    // strip. Away from there the tabs past the viewport can be virtualized, and the extent is the estimate
+    // that accounts for them.
+    private double MeasureTabStripContentWidth(ScrollViewer scrollViewer)
+    {
+        double arrangedRight = 0;
+        foreach (var tabItem in TabView.TabItems)
+        {
+            if (tabItem is not DocumentTab tab ||
+                tab.ActualWidth <= 0)
+            {
+                continue;
+            }
+
+            var bounds = tab
+                .TransformToVisual(scrollViewer)
+                .TransformBounds(new Rect(0, 0, tab.ActualWidth, tab.ActualHeight));
+
+            arrangedRight = Math.Max(arrangedRight, bounds.Right + scrollViewer.HorizontalOffset);
+        }
+
+        return Math.Max(scrollViewer.ExtentWidth, arrangedRight);
     }
 
     private static void HoldScrollButtonCollapsed(DependencyObject sender, DependencyProperty property)

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
@@ -78,7 +78,8 @@
                            ToolTipService.Placement="Bottom" />
             </StackPanel>
             
-            <!-- Selection indicator -->
+            <!-- Selection indicator. The bottom margin stops short of the strip's bottom edge so the scroll
+                 indicator can sit below it rather than across it while the strip overflows. -->
             <Border x:Name="SelectionIndicator"
                     Height="3"
                     CornerRadius="1.5"
@@ -86,7 +87,7 @@
                     Visibility="Collapsed"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Bottom"
-                    Margin="0,0,-36,-4" />
+                    Margin="0,0,-36,-1" />
         </Grid>
     </muxc:TabViewItem.Header>
 

--- a/Source/Workspace/Celbridge.Documents/Views/TabStripScrollIndicator.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/TabStripScrollIndicator.xaml
@@ -1,0 +1,23 @@
+<UserControl
+    x:Class="Celbridge.Documents.Views.TabStripScrollIndicator"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Height="3">
+
+  <!-- The track has no background, so it neither draws nor takes pointer input: only the thumb does, which
+       keeps the strip's bottom edge clickable as tab rather than as scrollbar. A drag still tracks the pointer
+       across the whole track because the thumb captures it. -->
+  <Grid x:Name="Track"
+        SizeChanged="Track_SizeChanged">
+    <Border x:Name="Thumb"
+            HorizontalAlignment="Left"
+            MinWidth="24"
+            CornerRadius="1.5"
+            Background="{ThemeResource DividerBrush}"
+            PointerPressed="Thumb_PointerPressed"
+            PointerMoved="Thumb_PointerMoved"
+            PointerReleased="Thumb_PointerReleased"
+            PointerCaptureLost="Thumb_PointerCaptureLost"/>
+  </Grid>
+</UserControl>

--- a/Source/Workspace/Celbridge.Documents/Views/TabStripScrollIndicator.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/TabStripScrollIndicator.xaml.cs
@@ -1,0 +1,124 @@
+namespace Celbridge.Documents.Views;
+
+/// <summary>
+/// The thin scroll indicator drawn along the bottom of an overflowing tab strip. The thumb reports how much of
+/// the strip is visible and where, and dragging it scrolls the strip.
+/// </summary>
+public sealed partial class TabStripScrollIndicator : UserControl
+{
+    // The strip geometry the thumb was last drawn from, kept so a track resize can re-place the thumb without
+    // the tab strip having to measure itself again.
+    private sealed record TabStripGeometry(double ContentWidth, double ViewportWidth, double Offset);
+
+    private TabStripGeometry? _geometry;
+    private double _dragStartPointerX;
+    private double _dragStartThumbOffset;
+    private bool _isDragging;
+
+    /// <summary>
+    /// Event raised while the thumb is dragged, carrying the strip offset the drag has reached.
+    /// </summary>
+    public event Action<double>? ScrollRequested;
+
+    public TabStripScrollIndicator()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Sizes and places the thumb from the strip's current geometry, collapsing the whole indicator while the
+    /// strip has nothing to scroll.
+    /// </summary>
+    public void Update(double contentWidth, double viewportWidth, double offset)
+    {
+        _geometry = new TabStripGeometry(contentWidth, viewportWidth, offset);
+        ApplyGeometry();
+    }
+
+    private void ApplyGeometry()
+    {
+        if (_geometry is null)
+        {
+            return;
+        }
+
+        var geometry = _geometry;
+        double scrollableWidth = geometry.ContentWidth - geometry.ViewportWidth;
+        if (scrollableWidth < 1 ||
+            geometry.ViewportWidth <= 0)
+        {
+            Visibility = Visibility.Collapsed;
+
+            return;
+        }
+
+        Visibility = Visibility.Visible;
+
+        double trackWidth = Track.ActualWidth;
+        if (trackWidth <= 0)
+        {
+            // The track has not been arranged yet, so its SizeChanged will bring us back here.
+            return;
+        }
+
+        double visibleFraction = geometry.ViewportWidth / geometry.ContentWidth;
+        double thumbWidth = Math.Max(Thumb.MinWidth, trackWidth * visibleFraction);
+        thumbWidth = Math.Min(thumbWidth, trackWidth);
+
+        double travel = trackWidth - thumbWidth;
+        double scrolledFraction = Math.Clamp(geometry.Offset / scrollableWidth, 0, 1);
+
+        Thumb.Width = thumbWidth;
+        Thumb.Margin = new Thickness(travel * scrolledFraction, 0, 0, 0);
+    }
+
+    private void Track_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        ApplyGeometry();
+    }
+
+    private void Thumb_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        _dragStartPointerX = e.GetCurrentPoint(Track).Position.X;
+        _dragStartThumbOffset = Thumb.Margin.Left;
+        _isDragging = Thumb.CapturePointer(e.Pointer);
+
+        e.Handled = true;
+    }
+
+    private void Thumb_PointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_isDragging ||
+            _geometry is null)
+        {
+            return;
+        }
+
+        double travel = Track.ActualWidth - Thumb.ActualWidth;
+        if (travel <= 0)
+        {
+            return;
+        }
+
+        double scrollableWidth = _geometry.ContentWidth - _geometry.ViewportWidth;
+        double pointerX = e.GetCurrentPoint(Track).Position.X;
+        double thumbOffset = Math.Clamp(_dragStartThumbOffset + (pointerX - _dragStartPointerX), 0, travel);
+
+        ScrollRequested?.Invoke(scrollableWidth * (thumbOffset / travel));
+
+        e.Handled = true;
+    }
+
+    private void Thumb_PointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        Thumb.ReleasePointerCapture(e.Pointer);
+        _isDragging = false;
+
+        e.Handled = true;
+    }
+
+    private void Thumb_PointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        _isDragging = false;
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the UI infrastructure, focusing on design token generation, tab strip behavior, and document section layout consistency. The most significant changes are grouped below.

**Design Token Generation and XAML Resource Updates:**

* The XAML design token generator (`XamlTokenWriter.cs`) now emits brushes within each theme dictionary instead of once over the palette. This ensures brushes resolve according to the correct theme, preventing mismatches when the OS theme and app theme differ. Explanatory comments have been added to the generated files for clarity. [[1]](diffhunk://#diff-f9217ae15a627dbd5cb5b47319e092cfcf78ab3424fd100a4f31320992d8299dL6-R19) [[2]](diffhunk://#diff-f9217ae15a627dbd5cb5b47319e092cfcf78ab3424fd100a4f31320992d8299dL99-R132) [[3]](diffhunk://#diff-f9217ae15a627dbd5cb5b47319e092cfcf78ab3424fd100a4f31320992d8299dR81-R82) [[4]](diffhunk://#diff-f9217ae15a627dbd5cb5b47319e092cfcf78ab3424fd100a4f31320992d8299dL35-L36)
* Documentation in `CLAUDE.md` and code comments have been updated to reflect the new brush placement logic and its rationale. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L67-R67) [[2]](diffhunk://#diff-f9217ae15a627dbd5cb5b47319e092cfcf78ab3424fd100a4f31320992d8299dL6-R19)

**Tab Strip and Document Section UI Consistency:**

* The tab strip band height is now fixed to the authored value, preventing the strip (and thus section minimums) from resizing based on tab content (e.g., icons of varying heights). This is handled by the new `FixTabStripBandHeight` method and related changes. [[1]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R666-R680) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L226-R243) [[3]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R125-R134)
* A new `TabStripScrollIndicator` overlay has been added to the document section view. It appears when the tab strip overflows, providing a scroll affordance without affecting layout. Its attachment and updates are handled in both the XAML and code-behind, responding to tab changes and resizing. [[1]](diffhunk://#diff-653b67fc1e1111ac33543fbbe336209a80e3ab5bf8d4ab4a2e0064b73e14c160R57-R64) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R645-R652) [[3]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R125-R134) [[4]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R147-R151)

**Platform-Specific and Build Improvements:**

* The macOS build process now includes a target to mirror the published bundle's resource layout during local debug runs. This ensures asset resolution (such as fonts) matches the shipped app, preventing missing icons or fallback glyphs when running in place.

**Icon Rendering Fix:**

* The file icon control now explicitly sets its layout box size, ensuring enlarged glyphs (due to scaling) overhang their box rather than resizing it. This prevents a single file type's icon from affecting row or tab strip heights.

**Code Cleanups and Minor Refactors:**

* Unused fields and redundant logic were removed or simplified in the document section view code-behind, improving maintainability. [[1]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L38-L40) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R28) [[3]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L100-L106)

These changes collectively improve theme correctness, UI consistency, and developer experience across platforms.