### PR TITLE
Refactor focus handling and enhance web surface focus detection

### DIFF
--- a/Source/Core/Celbridge.Foundation/UserInterface/UserInterfaceMessages.cs
+++ b/Source/Core/Celbridge.Foundation/UserInterface/UserInterfaceMessages.cs
@@ -6,6 +6,11 @@ namespace Celbridge.UserInterface;
 public record MainWindowActivatedMessage();
 
 /// <summary>
+/// Sent when the main window has been deactivated (i.e. another application took the keyboard).
+/// </summary>
+public record MainWindowDeactivatedMessage();
+
+/// <summary>
 /// Sent when the active application page changes.
 /// </summary>
 public record ActivePageChangedMessage(ApplicationPage ActivePage);

--- a/Source/Core/Celbridge.Foundation/Workspace/IFocusService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IFocusService.cs
@@ -1,6 +1,84 @@
 namespace Celbridge.Workspace;
 
 /// <summary>
+/// What took the keyboard. A claim naming the panel a web surface already holds means opposite things
+/// depending on this: a managed control taking it moves the keyboard off that surface, while the surface
+/// re-reporting its own focus does not.
+/// </summary>
+public enum FocusClaimKind
+{
+    /// <summary>
+    /// A managed control in the visual tree, classified by its nearest panel declaration.
+    /// </summary>
+    ManagedControl,
+
+    /// <summary>
+    /// A web surface, reporting through the web-view focus registry.
+    /// </summary>
+    WebSurface
+}
+
+/// <summary>
+/// A report that something has taken the keyboard: what took it, the panel it belongs to, the edit target it
+/// offers, and for a web surface the callback that drops its caret once focus moves on.
+/// </summary>
+public sealed record FocusClaim
+{
+    private FocusClaim(
+        FocusClaimKind kind,
+        WorkspacePanelId panel,
+        IEditTarget? editTarget,
+        Action? releaseFocus)
+    {
+        Kind = kind;
+        Panel = panel;
+        EditTarget = editTarget;
+        ReleaseFocus = releaseFocus;
+    }
+
+    /// <summary>
+    /// What took the keyboard.
+    /// </summary>
+    public FocusClaimKind Kind { get; }
+
+    /// <summary>
+    /// The panel the claiming element belongs to, or None when it belongs to no panel.
+    /// </summary>
+    public WorkspacePanelId Panel { get; }
+
+    /// <summary>
+    /// The surface Edit commands should route to, or null when the claim offers none.
+    /// </summary>
+    public IEditTarget? EditTarget { get; }
+
+    /// <summary>
+    /// Drops the claiming surface's caret once focus moves off it. Null for a managed control, which has no
+    /// caret of its own to drop.
+    /// </summary>
+    public Action? ReleaseFocus { get; }
+
+    /// <summary>
+    /// A claim by a managed control in the visual tree.
+    /// </summary>
+    public static FocusClaim FromManagedControl(WorkspacePanelId panel, IEditTarget? editTarget = null)
+    {
+        return new FocusClaim(FocusClaimKind.ManagedControl, panel, editTarget, releaseFocus: null);
+    }
+
+    /// <summary>
+    /// A claim by a web surface. The release callback is required rather than optional: supplying it
+    /// is what allows the surface to be released when focus later moves off it.
+    /// </summary>
+    public static FocusClaim FromWebSurface(
+        WorkspacePanelId panel,
+        IEditTarget? editTarget,
+        Action releaseFocus)
+    {
+        return new FocusClaim(FocusClaimKind.WebSurface, panel, editTarget, releaseFocus);
+    }
+}
+
+/// <summary>
 /// Tracks which workspace panel holds focus so that only one panel appears focused at a time, and
 /// coordinates release of focus from the surface that is losing it. Panel focus and edit context are
 /// distinct: panel focus follows the caret, while the edit context follows the surface that Edit commands
@@ -22,13 +100,12 @@ public interface IFocusService
     IEditTarget? EditTarget { get; }
 
     /// <summary>
-    /// Handles a panel receiving focus: records it as the focused panel and invokes the previous surface's
-    /// release callback. A claim that carries a target replaces the edit target; a target-less claim leaves
-    /// the edit target in place. Both target and onReleaseFocus are optional. Only a hosted surface supplies
-    /// a release callback, so a claim without one that names the panel a surface already holds is managed
-    /// chrome (a URL bar, a find bar) taking the keyboard off that surface, and releases it.
+    /// Handles a claim of the keyboard: records the claimed panel as the focused one and invokes the previous
+    /// surface's release callback. A claim carrying an edit target replaces the current one; a claim without
+    /// leaves it in place. A managed control claiming the panel a web surface already holds is chrome
+    /// (a URL bar, a find bar) taking the keyboard off that surface, so the surface is released.
     /// </summary>
-    void OnFocusReceived(WorkspacePanelId panel, IEditTarget? target = null, Action? onReleaseFocus = null);
+    void OnFocusReceived(FocusClaim claim);
 
     /// <summary>
     /// Clears the focused panel to None and releases the surface that holds the caret. The edit context is

--- a/Source/Core/Celbridge.Foundation/Workspace/IFocusService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IFocusService.cs
@@ -13,7 +13,9 @@ public enum FocusClaimKind
     ManagedControl,
 
     /// <summary>
-    /// A web surface, reporting through the web-view focus registry.
+    /// A web surface, reporting through the web-view focus registry. The surface rather than the web view
+    /// control: on macOS that control never takes focus at all, the native web view inside it becomes the
+    /// window's first responder instead.
     /// </summary>
     WebSurface
 }

--- a/Source/Core/Celbridge.Foundation/Workspace/IFocusService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IFocusService.cs
@@ -1,9 +1,13 @@
 namespace Celbridge.Workspace;
 
 /// <summary>
