### PR TITLE
Reveal bottom area on alignment change and improve toolbar handling

### DIFF
--- a/Source/Core/Celbridge.Foundation/Workspace/ISetBottomAreaAlignmentCommand.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/ISetBottomAreaAlignmentCommand.cs
@@ -3,7 +3,7 @@ using Celbridge.Commands;
 namespace Celbridge.Workspace;
 
 /// <summary>
-/// Sets how far the Bottom document area spans across the workspace.
+/// Sets how far the Bottom document area spans across the workspace, showing the area if it is hidden.
 /// </summary>
 public interface ISetBottomAreaAlignmentCommand : IExecutableCommand
 {

--- a/Source/Core/Celbridge.UserInterface/Resources/Styles.xaml
+++ b/Source/Core/Celbridge.UserInterface/Resources/Styles.xaml
@@ -197,8 +197,11 @@
 
   <Style TargetType="controls:IconButton" BasedOn="{StaticResource IconButtonBaseStyle}"/>
 
-  <!-- The accent fill is reserved for a checked toggle, so a control with no selected state never takes it. -->
-  <Style TargetType="controls:IconToggleButton" BasedOn="{StaticResource IconButtonBaseStyle}"/>
+  <!-- The accent fill is reserved for a checked toggle, so a control with no selected state never takes it.
+       The checked tone is named here rather than in code so it resolves against the theme in force. -->
+  <Style TargetType="controls:IconToggleButton" BasedOn="{StaticResource IconButtonBaseStyle}">
+    <Setter Property="CheckedForeground" Value="{ThemeResource AccentTextBrush}"/>
+  </Style>
 
   <!-- A project row in a menu. The path goes on a second line rather than in a column beside the name: a
        path long enough to fill the menu squeezes a single-line row's name down to nothing. The padding and

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/IconToggleButton.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/IconToggleButton.cs
@@ -1,4 +1,5 @@
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media;
 
 namespace Celbridge.UserInterface.Views.Controls;
 
@@ -8,4 +9,97 @@ namespace Celbridge.UserInterface.Views.Controls;
 /// </summary>
 public sealed class IconToggleButton : ToggleButton
 {
+    public static readonly DependencyProperty CheckedForegroundProperty =
+        DependencyProperty.Register(
+            nameof(CheckedForeground),
+            typeof(Brush),
+            typeof(IconToggleButton),
+            new PropertyMetadata(null, OnTonePropertyChanged));
+
+    /// <summary>
+    /// The tone the content is drawn in while the button is checked, chosen to read against the accent fill.
+    /// </summary>
+    public Brush? CheckedForeground
+    {
+        get => (Brush?)GetValue(CheckedForegroundProperty);
+        set => SetValue(CheckedForegroundProperty, value);
+    }
+
+    public IconToggleButton()
+    {
+        Checked += OnCheckedChanged;
+        Unchecked += OnCheckedChanged;
+        Loaded += OnLoaded;
+
+        RegisterPropertyChangedCallback(ContentProperty, OnTonePropertyChanged);
+        RegisterPropertyChangedCallback(ForegroundProperty, OnTonePropertyChanged);
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ApplyContentTone();
+    }
+
+    private void OnCheckedChanged(object sender, RoutedEventArgs e)
+    {
+        ApplyContentTone();
+    }
+
+    private static void OnTonePropertyChanged(DependencyObject d, DependencyProperty e)
+    {
+        var button = (IconToggleButton)d;
+        button.ApplyContentTone();
+    }
+
+    private static void OnTonePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var button = (IconToggleButton)d;
+        button.ApplyContentTone();
+    }
+
+    // The tone is pushed onto the content rather than left to the presenter's Foreground, which reaches
+    // content unreliably: a FontIcon never picks it up, and content that reads Foreground through a binding
+    // takes only the value it was born with. Setting it on the content element is a plain property change,
+    // so every reader sees it every time.
+    private void ApplyContentTone()
+    {
+        var tone = IsChecked == true ? CheckedForeground : Foreground;
+        if (tone is null)
+        {
+            return;
+        }
+
+        ApplyTone(Content, tone);
+    }
+
+    private static void ApplyTone(object? element, Brush tone)
+    {
+        switch (element)
+        {
+            case IconElement iconElement:
+                iconElement.Foreground = tone;
+                break;
+
+            case TextBlock textBlock:
+                textBlock.Foreground = tone;
+                break;
+
+            case Control control:
+                control.Foreground = tone;
+                break;
+
+            // A wrapper holding the icon alongside something like a status dot, which keeps its own brush
+            // because it has no Foreground of its own.
+            case Panel panel:
+                foreach (var child in panel.Children)
+                {
+                    ApplyTone(child, tone);
+                }
+                break;
+
+            case Border border:
+                ApplyTone(border.Child, tone);
+                break;
+        }
+    }
 }

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/LayoutToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/LayoutToolbar.xaml.cs
@@ -365,10 +365,17 @@ public sealed partial class LayoutToolbar : UserControl
 
         if (alignment == _layoutService.BottomAreaAlignment)
         {
-            // Clicking the active option unchecked it and changes nothing, so no message comes back to
-            // put it right.
+            // Clicking the active option unchecked it, and the alignment itself does not change, so no
+            // message comes back to put the button right.
             UpdateBottomAreaAlignmentButtons();
-            return;
+
+            if (_layoutService.IsBottomAreaVisible)
+            {
+                return;
+            }
+
+            // The area is hidden, so the click still has something to do: bring it into view at the
+            // alignment already chosen.
         }
 
         _commandService.Execute<ISetBottomAreaAlignmentCommand>(command =>

--- a/Source/Tests/WorkspaceUI/SetBottomAreaAlignmentCommandTests.cs
+++ b/Source/Tests/WorkspaceUI/SetBottomAreaAlignmentCommandTests.cs
@@ -1,0 +1,104 @@
+using Celbridge.Messaging;
+using Celbridge.Messaging.Services;
+using Celbridge.Settings;
+using Celbridge.UserInterface;
+using Celbridge.UserInterface.Services;
+using Celbridge.Workspace;
+using Celbridge.WorkspaceUI.Commands;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Celbridge.Tests.WorkspaceUI;
+
+/// <summary>
+/// Tests that changing the Bottom area alignment brings the area into view, so the alignment the user
+/// picked is something they can see.
+/// </summary>
+[TestFixture]
+public class SetBottomAreaAlignmentCommandTests
+{
+    private ServiceProvider? _serviceProvider;
+    private LayoutManager _layoutManager = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var services = new ServiceCollection();
+
+        Logging.ServiceConfiguration.ConfigureServices(services);
+        services.AddSingleton<IMessengerService, MessengerService>();
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        var messengerService = _serviceProvider.GetRequiredService<IMessengerService>();
+        var settingsService = Substitute.For<ISettingsService>();
+
+        var workspaceSettings = Substitute.For<IBindableWorkspaceSettings>();
+        workspaceSettings.PreferredSurfaceVisibility = WorkspaceSurface.All;
+
+        var workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
+        var workspaceService = Substitute.For<IWorkspaceService>();
+        workspaceWrapper.IsWorkspacePageLoaded.Returns(true);
+        workspaceWrapper.WorkspaceService.Returns(workspaceService);
+        workspaceService.BindableWorkspaceSettings.Returns(workspaceSettings);
+
+        var logger = _serviceProvider.GetRequiredService<ILogger<LayoutManager>>();
+
+        _layoutManager = new LayoutManager(logger, messengerService, settingsService, workspaceWrapper);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        (_serviceProvider as IDisposable)?.Dispose();
+    }
+
+    [Test]
+    public async Task Execute_HiddenBottomArea_AppliesAlignmentAndShowsTheArea()
+    {
+        _layoutManager.SetSurfaceVisibility(WorkspaceSurface.BottomArea, false);
+
+        var command = new SetBottomAreaAlignmentCommand(_layoutManager)
+        {
+            Alignment = BottomAreaAlignment.Justify
+        };
+
+        var result = await command.ExecuteAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        _layoutManager.BottomAreaAlignment.Should().Be(BottomAreaAlignment.Justify);
+        _layoutManager.IsBottomAreaVisible.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Execute_VisibleBottomArea_LeavesTheOtherSurfacesAlone()
+    {
+        var command = new SetBottomAreaAlignmentCommand(_layoutManager)
+        {
+            Alignment = BottomAreaAlignment.Left
+        };
+
+        await command.ExecuteAsync();
+
+        _layoutManager.SurfaceVisibility.Should().Be(WorkspaceSurface.All);
+        _layoutManager.LayoutMode.Should().Be(LayoutMode.Default);
+    }
+
+    [Test]
+    public async Task Execute_InFocusMode_ShowsTheAreaAndReturnsToTheDefaultLayout()
+    {
+        // Focus mode hides every surface, so revealing the Bottom area is the same layout customization
+        // as toggling it by hand and leaves the mode behind.
+        _layoutManager.RequestLayoutTransition(LayoutTransition.Focus);
+
+        var command = new SetBottomAreaAlignmentCommand(_layoutManager)
+        {
+            Alignment = BottomAreaAlignment.Right
+        };
+
+        await command.ExecuteAsync();
+
+        _layoutManager.BottomAreaAlignment.Should().Be(BottomAreaAlignment.Right);
+        _layoutManager.IsBottomAreaVisible.Should().BeTrue();
+        _layoutManager.LayoutMode.Should().Be(LayoutMode.Default);
+    }
+}

--- a/Source/Workspace/Celbridge.WorkspaceUI/Commands/SetBottomAreaAlignmentCommand.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Commands/SetBottomAreaAlignmentCommand.cs
@@ -15,7 +15,10 @@ public class SetBottomAreaAlignmentCommand : CommandBase, ISetBottomAreaAlignmen
 
     public override async Task<Result> ExecuteAsync()
     {
+        // The alignment is applied before the reveal so a hidden area appears at its new span rather than
+        // laying out twice.
         _layoutService.SetBottomAreaAlignment(Alignment);
+        _layoutService.SetSurfaceVisibility(WorkspaceSurface.BottomArea, true);
 
         await Task.CompletedTask;
         return Result.Ok();


### PR DESCRIPTION
This pull request introduces improvements to the handling and visual feedback of the Bottom area alignment in the workspace, ensuring that changing the alignment also reveals the area if it is hidden. It also enhances the `IconToggleButton` control to support a checked foreground tone, and adds comprehensive tests for the new alignment behavior.

**Workspace Bottom Area Alignment Improvements:**

* Changing the Bottom area alignment now also reveals the Bottom area if it is hidden, ensuring the user always sees the effect of their action. This is reflected in both the interface contract (`ISetBottomAreaAlignmentCommand`), command execution logic, and UI event handling. [[1]](diffhunk://#diff-4db603b57e391255a79c1cf20d3ab2e0b66fb8abfbd19851000ccdf203a8b9e3L6-R6) [[2]](diffhunk://#diff-2873bf34a684b9f954ae3be8241745019102ab6725f4a35b74c557ef451e26ffR18-R21) [[3]](diffhunk://#diff-e79a691869f29b73b6f2b820e317ca7597b4d8415b2bba8d74ddd531c8dbace4L368-R380)
* Added a new test suite (`SetBottomAreaAlignmentCommandTests`) to verify that changing the alignment reveals the Bottom area, preserves surface visibility, and behaves correctly in special modes like Focus mode.

**IconToggleButton Visual Enhancements:**

* Introduced a `CheckedForeground` property to `IconToggleButton` and updated its logic so that the button content uses a distinct foreground brush when checked, improving theme support and visual clarity. [[1]](diffhunk://#diff-50a165730ac4a27339f43a076d4910f59070fa95cf2c11d7b74e0e718978e7c1R2) [[2]](diffhunk://#diff-50a165730ac4a27339f43a076d4910f59070fa95cf2c11d7b74e0e718978e7c1R12-R104)
* Updated the XAML style for `IconToggleButton` to set `CheckedForeground` using the theme's accent text brush, ensuring consistent appearance across themes.Update `SetBottomAreaAlignmentCommand` to always show the Bottom area after applying alignment, including when coming from hidden/focus layouts, and adjust toolbar handling for re-clicking the active option while hidden. Added focused WorkspaceUI tests to cover hidden, visible, and focus-mode behavior. Also improved `IconToggleButton` checked-state rendering by introducing a `CheckedForeground` brush (wired from styles) and applying tone directly to supported content elements.