-/// What took the keyboard. A claim naming the panel a web surface already holds means opposite things
-/// depending on this: a managed control taking it moves the keyboard off that surface, while the surface
-/// re-reporting its own focus does not.
+/// The identity of a surface that can hold the keyboard. Compared by reference only, so the focus service can
+/// tell one surface from another without knowing what a surface is.
+/// </summary>
+public interface IFocusSurface;
+
+/// <summary>
+/// What took the keyboard.
 /// </summary>
 public enum FocusClaimKind
 {
@@ -22,7 +26,7 @@ public enum FocusClaimKind
 
 /// <summary>
 /// A report that something has taken the keyboard: what took it, the panel it belongs to, the edit target it
-/// offers, and for a web surface the callback that drops its caret once focus moves on.
+/// offers, and for a web surface its identity and the callback that drops its caret once focus moves on.
 /// </summary>
 public sealed record FocusClaim
 {
@@ -30,11 +34,13 @@ public sealed record FocusClaim
         FocusClaimKind kind,
         WorkspacePanelId panel,
         IEditTarget? editTarget,
+        IFocusSurface? surface,
         Action? releaseFocus)
     {
         Kind = kind;
         Panel = panel;
         EditTarget = editTarget;
+        Surface = surface;
         ReleaseFocus = releaseFocus;
     }
 
@@ -54,6 +60,12 @@ public sealed record FocusClaim
     public IEditTarget? EditTarget { get; }
 
     /// <summary>
+    /// Which web surface is claiming, so a claim from a second surface in the same panel can be told from the
+    /// holding surface re-reporting its own focus. Null for a managed control.
+    /// </summary>
+    public IFocusSurface? Surface { get; }
+
+    /// <summary>
     /// Drops the claiming surface's caret once focus moves off it. Null for a managed control, which has no
     /// caret of its own to drop.
     /// </summary>
@@ -64,19 +76,34 @@ public sealed record FocusClaim
     /// </summary>
     public static FocusClaim FromManagedControl(WorkspacePanelId panel, IEditTarget? editTarget = null)
     {
-        return new FocusClaim(FocusClaimKind.ManagedControl, panel, editTarget, releaseFocus: null);
+        return new FocusClaim(FocusClaimKind.ManagedControl, panel, editTarget, surface: null, releaseFocus: null);
     }
 
     /// <summary>
-    /// A claim by a web surface. The release callback is required rather than optional: supplying it
-    /// is what allows the surface to be released when focus later moves off it.
+    /// A claim by a web surface. The identity and release callback are required rather than optional:
+    /// supplying them is what lets the surface be recognised on a later claim and released when focus moves
+    /// off it.
     /// </summary>
     public static FocusClaim FromWebSurface(
         WorkspacePanelId panel,
         IEditTarget? editTarget,
+        IFocusSurface surface,
         Action releaseFocus)
     {
-        return new FocusClaim(FocusClaimKind.WebSurface, panel, editTarget, releaseFocus);
+        return new FocusClaim(FocusClaimKind.WebSurface, panel, editTarget, surface, releaseFocus);
+    }
+
+    /// <summary>
+    /// A claim by nothing at all, for focus leaving the workspace panels entirely.
+    /// </summary>
+    public static FocusClaim None()
+    {
+        return new FocusClaim(
+            FocusClaimKind.ManagedControl,
+            WorkspacePanelId.None,
+            editTarget: null,
+            surface: null,
+            releaseFocus: null);
     }
 }
 

--- a/Source/Core/Celbridge.UserInterface/Platform/SkiaWindowActivationMonitor.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/SkiaWindowActivationMonitor.cs
@@ -4,8 +4,9 @@ using Celbridge.UserInterface.Services;
 namespace Celbridge.UserInterface.Platform;
 
 /// <summary>
-/// Broadcasts window activation on the Skia desktop heads, so services can refresh state that may have
-/// changed while the application was in the background.
+/// Broadcasts window activation and deactivation on the Skia desktop heads, so services can refresh state
+/// that may have changed while the application was in the background, and can tell the application losing the
+/// keyboard from focus moving within it.
 /// </summary>
 internal sealed class SkiaWindowActivationMonitor : IWindowActivationMonitor
 {
@@ -30,9 +31,14 @@ internal sealed class SkiaWindowActivationMonitor : IWindowActivationMonitor
         if (activationState == Windows.UI.Core.CoreWindowActivationState.PointerActivated
             || activationState == Windows.UI.Core.CoreWindowActivationState.CodeActivated)
         {
-            var message = new MainWindowActivatedMessage();
-            _messengerService.Send(message);
+            var activatedMessage = new MainWindowActivatedMessage();
+            _messengerService.Send(activatedMessage);
+
+            return;
         }
+
+        var deactivatedMessage = new MainWindowDeactivatedMessage();
+        _messengerService.Send(deactivatedMessage);
     }
 }
 #endif

--- a/Source/Core/Celbridge.UserInterface/Platform/WindowActivationMonitor.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/WindowActivationMonitor.cs
@@ -4,8 +4,9 @@ using Celbridge.UserInterface.Services;
 namespace Celbridge.UserInterface.Platform;
 
 /// <summary>
-/// Broadcasts window activation on the packaged WinUI head, so services can refresh state that may have
-/// changed while the application was in the background.
+/// Broadcasts window activation and deactivation on the packaged WinUI head, so services can refresh state
+/// that may have changed while the application was in the background, and can tell the application losing the
+/// keyboard from focus moving within it.
 /// </summary>
 internal sealed class WindowActivationMonitor : IWindowActivationMonitor
 {
@@ -30,9 +31,14 @@ internal sealed class WindowActivationMonitor : IWindowActivationMonitor
         if (activationState == WindowActivationState.PointerActivated
             || activationState == WindowActivationState.CodeActivated)
         {
-            var message = new MainWindowActivatedMessage();
-            _messengerService.Send(message);
+            var activatedMessage = new MainWindowActivatedMessage();
+            _messengerService.Send(activatedMessage);
+
+            return;
         }
+
+        var deactivatedMessage = new MainWindowDeactivatedMessage();
+        _messengerService.Send(deactivatedMessage);
     }
 }
 #endif

--- a/Source/Core/Celbridge.UserInterface/Services/IWindowActivationMonitor.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/IWindowActivationMonitor.cs
@@ -1,7 +1,7 @@
 namespace Celbridge.UserInterface.Services;
 
 /// <summary>
-/// Watches the main window and broadcasts a message when it is activated.
+/// Watches the main window and broadcasts a message when it is activated or deactivated.
 /// </summary>
 public interface IWindowActivationMonitor
 {

--- a/Source/Core/Celbridge.WebHost/Services/IWebViewFocusRegistry.cs
+++ b/Source/Core/Celbridge.WebHost/Services/IWebViewFocusRegistry.cs
@@ -48,11 +48,11 @@ public interface IWebViewFocusRegistry
     void GrantFocus(WebView2 webView);
 
     /// <summary>
-    /// Whether the element is a web surface registered here. The registry reports a hosted surface's focus
+    /// Whether the element is a web surface registered here. The registry reports a web surface's focus
     /// itself, carrying the release callback that a report classified from the visual tree cannot supply, so
     /// an observer of managed focus asks this before reporting an element as its own claim.
     /// </summary>
-    bool IsRegisteredSurface(DependencyObject element);
+    bool IsRegisteredWebSurface(DependencyObject element);
 
     /// <summary>
     /// Whether a hosted web surface's focus report is current. The reconciler derives the desired focus

--- a/Source/Core/Celbridge.WebHost/Services/IWebViewFocusRegistry.cs
+++ b/Source/Core/Celbridge.WebHost/Services/IWebViewFocusRegistry.cs
@@ -18,7 +18,7 @@ public sealed record WebViewFocusRegistration(
     IEditTarget? EditTarget,
     Action ReleaseFocus,
     Func<Task>? GrantDomFocus = null,
-    Action? OnFocusGained = null);
+    Action? OnFocusGained = null) : IFocusSurface;
 
 /// <summary>
 /// The single integration point for hosted web-surface focus on the Skia heads, where WebView and host focus

--- a/Source/Core/Celbridge.WebHost/Services/WebViewFocusRegistry.cs
+++ b/Source/Core/Celbridge.WebHost/Services/WebViewFocusRegistry.cs
@@ -1,4 +1,8 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
 using Celbridge.Logging;
+using Celbridge.Messaging;
+using Celbridge.UserInterface;
 using Celbridge.Workspace;
 using Microsoft.Web.WebView2.Core;
 using Windows.Foundation;
@@ -10,6 +14,7 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
     private readonly IFocusService _focusService;
     private readonly IWebViewAdapter _webViewAdapter;
     private readonly IWebViewFocusMonitor _webViewFocusMonitor;
+    private readonly IMessengerService _messengerService;
     private readonly ILogger<WebViewFocusRegistry> _logger;
 
     // Keyed by CoreWebView2, the stable surface identity shared with the native monitor. Accessed only on the UI
@@ -25,6 +30,17 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
     // projection of the same native object than the one the WebView2 property returns, so it cannot be used
     // to find the registration. Each surface gets a handler closing over the key it registered under.
     private readonly Dictionary<CoreWebView2, TypedEventHandler<CoreWebView2, CoreWebView2WebMessageReceivedEventArgs>> _webMessageHandlers = new();
+
+    // Which surfaces already carry the focus-lost listener. Document-start scripts live as long as the
+    // CoreWebView2 and cannot be removed on every head, so installing once per surface rather than once per
+    // registration keeps a redock (which unregisters and re-registers a live surface) from stacking copies.
+    // Weak keys so tracking a surface never keeps its web view alive.
+    private readonly ConditionalWeakTable<CoreWebView2, object> _surfacesWithFocusLostScript = new();
+
+    // Whether the host window currently holds the keyboard. A page blurs both when focus moves to another
+    // part of the application and when the whole window is deactivated, and only the first is focus leaving
+    // the surface: alt-tabbing away must leave the caret where the user put it.
+    private bool _isHostWindowActive = true;
 
     // Resolved lazily: the reconciler depends on this registry, so constructor-injecting it here would cycle.
     private IFocusReconciler? _focusReconciler;
@@ -48,7 +64,8 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
             }
             window.__celbridgeFocusLostInstalled = true;
 
-            // macOS injects into every frame, and only the top document's focus stands for the surface.
+            // Document-start injection reaches every frame, and only the top document's focus stands for
+            // the surface.
             if (window.top !== window) {
                 return;
             }
@@ -63,9 +80,15 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
                         return;
                     }
 
-                    var webView = window.chrome && window.chrome.webview;
-                    if (webView) {
-                        webView.postMessage(notification);
+                    // The same two native bridges the client transport posts over: chrome.webview on the
+                    // WebView2 heads, and the Uno WKWebView message handler on macOS, where chrome.webview
+                    // is absent. Both surface on the host as CoreWebView2.WebMessageReceived.
+                    if (window.chrome && window.chrome.webview) {
+                        window.chrome.webview.postMessage(notification);
+                    } else if (window.webkit
+                        && window.webkit.messageHandlers
+                        && window.webkit.messageHandlers.unoWebView) {
+                        window.webkit.messageHandlers.unoWebView.postMessage(notification);
                     }
                 }, 0);
             });
@@ -81,12 +104,17 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         IFocusService focusService,
         IWebViewAdapter webViewAdapter,
         IWebViewFocusMonitor webViewFocusMonitor,
+        IMessengerService messengerService,
         ILogger<WebViewFocusRegistry> logger)
     {
         _focusService = focusService;
         _webViewAdapter = webViewAdapter;
         _webViewFocusMonitor = webViewFocusMonitor;
+        _messengerService = messengerService;
         _logger = logger;
+
+        _messengerService.Register<MainWindowActivatedMessage>(this, (_, _) => _isHostWindowActive = true);
+        _messengerService.Register<MainWindowDeactivatedMessage>(this, (_, _) => _isHostWindowActive = false);
     }
 
     public void Register(WebViewFocusRegistration registration)
@@ -99,12 +127,10 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         }
 
         // A pooled WebView reacquired for a new surface keeps its CoreWebView2, so drop the previous
-        // registration's GotFocus subscription before replacing it.
+        // registration's subscriptions before replacing it.
         if (_registrations.ContainsKey(coreWebView))
         {
-            registration.WebView.GotFocus -= OnWebViewGotFocus;
-            coreWebView.NavigationCompleted -= OnNavigationCompleted;
-            RemoveWebMessageHandler(coreWebView);
+            DetachSurfaceHandlers(registration.WebView, coreWebView);
         }
 
         _registrations[coreWebView] = registration;
@@ -122,7 +148,12 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         coreWebView.WebMessageReceived += webMessageHandler;
 
         coreWebView.NavigationCompleted += OnNavigationCompleted;
-        _ = InstallFocusLostScriptAsync(coreWebView);
+
+        if (!_surfacesWithFocusLostScript.TryGetValue(coreWebView, out _))
+        {
+            _surfacesWithFocusLostScript.Add(coreWebView, new object());
+            _ = InstallFocusLostScriptAsync(coreWebView);
+        }
 
         if (!ReferenceEquals(_pendingGrant, registration.WebView))
         {
@@ -163,9 +194,7 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
             _focusedRegistration = null;
         }
 
-        registration.WebView.GotFocus -= OnWebViewGotFocus;
-        coreWebView.NavigationCompleted -= OnNavigationCompleted;
-        RemoveWebMessageHandler(coreWebView);
+        DetachSurfaceHandlers(registration.WebView, coreWebView);
         _webViewFocusMonitor.Unregister(coreWebView);
 
         // Invalidate the edit context on teardown so a closed editor cannot leave the Edit menu enabled. The
@@ -242,8 +271,14 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         }
     }
 
-    private void RemoveWebMessageHandler(CoreWebView2 coreWebView)
+    // Drops everything Register subscribed on the surface itself. The document-start script is deliberately
+    // left in place: it cannot be removed on every head, and the surface is tracked so it is never installed
+    // twice.
+    private void DetachSurfaceHandlers(WebView2 webView, CoreWebView2 coreWebView)
     {
+        webView.GotFocus -= OnWebViewGotFocus;
+        coreWebView.NavigationCompleted -= OnNavigationCompleted;
+
         if (_webMessageHandlers.Remove(coreWebView, out var webMessageHandler))
         {
             coreWebView.WebMessageReceived -= webMessageHandler;
@@ -263,14 +298,15 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
 
             // Read as JSON rather than through TryGetWebMessageAsString, which throws on the macOS WKWebView
             // head where a message arrives as JSON rather than a string. That would cost a thrown exception
-            // per message per surface, only to reach a discriminator. The marker carries no character JSON
-            // escaping touches, so it matches whichever shape the message takes.
+            // per message per surface, only to reach a discriminator.
             var message = e.WebMessageAsJson;
+
+            // Every message the surface sends its host arrives here too, including editor content, so the
+            // marker only pre-filters: matching it decides whether to parse, never whether to act.
             if (string.IsNullOrEmpty(message)
-                || !message.Contains(FocusLostMethod, StringComparison.Ordinal))
+                || !message.Contains(FocusLostMethod, StringComparison.Ordinal)
+                || !IsFocusLostNotification(message))
             {
-                // Every message the surface sends its host arrives here as well, so the marker is matched
-                // before parsing rather than deserializing the whole RPC stream twice.
                 return;
             }
 
@@ -282,21 +318,69 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         }
     }
 
-    // The keyboard has left the page. Only the surface holding focus can lose it, and a click that moves
-    // focus elsewhere claims the new panel before this arrives, so a loss that is still current on the
-    // next turn of the UI thread is one that left focus nowhere.
+    // Whether the message really is the focus-lost notification rather than content that merely mentions it.
+    internal static bool IsFocusLostNotification(string message)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(message);
+            var root = document.RootElement;
+
+            // The page posts the envelope as a JS string, so the WebView2 heads deliver it wrapped in a JSON
+            // string literal. The macOS head hands over the envelope itself.
+            if (root.ValueKind != JsonValueKind.String)
+            {
+                return HasFocusLostMethod(root);
+            }
+
+            var envelope = root.GetString();
+            if (string.IsNullOrEmpty(envelope))
+            {
+                return false;
+            }
+
+            using var envelopeDocument = JsonDocument.Parse(envelope);
+
+            return HasFocusLostMethod(envelopeDocument.RootElement);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasFocusLostMethod(JsonElement element)
+    {
+        return element.ValueKind == JsonValueKind.Object
+            && element.TryGetProperty("method", out var method)
+            && method.ValueKind == JsonValueKind.String
+            && method.GetString() == FocusLostMethod;
+    }
+
+    // The keyboard has left the page. A page can only ever report this for itself, so an untrusted document
+    // gains nothing by forging it: the report is ignored unless that same surface currently holds focus.
     private void OnFocusLost(WebViewFocusRegistration registration)
     {
+        // The window losing activation blurs the page just as a click on another panel does. The keyboard has
+        // left the application rather than the surface, so the caret stays where the user put it and comes
+        // back with them.
+        if (!_isHostWindowActive)
+        {
+            return;
+        }
+
+        // The surface must still hold focus both when the report arrives and one turn of the UI thread later.
+        // The first check drops a report that raced past a release (the user left the surface and came back
+        // while it was in flight); the second gives a click that moves focus elsewhere the chance to claim its
+        // new panel first, so what is left is a loss that put focus nowhere.
         if (!ReferenceEquals(_focusedRegistration, registration))
         {
             return;
         }
 
-        var departingRegistration = registration;
-
         registration.WebView.DispatcherQueue.TryEnqueue(() =>
         {
-            if (!ReferenceEquals(_focusedRegistration, departingRegistration))
+            if (!ReferenceEquals(_focusedRegistration, registration))
             {
                 return;
             }
@@ -412,7 +496,11 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         _focusedRegistration = registration;
         registration.OnFocusGained?.Invoke();
         Action releaseFocus = () => ReleaseSurface(registration);
-        var claim = FocusClaim.FromWebSurface(registration.Panel, registration.EditTarget, releaseFocus);
+        var claim = FocusClaim.FromWebSurface(
+            registration.Panel,
+            registration.EditTarget,
+            registration,
+            releaseFocus);
         _focusService.OnFocusReceived(claim);
 
         // Applied here rather than only on the grant path so every claim converges, however it arrived: a

--- a/Source/Core/Celbridge.WebHost/Services/WebViewFocusRegistry.cs
+++ b/Source/Core/Celbridge.WebHost/Services/WebViewFocusRegistry.cs
@@ -156,7 +156,7 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         }
     }
 
-    public bool IsRegisteredSurface(DependencyObject element)
+    public bool IsRegisteredWebSurface(DependencyObject element)
     {
         return element is WebView2 webView
             && webView.CoreWebView2 is not null
@@ -251,7 +251,9 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
     {
         _focusedRegistration = registration;
         registration.OnFocusGained?.Invoke();
-        _focusService.OnFocusReceived(registration.Panel, registration.EditTarget, () => ReleaseSurface(registration));
+        Action releaseFocus = () => ReleaseSurface(registration);
+        var claim = FocusClaim.FromWebSurface(registration.Panel, registration.EditTarget, releaseFocus);
+        _focusService.OnFocusReceived(claim);
 
         // Applied here rather than only on the grant path so every claim converges, however it arrived: a
         // click landing inside a native web view reports through the monitor without any managed focus

--- a/Source/Core/Celbridge.WebHost/Services/WebViewFocusRegistry.cs
+++ b/Source/Core/Celbridge.WebHost/Services/WebViewFocusRegistry.cs
@@ -1,6 +1,7 @@
 using Celbridge.Logging;
 using Celbridge.Workspace;
 using Microsoft.Web.WebView2.Core;
+using Windows.Foundation;
 
 namespace Celbridge.WebHost;
 
@@ -20,8 +21,56 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
     // another surface or panel (via the wrapped release callback in Report), and on Unregister.
     private WebViewFocusRegistration? _focusedRegistration;
 
+    // The web message handler per surface. The CoreWebView2 handed to the event is a different managed
+    // projection of the same native object than the one the WebView2 property returns, so it cannot be used
+    // to find the registration. Each surface gets a handler closing over the key it registered under.
+    private readonly Dictionary<CoreWebView2, TypedEventHandler<CoreWebView2, CoreWebView2WebMessageReceivedEventArgs>> _webMessageHandlers = new();
+
     // Resolved lazily: the reconciler depends on this registry, so constructor-injecting it here would cycle.
     private IFocusReconciler? _focusReconciler;
+
+    // The JSON-RPC method the injected listener reports the loss under. The input namespace and the past
+    // tense match the notifications the page already sends its host. A well formed notification rather
+    // than a bare string because every registered surface also has a host channel reading the same web
+    // message event, and that channel logs an error for anything it cannot deserialize. StreamJsonRpc drops
+    // a notification naming a method nothing implements, so the channel ignores this one quietly.
+    private const string FocusLostMethod = "input/focusLost";
+
+    // Reports the surface losing the keyboard, which the managed layer cannot see: on the packaged Windows
+    // head the web content lives in its own child window, so a click on the caption or on any non-focusable
+    // region moves the keyboard off it without moving managed focus at all. Injected at document start
+    // through the adapter seam rather than carried by the client bundle, so a page we did not author reports
+    // its losses too.
+    private const string FocusLostScript = """
+        (function () {
+            if (window.__celbridgeFocusLostInstalled) {
+                return;
+            }
+            window.__celbridgeFocusLostInstalled = true;
+
+            // macOS injects into every frame, and only the top document's focus stands for the surface.
+            if (window.top !== window) {
+                return;
+            }
+
+            var notification = JSON.stringify({ jsonrpc: '2.0', method: 'input/focusLost' });
+
+            window.addEventListener('blur', function () {
+                // Focus moving into an iframe of this same page also blurs the top window, and the document
+                // still reports focus in that case, so settle on the next task before deciding it left.
+                setTimeout(function () {
+                    if (document.hasFocus()) {
+                        return;
+                    }
+
+                    var webView = window.chrome && window.chrome.webview;
+                    if (webView) {
+                        webView.postMessage(notification);
+                    }
+                }, 0);
+            });
+        })();
+        """;
 
     // A grant for a surface that had not registered yet, applied when that web view registers. A freshly
     // opened document is activated before its web view finishes initializing. Dropped when the user moves
@@ -54,6 +103,8 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         if (_registrations.ContainsKey(coreWebView))
         {
             registration.WebView.GotFocus -= OnWebViewGotFocus;
+            coreWebView.NavigationCompleted -= OnNavigationCompleted;
+            RemoveWebMessageHandler(coreWebView);
         }
 
         _registrations[coreWebView] = registration;
@@ -62,6 +113,16 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         // that raise no DOM focus event. The native monitor is the macOS equivalent; a no-op elsewhere.
         registration.WebView.GotFocus += OnWebViewGotFocus;
         _webViewFocusMonitor.Register(coreWebView, () => OnNativeFocusSignal(coreWebView));
+
+        // The focus-lost signal comes back through the page rather than either of the gain paths above,
+        // because neither the managed nor the native layer observes the keyboard leaving the web content.
+        TypedEventHandler<CoreWebView2, CoreWebView2WebMessageReceivedEventArgs> webMessageHandler =
+            (_, args) => OnWebMessageReceived(coreWebView, args);
+        _webMessageHandlers[coreWebView] = webMessageHandler;
+        coreWebView.WebMessageReceived += webMessageHandler;
+
+        coreWebView.NavigationCompleted += OnNavigationCompleted;
+        _ = InstallFocusLostScriptAsync(coreWebView);
 
         if (!ReferenceEquals(_pendingGrant, registration.WebView))
         {
@@ -103,6 +164,8 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         }
 
         registration.WebView.GotFocus -= OnWebViewGotFocus;
+        coreWebView.NavigationCompleted -= OnNavigationCompleted;
+        RemoveWebMessageHandler(coreWebView);
         _webViewFocusMonitor.Unregister(coreWebView);
 
         // Invalidate the edit context on teardown so a closed editor cannot leave the Edit menu enabled. The
@@ -145,6 +208,103 @@ internal class WebViewFocusRegistry : IWebViewFocusRegistry
         {
             Report(registration);
         }
+    }
+
+    private async Task InstallFocusLostScriptAsync(CoreWebView2 coreWebView)
+    {
+        try
+        {
+            await _webViewAdapter.InstallDocumentStartScriptAsync(coreWebView, FocusLostScript);
+
+            // Document-start injection reaches the next navigation, not the current one, and a surface
+            // registers once its content has already loaded. Run the listener against the document showing
+            // now as well; installing twice is a no-op.
+            await _webViewAdapter.ReinjectDocumentStartScriptAsync(coreWebView, FocusLostScript);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to install the focus-lost listener");
+        }
+    }
+
+    // Document-start injection is unavailable on the Windows Skia head, which re-delivers after each
+    // navigation instead. The listener guards against installing twice, so re-delivery is a no-op on the
+    // heads whose injected script already survived the navigation.
+    private async void OnNavigationCompleted(CoreWebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
+    {
+        try
+        {
+            await _webViewAdapter.ReinjectDocumentStartScriptAsync(sender, FocusLostScript);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to re-install the focus-lost listener after a navigation");
+        }
+    }
+
+    private void RemoveWebMessageHandler(CoreWebView2 coreWebView)
+    {
+        if (_webMessageHandlers.Remove(coreWebView, out var webMessageHandler))
+        {
+            coreWebView.WebMessageReceived -= webMessageHandler;
+        }
+    }
+
+    private void OnWebMessageReceived(CoreWebView2 coreWebView, CoreWebView2WebMessageReceivedEventArgs e)
+    {
+        // This handler runs on the UI thread alongside the host channel reading the same event, so an
+        // escaping exception would be fatal. A malformed web message must never crash the host.
+        try
+        {
+            if (!_registrations.TryGetValue(coreWebView, out var registration))
+            {
+                return;
+            }
+
+            // Read as JSON rather than through TryGetWebMessageAsString, which throws on the macOS WKWebView
+            // head where a message arrives as JSON rather than a string. That would cost a thrown exception
+            // per message per surface, only to reach a discriminator. The marker carries no character JSON
+            // escaping touches, so it matches whichever shape the message takes.
+            var message = e.WebMessageAsJson;
+            if (string.IsNullOrEmpty(message)
+                || !message.Contains(FocusLostMethod, StringComparison.Ordinal))
+            {
+                // Every message the surface sends its host arrives here as well, so the marker is matched
+                // before parsing rather than deserializing the whole RPC stream twice.
+                return;
+            }
+
+            OnFocusLost(registration);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read a web message while watching for focus loss");
+        }
+    }
+
+    // The keyboard has left the page. Only the surface holding focus can lose it, and a click that moves
+    // focus elsewhere claims the new panel before this arrives, so a loss that is still current on the
+    // next turn of the UI thread is one that left focus nowhere.
+    private void OnFocusLost(WebViewFocusRegistration registration)
+    {
+        if (!ReferenceEquals(_focusedRegistration, registration))
+        {
+            return;
+        }
+
+        var departingRegistration = registration;
+
+        registration.WebView.DispatcherQueue.TryEnqueue(() =>
+        {
+            if (!ReferenceEquals(_focusedRegistration, departingRegistration))
+            {
+                return;
+            }
+
+            _logger.LogDebug("The focused web surface reported that the keyboard left it");
+
+            _focusService.ClearFocus();
+        });
     }
 
     private void OnNativeFocusSignal(CoreWebView2 coreWebView)

--- a/Source/Tests/UserInterface/FocusServiceTests.cs
+++ b/Source/Tests/UserInterface/FocusServiceTests.cs
@@ -7,9 +7,15 @@ namespace Celbridge.Tests.UserInterface;
 [TestFixture]
 public class FocusServiceTests
 {
+    private sealed class TestFocusSurface : IFocusSurface;
+
     private IMessengerService _messengerService = null!;
     private ILogger<FocusService> _logger = null!;
     private FocusService _focusService = null!;
+
+    // The web surface most tests report from. Claims are compared by surface identity, so a test that needs
+    // two distinct surfaces creates its own.
+    private IFocusSurface _surface = null!;
 
     [SetUp]
     public void SetUp()
@@ -17,6 +23,7 @@ public class FocusServiceTests
         _messengerService = Substitute.For<IMessengerService>();
         _logger = Substitute.For<ILogger<FocusService>>();
         _focusService = new FocusService(_messengerService, _logger);
+        _surface = new TestFocusSurface();
     }
 
     [Test]
@@ -35,7 +42,7 @@ public class FocusServiceTests
     public void OnFocusReceived_DifferentPanel_ReleasesPreviousSurface()
     {
         var released = false;
-        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, null, () => released = true);
+        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, null, _surface, () => released = true);
         _focusService.OnFocusReceived(surfaceClaim);
 
         var explorerClaim = FocusClaim.FromManagedControl(WorkspacePanelId.Explorer);
@@ -49,7 +56,7 @@ public class FocusServiceTests
     {
         var releaseCount = 0;
         var target = Substitute.For<IEditTarget>();
-        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => releaseCount++);
+        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, _surface, () => releaseCount++);
         _focusService.OnFocusReceived(surfaceClaim);
 
         // A managed control claiming the panel a surface holds is chrome (the URL bar, the find bar) taking
@@ -67,7 +74,7 @@ public class FocusServiceTests
     {
         var releaseCount = 0;
         var target = Substitute.For<IEditTarget>();
-        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => releaseCount++);
+        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, _surface, () => releaseCount++);
         _focusService.OnFocusReceived(surfaceClaim);
 
         var chromeClaim = FocusClaim.FromManagedControl(WorkspacePanelId.Documents);
@@ -82,17 +89,42 @@ public class FocusServiceTests
     {
         var releaseCount = 0;
         var target = Substitute.For<IEditTarget>();
-        var firstClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => releaseCount++);
+        var firstClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, _surface, () => releaseCount++);
         _focusService.OnFocusReceived(firstClaim);
 
         // A surface reporting its own focus again is not a move off it, so its caret is left alone. The
         // packaged Windows head reports twice for one click, because a web surface takes managed focus
         // there as well as native focus.
-        var secondClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => releaseCount++);
+        var secondClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, _surface, () => releaseCount++);
         _focusService.OnFocusReceived(secondClaim);
 
         releaseCount.Should().Be(0);
         _focusService.EditTarget.Should().Be(target);
+    }
+
+    [Test]
+    public void OnFocusReceived_SecondSurfaceInSamePanel_ReleasesTheFirst()
+    {
+        var firstReleaseCount = 0;
+        var firstClaim = FocusClaim.FromWebSurface(
+            WorkspacePanelId.Documents,
+            null,
+            _surface,
+            () => firstReleaseCount++);
+        _focusService.OnFocusReceived(firstClaim);
+
+        // Two .webview documents both claim the Documents panel and carry no edit target, so neither the
+        // panel nor the target changes when focus moves between them. Only the surface identity shows that
+        // the first has lost the keyboard and must drop its caret.
+        var secondSurface = new TestFocusSurface();
+        var secondClaim = FocusClaim.FromWebSurface(
+            WorkspacePanelId.Documents,
+            null,
+            secondSurface,
+            () => { });
+        _focusService.OnFocusReceived(secondClaim);
+
+        firstReleaseCount.Should().Be(1);
     }
 
     [Test]
@@ -130,7 +162,7 @@ public class FocusServiceTests
     {
         var released = false;
         var target = Substitute.For<IEditTarget>();
-        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => released = true);
+        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, _surface, () => released = true);
         _focusService.OnFocusReceived(surfaceClaim);
 
         // A chrome interaction (e.g. a toolbar click) clears panel focus and releases the caret, but the edit
@@ -147,7 +179,7 @@ public class FocusServiceTests
     {
         var releaseCount = 0;
         var target = Substitute.For<IEditTarget>();
-        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => releaseCount++);
+        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, _surface, () => releaseCount++);
         _focusService.OnFocusReceived(surfaceClaim);
 
         _focusService.ClearFocus();

--- a/Source/Tests/UserInterface/FocusServiceTests.cs
+++ b/Source/Tests/UserInterface/FocusServiceTests.cs
@@ -24,7 +24,8 @@ public class FocusServiceTests
     {
         var target = Substitute.For<IEditTarget>();
 
-        _focusService.OnFocusReceived(WorkspacePanelId.Explorer, target);
+        var claim = FocusClaim.FromManagedControl(WorkspacePanelId.Explorer, target);
+        _focusService.OnFocusReceived(claim);
 
         _focusService.FocusedPanel.Should().Be(WorkspacePanelId.Explorer);
         _focusService.EditTarget.Should().Be(target);
@@ -34,9 +35,11 @@ public class FocusServiceTests
     public void OnFocusReceived_DifferentPanel_ReleasesPreviousSurface()
     {
         var released = false;
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents, onReleaseFocus: () => released = true);
+        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, null, () => released = true);
+        _focusService.OnFocusReceived(surfaceClaim);
 
-        _focusService.OnFocusReceived(WorkspacePanelId.Explorer);
+        var explorerClaim = FocusClaim.FromManagedControl(WorkspacePanelId.Explorer);
+        _focusService.OnFocusReceived(explorerClaim);
 
         released.Should().BeTrue();
     }
@@ -46,12 +49,14 @@ public class FocusServiceTests
     {
         var releaseCount = 0;
         var target = Substitute.For<IEditTarget>();
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents, target, () => releaseCount++);
+        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => releaseCount++);
+        _focusService.OnFocusReceived(surfaceClaim);
 
-        // Only a hosted surface supplies a release callback, so a claim without one is managed chrome in the
-        // same panel (the URL bar, the find bar) taking the keyboard off that surface. The edit context still
-        // follows the surface, so Edit commands keep routing to it.
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents);
+        // A managed control claiming the panel a surface holds is chrome (the URL bar, the find bar) taking
+        // the keyboard off that surface. The edit context still follows the surface, so Edit commands keep
+        // routing to it.
+        var chromeClaim = FocusClaim.FromManagedControl(WorkspacePanelId.Documents);
+        _focusService.OnFocusReceived(chromeClaim);
 
         releaseCount.Should().Be(1);
         _focusService.EditTarget.Should().Be(target);
@@ -62,12 +67,32 @@ public class FocusServiceTests
     {
         var releaseCount = 0;
         var target = Substitute.For<IEditTarget>();
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents, target, () => releaseCount++);
+        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => releaseCount++);
+        _focusService.OnFocusReceived(surfaceClaim);
 
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents);
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents);
+        var chromeClaim = FocusClaim.FromManagedControl(WorkspacePanelId.Documents);
+        _focusService.OnFocusReceived(chromeClaim);
+        _focusService.OnFocusReceived(chromeClaim);
 
         releaseCount.Should().Be(1);
+    }
+
+    [Test]
+    public void OnFocusReceived_SameSurfaceReclaims_DoesNotReleaseIt()
+    {
+        var releaseCount = 0;
+        var target = Substitute.For<IEditTarget>();
+        var firstClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => releaseCount++);
+        _focusService.OnFocusReceived(firstClaim);
+
+        // A surface reporting its own focus again is not a move off it, so its caret is left alone. The
+        // packaged Windows head reports twice for one click, because a web surface takes managed focus
+        // there as well as native focus.
+        var secondClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => releaseCount++);
+        _focusService.OnFocusReceived(secondClaim);
+
+        releaseCount.Should().Be(0);
+        _focusService.EditTarget.Should().Be(target);
     }
 
     [Test]
@@ -75,9 +100,11 @@ public class FocusServiceTests
     {
         var firstTarget = Substitute.For<IEditTarget>();
         var secondTarget = Substitute.For<IEditTarget>();
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents, firstTarget);
+        var firstClaim = FocusClaim.FromManagedControl(WorkspacePanelId.Documents, firstTarget);
+        _focusService.OnFocusReceived(firstClaim);
 
-        _focusService.OnFocusReceived(WorkspacePanelId.Explorer, secondTarget);
+        var secondClaim = FocusClaim.FromManagedControl(WorkspacePanelId.Explorer, secondTarget);
+        _focusService.OnFocusReceived(secondClaim);
 
         _focusService.EditTarget.Should().Be(secondTarget);
     }
@@ -86,11 +113,13 @@ public class FocusServiceTests
     public void OnFocusReceived_NewPanelWithoutTarget_PreservesEditTarget()
     {
         var target = Substitute.For<IEditTarget>();
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents, target);
+        var documentsClaim = FocusClaim.FromManagedControl(WorkspacePanelId.Documents, target);
+        _focusService.OnFocusReceived(documentsClaim);
 
         // A panel that claims focus without an edit target (e.g. Search) leaves the last editing surface in
         // place, so Edit commands still route there.
-        _focusService.OnFocusReceived(WorkspacePanelId.Search);
+        var searchClaim = FocusClaim.FromManagedControl(WorkspacePanelId.Search);
+        _focusService.OnFocusReceived(searchClaim);
 
         _focusService.FocusedPanel.Should().Be(WorkspacePanelId.Search);
         _focusService.EditTarget.Should().Be(target);
@@ -101,7 +130,8 @@ public class FocusServiceTests
     {
         var released = false;
         var target = Substitute.For<IEditTarget>();
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents, target, () => released = true);
+        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => released = true);
+        _focusService.OnFocusReceived(surfaceClaim);
 
         // A chrome interaction (e.g. a toolbar click) clears panel focus and releases the caret, but the edit
         // context must survive so the Edit menu still routes to the console after the toolbar takes focus.
@@ -117,7 +147,8 @@ public class FocusServiceTests
     {
         var releaseCount = 0;
         var target = Substitute.For<IEditTarget>();
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents, target, () => releaseCount++);
+        var surfaceClaim = FocusClaim.FromWebSurface(WorkspacePanelId.Documents, target, () => releaseCount++);
+        _focusService.OnFocusReceived(surfaceClaim);
 
         _focusService.ClearFocus();
         _focusService.ClearFocus();
@@ -129,7 +160,8 @@ public class FocusServiceTests
     public void ClearEditTarget_MatchingTarget_ClearsIt()
     {
         var target = Substitute.For<IEditTarget>();
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents, target);
+        var claim = FocusClaim.FromManagedControl(WorkspacePanelId.Documents, target);
+        _focusService.OnFocusReceived(claim);
 
         _focusService.ClearEditTarget(target);
 
@@ -141,7 +173,8 @@ public class FocusServiceTests
     {
         var currentTarget = Substitute.For<IEditTarget>();
         var tornDownTarget = Substitute.For<IEditTarget>();
-        _focusService.OnFocusReceived(WorkspacePanelId.Documents, currentTarget);
+        var claim = FocusClaim.FromManagedControl(WorkspacePanelId.Documents, currentTarget);
+        _focusService.OnFocusReceived(claim);
 
         // A surface that already lost the edit context tearing down must not wipe the newer target.
         _focusService.ClearEditTarget(tornDownTarget);

--- a/Source/Tests/WebHost/FocusLostNotificationTests.cs
+++ b/Source/Tests/WebHost/FocusLostNotificationTests.cs
@@ -1,0 +1,60 @@
+using Celbridge.WebHost;
+
+namespace Celbridge.Tests.WebHost;
+
+/// <summary>
+/// Unit tests for the focus-lost discriminator. Every message a page sends its host arrives on the same web
+/// message event as this notification, so the discriminator has to separate the two without acting on page
+/// content that merely mentions the method name.
+/// </summary>
+[TestFixture]
+public class FocusLostNotificationTests
+{
+    // The envelope the injected listener posts, as the WebView2 heads deliver it: the page posts a JS string,
+    // so the message arrives wrapped in a JSON string literal.
+    private const string WrappedNotification =
+        "\"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"method\\\":\\\"input/focusLost\\\"}\"";
+
+    // The same envelope as the macOS WKWebView head delivers it, unwrapped.
+    private const string BareNotification =
+        """{"jsonrpc":"2.0","method":"input/focusLost"}""";
+
+    [Test]
+    public void WrappedNotification_IsRecognized()
+    {
+        WebViewFocusRegistry.IsFocusLostNotification(WrappedNotification).Should().BeTrue();
+    }
+
+    [Test]
+    public void BareNotification_IsRecognized()
+    {
+        WebViewFocusRegistry.IsFocusLostNotification(BareNotification).Should().BeTrue();
+    }
+
+    [Test]
+    public void MethodNameInsideContent_IsNotRecognized()
+    {
+        // Editor content reaches the host over the same channel, so a document that happens to contain the
+        // method name must not release the surface the user is typing into.
+        var contentNotification =
+            """{"jsonrpc":"2.0","method":"document/setContent","params":{"text":"input/focusLost"}}""";
+
+        WebViewFocusRegistry.IsFocusLostNotification(contentNotification).Should().BeFalse();
+    }
+
+    [Test]
+    public void AnotherMethod_IsNotRecognized()
+    {
+        var otherNotification =
+            """{"jsonrpc":"2.0","method":"input/linkClicked","params":{"href":"input/focusLost"}}""";
+
+        WebViewFocusRegistry.IsFocusLostNotification(otherNotification).Should().BeFalse();
+    }
+
+    [Test]
+    public void MalformedMessage_IsNotRecognized()
+    {
+        WebViewFocusRegistry.IsFocusLostNotification("input/focusLost").Should().BeFalse();
+        WebViewFocusRegistry.IsFocusLostNotification("{\"method\":").Should().BeFalse();
+    }
+}

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/FocusService.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/FocusService.cs
@@ -34,15 +34,18 @@ public class FocusService : IFocusService
 
     public IEditTarget? EditTarget => _editTarget;
 
-    public void OnFocusReceived(WorkspacePanelId panel, IEditTarget? target = null, Action? onReleaseFocus = null)
+    public void OnFocusReceived(FocusClaim claim)
     {
+        var panel = claim.Panel;
+        var target = claim.EditTarget;
+
         if (panel != _focusedPanel)
         {
             var previousPanel = _focusedPanel;
             var releasePreviousFocus = _releaseFocusedSurface;
 
             _focusedPanel = panel;
-            _releaseFocusedSurface = onReleaseFocus;
+            _releaseFocusedSurface = claim.ReleaseFocus;
 
             // The edit context follows edit intent, not the caret. A claim carrying a target replaces it; a
             // target-less claim (chrome focus, or None) preserves the last editing surface so Edit commands
@@ -78,7 +81,7 @@ public class FocusService : IFocusService
             var releasePreviousFocus = _releaseFocusedSurface;
 
             _editTarget = target;
-            _releaseFocusedSurface = onReleaseFocus;
+            _releaseFocusedSurface = claim.ReleaseFocus;
 
             releasePreviousFocus?.Invoke();
 
@@ -97,16 +100,17 @@ public class FocusService : IFocusService
             _editTarget = target;
         }
 
-        if (onReleaseFocus is not null)
+        // The surface re-reporting its own focus is not a move off it, so it adopts the newer callback and
+        // keeps its caret.
+        if (claim.Kind == FocusClaimKind.WebSurface)
         {
-            _releaseFocusedSurface = onReleaseFocus;
+            _releaseFocusedSurface = claim.ReleaseFocus;
             return;
         }
 
-        // A claim with no release callback comes from a managed control rather than a hosted surface, so
-        // managed chrome has taken the keyboard inside the panel a web surface holds it for: the URL bar
-        // and the find bar both sit in the Documents panel. That is a move off the surface even though the
-        // panel is unchanged, so release it. Without this the surface stays the focused one and focus
+        // Managed chrome has taken the keyboard inside the panel a web surface holds it for: the URL bar and
+        // the find bar both sit in the Documents panel. That is a move off the surface even though the panel
+        // is unchanged, so release it. Without this the surface stays the focused one and focus
         // reconciliation hands the keyboard straight back, leaving the chrome unfocusable.
         var releaseFocusedSurface = _releaseFocusedSurface;
         if (releaseFocusedSurface is null)
@@ -122,7 +126,10 @@ public class FocusService : IFocusService
 
     public void ClearFocus()
     {
-        OnFocusReceived(WorkspacePanelId.None);
+        // Leaving the workspace hands the keyboard to managed content on another page, which belongs to no
+        // workspace panel.
+        var claim = FocusClaim.FromManagedControl(WorkspacePanelId.None);
+        OnFocusReceived(claim);
     }
 
     public void ClearEditTarget(IEditTarget target)

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/FocusService.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/FocusService.cs
@@ -18,6 +18,10 @@ public class FocusService : IFocusService
     // native panel taking focus would otherwise leave a WebView editor's DOM caret active.
     private Action? _releaseFocusedSurface;
 
+    // Identifies the surface that release callback belongs to. Two surfaces in the same panel that both carry
+    // no edit target (two .webview documents) are otherwise indistinguishable from one surface re-reporting.
+    private IFocusSurface? _focusedSurface;
+
     public FocusService(
         IMessengerService messengerService,
         ILogger<FocusService> logger)
@@ -46,6 +50,7 @@ public class FocusService : IFocusService
 
             _focusedPanel = panel;
             _releaseFocusedSurface = claim.ReleaseFocus;
+            _focusedSurface = claim.Surface;
 
             // The edit context follows edit intent, not the caret. A claim carrying a target replaces it; a
             // target-less claim (chrome focus, or None) preserves the last editing surface so Edit commands
@@ -82,6 +87,7 @@ public class FocusService : IFocusService
 
             _editTarget = target;
             _releaseFocusedSurface = claim.ReleaseFocus;
+            _focusedSurface = claim.Surface;
 
             releasePreviousFocus?.Invoke();
 
@@ -100,11 +106,25 @@ public class FocusService : IFocusService
             _editTarget = target;
         }
 
-        // The surface re-reporting its own focus is not a move off it, so it adopts the newer callback and
-        // keeps its caret.
         if (claim.Kind == FocusClaimKind.WebSurface)
         {
+            // The surface re-reporting its own focus is not a move off it, so it adopts the newer callback
+            // and keeps its caret. A different surface in the same panel is a move, even though neither the
+            // panel nor the edit target changed: two .webview documents both claim Documents and carry no
+            // edit target, so only the identity separates the two cases.
+            var releasePreviousSurface = _releaseFocusedSurface;
+            var isSameSurface = ReferenceEquals(claim.Surface, _focusedSurface);
+
             _releaseFocusedSurface = claim.ReleaseFocus;
+            _focusedSurface = claim.Surface;
+
+            if (!isSameSurface)
+            {
+                releasePreviousSurface?.Invoke();
+
+                _logger.LogDebug("Released the previous web surface in {Panel} to another surface", panel);
+            }
+
             return;
         }
 
@@ -119,6 +139,7 @@ public class FocusService : IFocusService
         }
 
         _releaseFocusedSurface = null;
+        _focusedSurface = null;
         releaseFocusedSurface.Invoke();
 
         _logger.LogDebug("Released the focused surface in {Panel} to managed chrome", panel);
@@ -126,9 +147,7 @@ public class FocusService : IFocusService
 
     public void ClearFocus()
     {
-        // Leaving the workspace hands the keyboard to managed content on another page, which belongs to no
-        // workspace panel.
-        var claim = FocusClaim.FromManagedControl(WorkspacePanelId.None);
+        var claim = FocusClaim.None();
         OnFocusReceived(claim);
     }
 

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/PanelFocusTracker.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/PanelFocusTracker.cs
@@ -58,11 +58,11 @@ public class PanelFocusTracker
             return;
         }
 
-        // A hosted surface reports through the registry, which alone can supply the callback that releases
+        // A web surface reports through the registry, which alone can supply the callback that releases
         // the surface later. On the packaged Windows head the web view also takes managed focus, and a
         // report classified from the visual tree here would carry no such callback, so it would read as
         // managed chrome claiming the keyboard and release the surface that had just taken it.
-        if (_webViewFocusRegistry.IsRegisteredSurface(element))
+        if (_webViewFocusRegistry.IsRegisteredWebSurface(element))
         {
             return;
         }
@@ -120,6 +120,7 @@ public class PanelFocusTracker
 
         // The focus service treats a repeated report for the current panel and target as a no-op,
         // so intra-panel focus moves do not spam it.
-        _focusService.OnFocusReceived(panel, editTarget);
+        var claim = FocusClaim.FromManagedControl(panel, editTarget);
+        _focusService.OnFocusReceived(claim);
     }
 }


### PR DESCRIPTION
This pull request introduces a comprehensive set of changes to improve focus management and window activation handling across the application, particularly for web surfaces embedded in the UI. The most significant updates include a new abstraction for focus claims, propagation of window deactivation events, and robust detection of focus loss in web surfaces. These changes provide a more reliable and accurate way to track keyboard focus, especially in scenarios involving web views and platform-specific window activation behaviors.

**Focus management improvements:**

* Introduced the `IFocusSurface` interface and the `FocusClaim` record, encapsulating detailed information about what currently holds keyboard focus (managed control or web surface), including identity and release callbacks. The `IFocusService` API is updated to accept a `FocusClaim` instead of multiple parameters, improving clarity and extensibility. [[1]](diffhunk://#diff-1bec091fbf3a8f40cb7709c848f97363ec25f26d67d7345c8c2f90c5ba27f2f5R3-R109) [[2]](diffhunk://#diff-1bec091fbf3a8f40cb7709c848f97363ec25f26d67d7345c8c2f90c5ba27f2f5L25-R137)
* Updated the `WebViewFocusRegistration` record to implement `IFocusSurface`, aligning web surface registration with the new focus abstraction.

**Window activation and deactivation propagation:**

* Added `MainWindowDeactivatedMessage` alongside the existing activation message, and updated both Skia and WinUI window activation monitors to broadcast deactivation events. This enables services to distinguish between losing focus within the app and the app window itself losing keyboard focus. [[1]](diffhunk://#diff-ab1d14d3965627a73f0923ece16b988692b27e0ed628e7f4508fabd5033e1124R8-R12) [[2]](diffhunk://#diff-b9e8ab92612f1784674d2cda883a16ef41afc578a583e796e1ce837fddbc947bL7-R9) [[3]](diffhunk://#diff-b9e8ab92612f1784674d2cda883a16ef41afc578a583e796e1ce837fddbc947bL33-R41) [[4]](diffhunk://#diff-b6068fb32b451e2a883c44407a665d36158753d41b4c6a4d5f37e063a5224adfL7-R9) [[5]](diffhunk://#diff-b6068fb32b451e2a883c44407a665d36158753d41b4c6a4d5f37e063a5224adfL33-R41) F1be21b5L4R4)

**Web surface focus loss detection and handling:**

* Enhanced `WebViewFocusRegistry` to track host window activation state, injects a JavaScript listener into web surfaces to detect focus loss (e.g., when the user alt-tabs away), and responds appropriately by updating internal focus state only when the app window is still active. Also, manages per-surface event handlers and ensures scripts are injected only once per surface. [[1]](diffhunk://#diff-801d5288cbefea23b343d9303d972f729095eb93d427624c912f8a8a4a6d5593R1-R8) [[2]](diffhunk://#diff-801d5288cbefea23b343d9303d972f729095eb93d427624c912f8a8a4a6d5593R17) [[3]](diffhunk://#diff-801d5288cbefea23b343d9303d972f729095eb93d427624c912f8a8a4a6d5593R29-R97) [[4]](diffhunk://#diff-801d5288cbefea23b343d9303d972f729095eb93d427624c912f8a8a4a6d5593R107-R117) [[5]](diffhunk://#diff-801d5288cbefea23b343d9303d972f729095eb93d427624c912f8a8a4a6d5593L53-R133) [[6]](diffhunk://#diff-801d5288cbefea23b343d9303d972f729095eb93d427624c912f8a8a4a6d5593R143-R157) [[7]](diffhunk://#diff-801d5288cbefea23b343d9303d972f729095eb93d427624c912f8a8a4a6d5593L105-R197)

**API consistency and naming:**

* Renamed `IsRegisteredSurface` to `IsRegisteredWebSurface` in `IWebViewFocusRegistry` for clarity.

These changes collectively provide a more robust and extensible infrastructure for managing keyboard focus and responding to window activation changes, especially in complex multi-surface and hybrid web/native scenarios.