### PR TITLE
Add View menu controls and theme command with toolbar adjustments

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -1113,7 +1113,7 @@ Open with default application instead?</value>
     <value>Exit Presentation</value>
   </data>
   <data name="FullScreenToolbar_ExitPresentationHint" xml:space="preserve">
-    <value>To exit Presentation mode, choose Window &gt; Exit Presentation</value>
+    <value>To exit Presentation mode, choose another layout from the View menu</value>
   </data>
   <data name="TitleBar_WorkspaceTooltip" xml:space="preserve">
     <value>Workspace</value>
@@ -1166,6 +1166,24 @@ Open with default application instead?</value>
   <data name="Menu_File" xml:space="preserve">
     <value>File</value>
   </data>
+  <data name="Menu_View" xml:space="preserve">
+    <value>View</value>
+  </data>
+  <data name="Menu_UtilityPanel" xml:space="preserve">
+    <value>Left Panel</value>
+  </data>
+  <data name="Menu_BottomArea" xml:space="preserve">
+    <value>Bottom Panel</value>
+  </data>
+  <data name="Menu_SideArea" xml:space="preserve">
+    <value>Right Panel</value>
+  </data>
+  <data name="Menu_Theme" xml:space="preserve">
+    <value>Theme</value>
+  </data>
+  <data name="Menu_EnterFullScreen" xml:space="preserve">
+    <value>Enter Full Screen</value>
+  </data>
   <data name="Menu_Edit" xml:space="preserve">
     <value>Edit</value>
   </data>
@@ -1201,9 +1219,6 @@ Open with default application instead?</value>
   </data>
   <data name="Menu_BringAllToFront" xml:space="preserve">
     <value>Bring All to Front</value>
-  </data>
-  <data name="Menu_ExitPresentation" xml:space="preserve">
-    <value>Exit Presentation</value>
   </data>
   <data name="Menu_Help" xml:space="preserve">
     <value>Help</value>

--- a/Source/Core/Celbridge.Foundation/UserInterface/ISetThemeCommand.cs
+++ b/Source/Core/Celbridge.Foundation/UserInterface/ISetThemeCommand.cs
@@ -1,0 +1,15 @@
+using Celbridge.Commands;
+using Celbridge.Settings;
+
+namespace Celbridge.UserInterface;
+
+/// <summary>
+/// A command that selects the application colour theme.
+/// </summary>
+public interface ISetThemeCommand : IExecutableCommand
+{
+    /// <summary>
+    /// The colour theme to apply.
+    /// </summary>
+    ApplicationColorTheme Theme { get; set; }
+}

--- a/Source/Core/Celbridge.Foundation/UserInterface/IUserInterfaceService.cs
+++ b/Source/Core/Celbridge.Foundation/UserInterface/IUserInterfaceService.cs
@@ -1,3 +1,5 @@
+using Celbridge.Settings;
+
 namespace Celbridge.UserInterface;
 
 /// <summary>
@@ -34,4 +36,9 @@ public interface IUserInterfaceService
     /// Applies the currently selected theme to the UserInterface.
     /// </summary>
     void ApplyCurrentTheme();
+
+    /// <summary>
+    /// Selects the application colour theme, persisting it and applying it immediately.
+    /// </summary>
+    void SetTheme(ApplicationColorTheme theme);
 }

--- a/Source/Core/Celbridge.UserInterface/Commands/SetThemeCommand.cs
+++ b/Source/Core/Celbridge.UserInterface/Commands/SetThemeCommand.cs
@@ -1,0 +1,25 @@
+using Celbridge.Commands;
+using Celbridge.Settings;
+
+namespace Celbridge.UserInterface.Commands;
+
+public class SetThemeCommand : CommandBase, ISetThemeCommand
+{
+    private readonly IUserInterfaceService _userInterfaceService;
+
+    public ApplicationColorTheme Theme { get; set; }
+
+    public SetThemeCommand(IUserInterfaceService userInterfaceService)
+    {
+        _userInterfaceService = userInterfaceService;
+    }
+
+    public override async Task<Result> ExecuteAsync()
+    {
+        _userInterfaceService.SetTheme(Theme);
+
+        await Task.CompletedTask;
+
+        return Result.Ok();
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSMainMenu.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSMainMenu.cs
@@ -1,15 +1,15 @@
 using Celbridge.Commands;
 using Celbridge.Documents;
 using Celbridge.Explorer;
+using Celbridge.Settings;
 using Celbridge.UserInterface.ViewModels.Controls;
 using Celbridge.Workspace;
 
 namespace Celbridge.UserInterface.Platform;
 
 /// <summary>
-/// Defines and installs Celbridge's native macOS menubar. Mirrors the in-window hamburger menu's project
-/// commands (dispatched to the same ApplicationMenuViewModel) and adds the standard App, Edit, and Window menus
-/// macOS users expect. macOS-only. Call once at startup on the UI thread.
+/// Defines and installs Celbridge's native macOS menubar, dispatching to the same view models as the in-window
+/// hamburger menu. macOS-only. Call once at startup on the UI thread.
 /// </summary>
 internal static class MacOSMainMenu
 {
@@ -27,8 +27,17 @@ internal static class MacOSMainMenu
     private const long TagNewFolder = 12;
     private const long TagShowLogs = 13;
     private const long TagFind = 14;
-    private const long TagExitPresentation = 15;
-    private const long TagCheckReferences = 16;
+    private const long TagCheckReferences = 15;
+    private const long TagLayoutDefault = 16;
+    private const long TagLayoutFocus = 17;
+    private const long TagLayoutPresentation = 18;
+    private const long TagUtilityPanel = 19;
+    private const long TagBottomArea = 20;
+    private const long TagSideArea = 21;
+    private const long TagResetLayout = 22;
+    private const long TagThemeSystem = 23;
+    private const long TagThemeLight = 24;
+    private const long TagThemeDark = 25;
 
     // Recent project items are generated on demand, so their tags start above the fixed tags and index into
     // _recentProjectPaths, which the Open Recent submenu provider rebuilds each time the menu opens.
@@ -115,6 +124,32 @@ internal static class MacOSMainMenu
             }
         };
 
+        // The layout modes carry check marks rather than being separate enter and exit commands, so
+        // Presentation mode always has a visible way out here. The in-window reveal strip cannot serve as
+        // one on macOS, because the menu bar and title bar auto-reveal over it in native fullscreen.
+        var viewMenu = new MacMenu
+        {
+            Title = Text("Menu_View"),
+            Items = new List<MacMenuItem>
+            {
+                MacMenuItem.Command(Text("LayoutToolbar_DefaultLabel"), TagLayoutDefault),
+                MacMenuItem.Command(Text("LayoutToolbar_FocusLabel"), TagLayoutFocus),
+                MacMenuItem.Command(Text("LayoutToolbar_PresentationLabel"), TagLayoutPresentation),
+                MacMenuItem.Separator(),
+                MacMenuItem.Command(Text("Menu_UtilityPanel"), TagUtilityPanel),
+                MacMenuItem.Command(Text("Menu_BottomArea"), TagBottomArea),
+                MacMenuItem.Command(Text("Menu_SideArea"), TagSideArea),
+                MacMenuItem.Separator(),
+                // Full Screen and Reset Layout act on the window as a whole rather than on one
+                // surface, so they group together as they do in the layout flyout. macOS owns fullscreen,
+                // so it is a responder-chain Selector reaching the window rather than a command of ours.
+                MacMenuItem.Selector(Text("Menu_EnterFullScreen"), "toggleFullScreen:", "f", MacKeyModifier.Command | MacKeyModifier.Control),
+                MacMenuItem.Command(Text("LayoutToolbar_ResetLayoutButton"), TagResetLayout),
+                MacMenuItem.Separator(),
+                MacMenuItem.Submenu(Text("Menu_Theme"), BuildThemeItems)
+            }
+        };
+
         var windowMenu = new MacMenu
         {
             Title = Text("Menu_Window"),
@@ -123,10 +158,6 @@ internal static class MacOSMainMenu
             {
                 MacMenuItem.Selector(Text("Menu_Minimize"), "performMiniaturize:", "m"),
                 MacMenuItem.Selector(Text("Menu_Zoom"), "performZoom:"),
-                MacMenuItem.Separator(),
-                // The only way out of Presentation mode on macOS. The in-window reveal strip cannot be
-                // used there because the menu bar and title bar auto-reveal over it in native fullscreen.
-                MacMenuItem.Command(Text("Menu_ExitPresentation"), TagExitPresentation),
                 MacMenuItem.Separator(),
                 MacMenuItem.Selector(Text("Menu_BringAllToFront"), "arrangeInFront:")
             }
@@ -146,11 +177,12 @@ internal static class MacOSMainMenu
             appMenu,
             fileMenu,
             editMenu,
+            viewMenu,
             windowMenu,
             helpMenu
         };
 
-        return MacOSMenuInterop.Install(menus, OnCommand, Validate);
+        return MacOSMenuInterop.Install(menus, OnCommand, QueryState);
     }
 
     private static IReadOnlyList<MacMenuItem> BuildRecentProjectItems()
@@ -165,7 +197,7 @@ internal static class MacOSMainMenu
 
         if (recentProjects.Count == 0)
         {
-            // A single disabled placeholder (greyed by Validate) when there is no history, matching the
+            // A single disabled placeholder (greyed by QueryState) when there is no history, matching the
             // in-window menu's disabled Open Recent entry.
             var noRecentItem = MacMenuItem.Command(stringLocalizer.GetString("Menu_NoRecentProjects"), TagNoRecentProjects);
             items.Add(noRecentItem);
@@ -189,6 +221,20 @@ internal static class MacOSMainMenu
         return items;
     }
 
+    private static IReadOnlyList<MacMenuItem> BuildThemeItems()
+    {
+        var stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
+
+        var items = new List<MacMenuItem>
+        {
+            MacMenuItem.Command(stringLocalizer.GetString("Theme_System"), TagThemeSystem),
+            MacMenuItem.Command(stringLocalizer.GetString("Theme_Light"), TagThemeLight),
+            MacMenuItem.Command(stringLocalizer.GetString("Theme_Dark"), TagThemeDark)
+        };
+
+        return items;
+    }
+
     private static IFindableDocument? GetActiveFindableDocument()
     {
         var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
@@ -200,13 +246,13 @@ internal static class MacOSMainMenu
         return workspaceWrapper.WorkspaceService.DocumentsService.GetActiveFindableDocument();
     }
 
-    private static bool Validate(long tag)
+    private static MacMenuItemState QueryState(long tag)
     {
-        // The standard Edit verbs are responder-chain Selector items (see the Edit menu in Install), so
-        // AppKit handles their enable state. This validation only covers the Command items below.
+        // The standard Edit verbs and Full Screen are responder-chain Selector items (see Install), so
+        // AppKit handles their state. This only covers the Command items below.
 
         // Reload and Close act on the open project, so they are enabled only while a workspace is loaded.
-        // Every other command is always available. Mirrors the hamburger menu's IsWorkspaceLoaded gating.
+        // Every other project command is always available. Mirrors the hamburger menu's gating.
         switch (tag)
         {
             case TagReloadProject:
@@ -214,20 +260,91 @@ internal static class MacOSMainMenu
             case TagNewFile:
             case TagNewFolder:
             case TagCheckReferences:
-                return ServiceLocator.AcquireService<IWorkspaceWrapper>().IsWorkspacePageLoaded;
+                return WorkspaceCommandState();
 
             case TagFind:
-                return GetActiveFindableDocument()?.CanFind ?? false;
+                return FindCommandState();
 
-            case TagExitPresentation:
-                return ServiceLocator.AcquireService<IWindowModeService>().LayoutMode == LayoutMode.Presentation;
+            case TagLayoutDefault:
+                return LayoutModeState(LayoutMode.Default);
+
+            case TagLayoutFocus:
+                return LayoutModeState(LayoutMode.Focus);
+
+            case TagLayoutPresentation:
+                return LayoutModeState(LayoutMode.Presentation);
+
+            case TagUtilityPanel:
+                return SurfaceState(WorkspaceSurface.UtilityPanel);
+
+            case TagBottomArea:
+                return SurfaceState(WorkspaceSurface.BottomArea);
+
+            case TagSideArea:
+                return SurfaceState(WorkspaceSurface.SideArea);
+
+            case TagResetLayout:
+                return WorkspaceCommandState();
+
+            case TagThemeSystem:
+                return ThemeState(ApplicationColorTheme.System);
+
+            case TagThemeLight:
+                return ThemeState(ApplicationColorTheme.Light);
+
+            case TagThemeDark:
+                return ThemeState(ApplicationColorTheme.Dark);
 
             case TagNoRecentProjects:
-                return false;
+                return MacMenuItemState.Disabled;
 
             default:
-                return true;
+                return MacMenuItemState.Enabled;
         }
+    }
+
+    private static MacMenuItemState FindCommandState()
+    {
+        var canFind = GetActiveFindableDocument()?.CanFind ?? false;
+
+        return canFind ? MacMenuItemState.Enabled : MacMenuItemState.Disabled;
+    }
+
+    private static MacMenuItemState WorkspaceCommandState()
+    {
+        var isWorkspaceLoaded = ServiceLocator.AcquireService<IWorkspaceWrapper>().IsWorkspacePageLoaded;
+
+        return isWorkspaceLoaded ? MacMenuItemState.Enabled : MacMenuItemState.Disabled;
+    }
+
+    private static MacMenuItemState LayoutModeState(LayoutMode layoutMode)
+    {
+        var viewModel = GetViewMenuViewModel();
+        if (!viewModel.IsWorkspaceLoaded)
+        {
+            return MacMenuItemState.Disabled;
+        }
+
+        return MacMenuItemState.Checkable(viewModel.LayoutMode == layoutMode);
+    }
+
+    private static MacMenuItemState SurfaceState(WorkspaceSurface surface)
+    {
+        var viewModel = GetViewMenuViewModel();
+        if (!viewModel.IsWorkspaceLoaded)
+        {
+            return MacMenuItemState.Disabled;
+        }
+
+        return MacMenuItemState.Checkable(viewModel.IsSurfaceVisible(surface));
+    }
+
+    private static MacMenuItemState ThemeState(ApplicationColorTheme theme)
+    {
+        // The theme applies to the whole application, so it stays available with no project open.
+        var viewModel = GetViewMenuViewModel();
+
+        return MacMenuItemState.Checkable(viewModel.Theme == theme);
     }
 
     private static void OnCommand(long tag)
@@ -309,13 +426,44 @@ internal static class MacOSMainMenu
                 GetActiveFindableDocument()?.TryBeginFind();
                 break;
 
-            case TagExitPresentation:
-                // Focus keeps the side panels hidden while restoring the application toolbar, so the user
-                // can pick their next layout from there.
-                ServiceLocator.AcquireService<ICommandService>().Execute<ISetLayoutCommand>(command =>
-                {
-                    command.Transition = LayoutTransition.Focus;
-                });
+            case TagLayoutDefault:
+                GetViewMenuViewModel().SetLayoutMode(LayoutMode.Default);
+                break;
+
+            case TagLayoutFocus:
+                GetViewMenuViewModel().SetLayoutMode(LayoutMode.Focus);
+                break;
+
+            case TagLayoutPresentation:
+                GetViewMenuViewModel().SetLayoutMode(LayoutMode.Presentation);
+                break;
+
+            case TagUtilityPanel:
+                ToggleSurface(WorkspaceSurface.UtilityPanel);
+                break;
+
+            case TagBottomArea:
+                ToggleSurface(WorkspaceSurface.BottomArea);
+                break;
+
+            case TagSideArea:
+                ToggleSurface(WorkspaceSurface.SideArea);
+                break;
+
+            case TagResetLayout:
+                GetViewMenuViewModel().ResetLayout();
+                break;
+
+            case TagThemeSystem:
+                GetViewMenuViewModel().SetTheme(ApplicationColorTheme.System);
+                break;
+
+            case TagThemeLight:
+                GetViewMenuViewModel().SetTheme(ApplicationColorTheme.Light);
+                break;
+
+            case TagThemeDark:
+                GetViewMenuViewModel().SetTheme(ApplicationColorTheme.Dark);
                 break;
 
             case TagClearRecentProjects:
@@ -327,6 +475,19 @@ internal static class MacOSMainMenu
                 commandService.Execute<IOpenBrowserCommand>(command => command.URL = WebsiteUrl);
                 break;
         }
+    }
+
+    private static ViewMenuViewModel GetViewMenuViewModel()
+    {
+        return ServiceLocator.AcquireService<ViewMenuViewModel>();
+    }
+
+    private static void ToggleSurface(WorkspaceSurface surface)
+    {
+        var viewModel = GetViewMenuViewModel();
+        var isVisible = viewModel.IsSurfaceVisible(surface);
+
+        viewModel.SetSurfaceVisibility(surface, !isVisible);
     }
 
     private static void ShowAboutPanel()

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSMenuInterop.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSMenuInterop.cs
@@ -55,6 +55,22 @@ internal enum MacKeyModifier
 }
 
 /// <summary>
+/// The display state of a Command item at the moment its menu is about to be shown: whether the item can
+/// be chosen, and whether it carries a check mark. Selector items are validated by AppKit instead.
+/// </summary>
+internal sealed record MacMenuItemState(bool IsEnabled, bool IsChecked)
+{
+    public static readonly MacMenuItemState Enabled = new(true, false);
+
+    public static readonly MacMenuItemState Disabled = new(false, false);
+
+    /// <summary>
+    /// An enabled item that shows a check mark while it represents the current selection.
+    /// </summary>
+    public static MacMenuItemState Checkable(bool isChecked) => new(true, isChecked);
+}
+
+/// <summary>
 /// One top-level menu in the menubar. IsWindowMenu marks the menu AppKit manages as the standard Window
 /// menu (it appends the open-window list and the standard items).
 /// </summary>
@@ -93,8 +109,8 @@ internal static class MacOSMenuInterop
     // Invoked with the tag of the Command item the user chose.
     private static Action<long>? _onCommand;
 
-    // Invoked with a Command item's tag to decide whether it is currently enabled.
-    private static Func<long, bool>? _onValidate;
+    // Invoked with a Command item's tag to decide how the item should currently be displayed.
+    private static Func<long, MacMenuItemState>? _onQueryState;
 
     // Each dynamic submenu's NSMenu pointer mapped to the provider that rebuilds its items on open. AppKit
     // hands the NSMenu back in menuNeedsUpdate:, so the pointer is the lookup key.
@@ -122,10 +138,10 @@ internal static class MacOSMenuInterop
     /// <summary>
     /// Builds the menubar from the given menus and installs it as the application's main menu. The first
     /// menu is the application menu (its title is replaced by the app name). onCommand runs a chosen Command
-    /// item by tag. onValidate decides, by tag, whether a Command item is currently enabled. Returns false
+    /// item by tag. onQueryState decides, by tag, how a Command item is currently displayed. Returns false
     /// off macOS or if the AppKit application cannot be reached.
     /// </summary>
-    public static bool Install(IReadOnlyList<MacMenu> menus, Action<long> onCommand, Func<long, bool> onValidate)
+    public static bool Install(IReadOnlyList<MacMenu> menus, Action<long> onCommand, Func<long, MacMenuItemState> onQueryState)
     {
         if (!OperatingSystem.IsMacOS())
         {
@@ -145,7 +161,7 @@ internal static class MacOSMenuInterop
         }
 
         _onCommand = onCommand;
-        _onValidate = onValidate;
+        _onQueryState = onQueryState;
         EnsureCommandTarget();
 
         var mainMenu = CreateMenu("MainMenu");
@@ -302,13 +318,20 @@ internal static class MacOSMenuInterop
 
     private static byte HandleValidateMenuItem(IntPtr self, IntPtr selector, IntPtr menuItem)
     {
-        // Runs on the AppKit main thread before a menu shows (and before a key equivalent fires). Defaults
-        // to enabled on any failure. Never let an exception cross back into native code.
+        // Runs on the AppKit main thread before a menu shows (and before a key equivalent fires). AppKit
+        // takes the enabled state from the return value, and the check mark has to be written onto the item
+        // here, as this is the only point at which it is known to be up to date. Defaults to enabled and
+        // unchecked on any failure. Never let an exception cross back into native code.
         try
         {
             var tag = SendMessageReturnNint(menuItem, GetSelector("tag"));
-            var enabled = _onValidate?.Invoke(tag) ?? true;
-            return enabled ? (byte)1 : (byte)0;
+            var state = _onQueryState?.Invoke(tag) ?? MacMenuItemState.Enabled;
+
+            // NSControlStateValueOn is 1 and NSControlStateValueOff is 0.
+            nint controlState = state.IsChecked ? 1 : 0;
+            SendMessageVoid(menuItem, GetSelector("setState:"), controlState);
+
+            return state.IsEnabled ? (byte)1 : (byte)0;
         }
         catch
         {

--- a/Source/Core/Celbridge.UserInterface/ServiceConfiguration.cs
+++ b/Source/Core/Celbridge.UserInterface/ServiceConfiguration.cs
@@ -58,6 +58,7 @@ public static class ServiceConfiguration
         //
 
         services.AddTransient<ISetLayoutCommand, SetLayoutCommand>();
+        services.AddTransient<ISetThemeCommand, SetThemeCommand>();
         services.AddTransient<IAlertCommand, AlertCommand>();
         services.AddTransient<IConfirmActionCommand, ConfirmActionCommand>();
         services.AddTransient<ISpotlightCommand, SpotlightCommand>();
@@ -76,6 +77,7 @@ public static class ServiceConfiguration
         services.AddTransient<NavigationToolbarViewModel>();
         services.AddTransient<ProjectSwitcherViewModel>();
         services.AddTransient<ApplicationMenuViewModel>();
+        services.AddTransient<ViewMenuViewModel>();
         services.AddTransient<AlertDialogViewModel>();
         services.AddTransient<ConfirmationDialogViewModel>();
         services.AddTransient<ProgressDialogViewModel>();

--- a/Source/Core/Celbridge.UserInterface/Services/UserInterfaceService.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/UserInterfaceService.cs
@@ -194,6 +194,12 @@ public class UserInterfaceService : IUserInterfaceService
         ApplyCurrentTheme();
     }
 
+    public void SetTheme(ApplicationColorTheme theme)
+    {
+        _settingsService.Set(SettingCatalog.Application.Theme, theme);
+        ApplyCurrentTheme();
+    }
+
     public void ApplyCurrentTheme()
     {
         var theme = _settingsService.Get(SettingCatalog.Application.Theme);

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Controls/ViewMenuViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Controls/ViewMenuViewModel.cs
@@ -1,0 +1,108 @@
+using Celbridge.Commands;
+using Celbridge.Settings;
+using Celbridge.Workspace;
+
+namespace Celbridge.UserInterface.ViewModels.Controls;
+
+/// <summary>
+/// Shared view model for the View menu. Holds no state of its own, so both the in-window menu and the
+/// native macOS menubar read the current state each time their menu opens.
+/// </summary>
+public class ViewMenuViewModel
+{
+    private readonly ICommandService _commandService;
+    private readonly ISettingsService _settingsService;
+    private readonly IWindowModeService _windowModeService;
+    private readonly ILayoutService _layoutService;
+    private readonly IWorkspaceWrapper _workspaceWrapper;
+
+    public ViewMenuViewModel(
+        ICommandService commandService,
+        ISettingsService settingsService,
+        IWindowModeService windowModeService,
+        ILayoutService layoutService,
+        IWorkspaceWrapper workspaceWrapper)
+    {
+        _commandService = commandService;
+        _settingsService = settingsService;
+        _windowModeService = windowModeService;
+        _layoutService = layoutService;
+        _workspaceWrapper = workspaceWrapper;
+    }
+
+    /// <summary>
+    /// Whether a workspace is loaded. The layout commands all act on the workspace surfaces, so they are
+    /// unavailable on the other pages.
+    /// </summary>
+    public bool IsWorkspaceLoaded => _workspaceWrapper.IsWorkspacePageLoaded;
+
+    public LayoutMode LayoutMode => _windowModeService.LayoutMode;
+
+    public bool IsFullScreen => _windowModeService.IsFullScreen;
+
+    /// <summary>
+    /// The selected application colour theme, which may be System rather than a fixed light or dark.
+    /// </summary>
+    public ApplicationColorTheme Theme => _settingsService.Get(SettingCatalog.Application.Theme);
+
+    public bool IsSurfaceVisible(WorkspaceSurface surface)
+    {
+        return _layoutService.SurfaceVisibility.HasFlag(surface);
+    }
+
+    public void SetLayoutMode(LayoutMode layoutMode)
+    {
+        var transition = LayoutTransition.Default;
+        switch (layoutMode)
+        {
+            case LayoutMode.Focus:
+                transition = LayoutTransition.Focus;
+                break;
+
+            case LayoutMode.Presentation:
+                transition = LayoutTransition.Presentation;
+                break;
+        }
+
+        _commandService.Execute<ISetLayoutCommand>(command =>
+        {
+            command.Transition = transition;
+        });
+    }
+
+    public void SetSurfaceVisibility(WorkspaceSurface surface, bool isVisible)
+    {
+        _commandService.Execute<ISetSurfaceVisibilityCommand>(command =>
+        {
+            command.Surfaces = surface;
+            command.IsVisible = isVisible;
+        });
+    }
+
+    public void ToggleFullScreen()
+    {
+        _commandService.Execute<ISetLayoutCommand>(command =>
+        {
+            command.Transition = LayoutTransition.ToggleFullScreen;
+        });
+    }
+
+    /// <summary>
+    /// Restores all panels to visible at their default sizes and returns to the Default layout.
+    /// </summary>
+    public void ResetLayout()
+    {
+        _commandService.Execute<ISetLayoutCommand>(command =>
+        {
+            command.Transition = LayoutTransition.ResetLayout;
+        });
+    }
+
+    public void SetTheme(ApplicationColorTheme theme)
+    {
+        _commandService.Execute<ISetThemeCommand>(command =>
+        {
+            command.Theme = theme;
+        });
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Pages/SettingsPageViewModel.cs
@@ -1,3 +1,4 @@
+using Celbridge.Commands;
 using Celbridge.Settings;
 
 namespace Celbridge.UserInterface.ViewModels.Pages;
@@ -22,39 +23,83 @@ public partial class SettingsPageViewModel : ObservableObject
 {
     private readonly ISettingsService _settingsService;
     private readonly IStringLocalizer _stringLocalizer;
-    private readonly IUserInterfaceService _userInterfaceService;
+    private readonly ICommandService _commandService;
+    private readonly IMessengerService _messengerService;
 
     public IReadOnlyList<ThemeOption> ThemeOptions { get; }
 
     [ObservableProperty]
     private ThemeOption? _selectedTheme;
 
+    private bool _isReflectingStoredTheme;
+
     public SettingsPageViewModel(
         ISettingsService settingsService,
         IStringLocalizer stringLocalizer,
-        IUserInterfaceService userInterfaceService)
+        ICommandService commandService,
+        IMessengerService messengerService)
     {
         _settingsService = settingsService;
         _stringLocalizer = stringLocalizer;
-        _userInterfaceService = userInterfaceService;
+        _commandService = commandService;
+        _messengerService = messengerService;
 
         ThemeOptions = BuildThemeOptions();
 
-        // Assign the backing field rather than the property so reflecting the stored theme in the combo box
-        // does not run the changed handler, which would redundantly persist and re-apply the current theme.
+        ReflectStoredTheme();
+    }
+
+    public void OnLoaded()
+    {
+        // The View menu can change the theme while this page is open, so follow it rather than showing the
+        // value read at construction.
+        _messengerService.Register<ThemeChangedMessage>(this, OnThemeChanged);
+
+        ReflectStoredTheme();
+    }
+
+    public void OnUnloaded()
+    {
+        _messengerService.UnregisterAll(this);
+    }
+
+    private void OnThemeChanged(object recipient, ThemeChangedMessage message)
+    {
+        // The message carries the resolved light or dark theme, which cannot distinguish System from a
+        // fixed theme that happens to match it. The stored setting can, so read that instead.
+        ReflectStoredTheme();
+    }
+
+    private void ReflectStoredTheme()
+    {
         var storedTheme = _settingsService.Get(SettingCatalog.Application.Theme);
-        _selectedTheme = ThemeOptions.FirstOrDefault(themeOption => themeOption.Theme == storedTheme);
+        var storedOption = ThemeOptions.FirstOrDefault(themeOption => themeOption.Theme == storedTheme);
+
+        // Reflecting the stored theme in the combo box must not run the changed handler, which would
+        // dispatch a command to re-apply the theme that was just applied.
+        _isReflectingStoredTheme = true;
+        try
+        {
+            SelectedTheme = storedOption;
+        }
+        finally
+        {
+            _isReflectingStoredTheme = false;
+        }
     }
 
     partial void OnSelectedThemeChanged(ThemeOption? value)
     {
-        if (value is null)
+        if (value is null
+            || _isReflectingStoredTheme)
         {
             return;
         }
 
-        _settingsService.Set(SettingCatalog.Application.Theme, value.Theme);
-        _userInterfaceService.ApplyCurrentTheme();
+        _commandService.Execute<ISetThemeCommand>(command =>
+        {
+            command.Theme = value.Theme;
+        });
     }
 
     private List<ThemeOption> BuildThemeOptions()

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/FullscreenToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/FullscreenToolbar.xaml.cs
@@ -8,7 +8,7 @@ namespace Celbridge.UserInterface.Views;
 /// A minimal strip shown at the top of the screen in Presentation mode, where the application toolbar is
 /// hidden. On platforms without a native menu bar it is revealed whenever the mouse moves near the top
 /// edge, and clicking it switches to the Focus layout. On platforms with a native menu bar the exit lives
-/// in the Window menu instead, so the strip is a non-interactive hint that points there and is shown only
+/// in the View menu instead, so the strip is a non-interactive hint that points there and is shown only
 /// when Presentation mode is entered.
 /// </summary>
 public sealed partial class FullscreenToolbar : UserControl

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/MainMenu.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/MainMenu.cs
@@ -2,6 +2,8 @@ using Celbridge.Commands;
 using Celbridge.Explorer;
 using Celbridge.Logging;
 using Celbridge.Navigation;
+using Celbridge.Platform;
+using Celbridge.Settings;
 using Celbridge.UserInterface.Views.Controls;
 using Celbridge.UserInterface.ViewModels.Controls;
 using Celbridge.Workspace;
@@ -16,6 +18,7 @@ public class MainMenu
 {
     private readonly IStringLocalizer _stringLocalizer;
     private readonly MenuFlyout _menuFlyout;
+    private readonly ViewMenuViewModel _viewMenuViewModel;
 
     public ApplicationMenuViewModel ViewModel { get; }
 
@@ -23,6 +26,7 @@ public class MainMenu
     {
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
         ViewModel = ServiceLocator.AcquireService<ApplicationMenuViewModel>();
+        _viewMenuViewModel = ServiceLocator.AcquireService<ViewMenuViewModel>();
 
         _menuFlyout = menuFlyout;
 
@@ -41,13 +45,15 @@ public class MainMenu
     {
         _menuFlyout.Items.Clear();
 
-        // The File and Edit groups mirror the macOS menu bar (see MacOSMainMenu), folded into submenus so the
+        // The named groups mirror the macOS menu bar (see MacOSMainMenu), folded into submenus so the
         // hamburger reads the same way on Windows and Linux. Single app-level commands stay flat below them.
         _menuFlyout.Items.Add(CreateFileSubItem());
 
         // Edit verbs route to the focused surface through the edit-intent command; enable state reflects what
         // that surface can currently do.
         _menuFlyout.Items.Add(CreateEditSubItem());
+
+        _menuFlyout.Items.Add(CreateViewSubItem());
 
         _menuFlyout.Items.Add(new MenuFlyoutSeparator());
 
@@ -217,6 +223,129 @@ public class MainMenu
         AddEditItem("Menu_SelectAll", EditIntent.SelectAll);
 
         return editSubItem;
+    }
+
+    private MenuFlyoutSubItem CreateViewSubItem()
+    {
+        // Everything here except the theme acts on the workspace surfaces.
+        var isWorkspaceLoaded = _viewMenuViewModel.IsWorkspaceLoaded;
+
+        // Unlike the File submenu, the items here carry no icons: a check mark and an icon share the same
+        // leading column, so the submenu gives that column over to the check glyph.
+        var viewSubItem = new MenuFlyoutSubItem
+        {
+            Text = _stringLocalizer.GetString("Menu_View")
+        };
+
+        void AddLayoutModeItem(string labelKey, LayoutMode layoutMode)
+        {
+            var isCurrentMode = _viewMenuViewModel.LayoutMode == layoutMode;
+
+            var modeItem = CreateToggleMenuItem(
+                label: _stringLocalizer.GetString(labelKey),
+                isChecked: isCurrentMode,
+                isEnabled: isWorkspaceLoaded,
+                onClick: (sender, e) => _viewMenuViewModel.SetLayoutMode(layoutMode));
+
+            viewSubItem.Items.Add(modeItem);
+        }
+
+        AddLayoutModeItem("LayoutToolbar_DefaultLabel", LayoutMode.Default);
+        AddLayoutModeItem("LayoutToolbar_FocusLabel", LayoutMode.Focus);
+        AddLayoutModeItem("LayoutToolbar_PresentationLabel", LayoutMode.Presentation);
+
+        viewSubItem.Items.Add(new MenuFlyoutSeparator());
+
+        void AddSurfaceItem(string labelKey, WorkspaceSurface surface)
+        {
+            var isVisible = _viewMenuViewModel.IsSurfaceVisible(surface);
+
+            var surfaceItem = CreateToggleMenuItem(
+                label: _stringLocalizer.GetString(labelKey),
+                isChecked: isVisible,
+                isEnabled: isWorkspaceLoaded,
+                onClick: (sender, e) => _viewMenuViewModel.SetSurfaceVisibility(surface, !isVisible));
+
+            viewSubItem.Items.Add(surfaceItem);
+        }
+
+        AddSurfaceItem("Menu_UtilityPanel", WorkspaceSurface.UtilityPanel);
+        AddSurfaceItem("Menu_BottomArea", WorkspaceSurface.BottomArea);
+        AddSurfaceItem("Menu_SideArea", WorkspaceSurface.SideArea);
+
+        viewSubItem.Items.Add(new MenuFlyoutSeparator());
+
+        // Full Screen and Reset Layout act on the window as a whole rather than on one surface, so they
+        // group together as they do in the layout flyout. Where the platform supplies fullscreen through
+        // the window chrome the app offers no toggle of its own (see LayoutToolbar, which hides the same
+        // control).
+        var platformInfo = ServiceLocator.AcquireService<IPlatformInfo>();
+        if (!platformInfo.HasNativeFullScreenAffordance)
+        {
+            var fullScreenItem = CreateToggleMenuItem(
+                label: _stringLocalizer.GetString("LayoutToolbar_FullScreen"),
+                isChecked: _viewMenuViewModel.IsFullScreen,
+                isEnabled: true,
+                onClick: (sender, e) => _viewMenuViewModel.ToggleFullScreen());
+
+            viewSubItem.Items.Add(fullScreenItem);
+        }
+
+        var resetLayoutItem = new MenuFlyoutItem
+        {
+            Text = _stringLocalizer.GetString("LayoutToolbar_ResetLayoutButton"),
+            IsEnabled = isWorkspaceLoaded
+        };
+        resetLayoutItem.Click += (sender, e) => _viewMenuViewModel.ResetLayout();
+        viewSubItem.Items.Add(resetLayoutItem);
+
+        viewSubItem.Items.Add(new MenuFlyoutSeparator());
+
+        viewSubItem.Items.Add(CreateThemeSubItem());
+
+        return viewSubItem;
+    }
+
+    private MenuFlyoutSubItem CreateThemeSubItem()
+    {
+        var themeSubItem = new MenuFlyoutSubItem
+        {
+            Text = _stringLocalizer.GetString("Menu_Theme")
+        };
+
+        // The stored theme can be System as well as a fixed Light or Dark, so all three are offered rather
+        // than a single toggle. Mirrors the Settings page theme options.
+        var currentTheme = _viewMenuViewModel.Theme;
+
+        foreach (var theme in Enum.GetValues<ApplicationColorTheme>())
+        {
+            var themeItem = CreateToggleMenuItem(
+                label: _stringLocalizer.GetString("Theme_" + theme),
+                isChecked: theme == currentTheme,
+                isEnabled: true,
+                onClick: (sender, e) => _viewMenuViewModel.SetTheme(theme));
+
+            themeSubItem.Items.Add(themeItem);
+        }
+
+        return themeSubItem;
+    }
+
+    private ToggleMenuFlyoutItem CreateToggleMenuItem(
+        string label,
+        bool isChecked,
+        bool isEnabled,
+        RoutedEventHandler onClick)
+    {
+        var menuItem = new ToggleMenuFlyoutItem
+        {
+            Text = label,
+            IsChecked = isChecked,
+            IsEnabled = isEnabled
+        };
+        menuItem.Click += onClick;
+
+        return menuItem;
     }
 
     private void ExecuteCreateResource(ResourceType resourceType)

--- a/Source/Core/Celbridge.UserInterface/Views/Pages/SettingsPage.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Pages/SettingsPage.xaml.cs
@@ -22,5 +22,21 @@ public sealed partial class SettingsPage : Page
         ViewModel = ServiceLocator.AcquireService<SettingsPageViewModel>();
 
         this.InitializeComponent();
+
+        Loaded += OnSettingsPage_Loaded;
+        Unloaded += OnSettingsPage_Unloaded;
+    }
+
+    private void OnSettingsPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        ViewModel.OnLoaded();
+    }
+
+    private void OnSettingsPage_Unloaded(object sender, RoutedEventArgs e)
+    {
+        ViewModel.OnUnloaded();
+
+        Loaded -= OnSettingsPage_Loaded;
+        Unloaded -= OnSettingsPage_Unloaded;
     }
 }

--- a/Source/Tests/UserInterface/SetThemeCommandTests.cs
+++ b/Source/Tests/UserInterface/SetThemeCommandTests.cs
@@ -1,0 +1,47 @@
+using Celbridge.Settings;
+using Celbridge.UserInterface;
+using Celbridge.UserInterface.Commands;
+
+namespace Celbridge.Tests.UserInterface;
+
+/// <summary>
+/// Verifies that SetThemeCommand forwards its theme to IUserInterfaceService, which owns persisting and
+/// applying it.
+/// </summary>
+[TestFixture]
+public class SetThemeCommandTests
+{
+    private IUserInterfaceService _userInterfaceService = null!;
+    private SetThemeCommand _command = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _userInterfaceService = Substitute.For<IUserInterfaceService>();
+
+        _command = new SetThemeCommand(_userInterfaceService);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_SetsTheRequestedTheme()
+    {
+        _command.Theme = ApplicationColorTheme.Dark;
+
+        var result = await _command.ExecuteAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        _userInterfaceService.Received(1).SetTheme(ApplicationColorTheme.Dark);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_SystemIsForwardedLikeAnyOtherTheme()
+    {
+        // System is the default, so a command that left Theme unset would look identical to one asking
+        // for System. The command forwards it either way.
+        _command.Theme = ApplicationColorTheme.System;
+
+        await _command.ExecuteAsync();
+
+        _userInterfaceService.Received(1).SetTheme(ApplicationColorTheme.System);
+    }
+}

--- a/Source/Tests/UserInterface/SettingsPageViewModelTests.cs
+++ b/Source/Tests/UserInterface/SettingsPageViewModelTests.cs
@@ -1,3 +1,6 @@
+using Celbridge.Commands;
+using Celbridge.Messaging;
+using Celbridge.Messaging.Services;
 using Celbridge.Settings;
 using Celbridge.Settings.Services;
 using Celbridge.Tests.Helpers;
@@ -10,9 +13,10 @@ using Microsoft.Extensions.Localization;
 namespace Celbridge.Tests.UserInterface;
 
 /// <summary>
-/// Unit tests for the Settings page view model. The theme selection round-trips through the real
-/// SettingsService over an in-memory settings store fake, so the test asserts the stored value directly.
-/// The theme apply is verified through a substitute IUserInterfaceService.
+/// Unit tests for the Settings page view model. The stored theme is read through the real SettingsService
+/// over an in-memory settings store fake. Selecting a theme dispatches ISetThemeCommand rather than writing
+/// the setting here, so that is asserted against a substitute command service. A real MessengerService
+/// carries the theme-changed broadcast the page follows.
 /// </summary>
 [TestFixture]
 public class SettingsPageViewModelTests
@@ -20,7 +24,8 @@ public class SettingsPageViewModelTests
     private FakeSettingsStore _settingsStore = null!;
     private FakeCredentialStore _credentialStore = null!;
     private SettingsService _settingsService = null!;
-    private IUserInterfaceService _userInterfaceService = null!;
+    private ICommandService _commandService = null!;
+    private IMessengerService _messengerService = null!;
     private SettingsPageViewModel _viewModel = null!;
 
     [SetUp]
@@ -38,7 +43,8 @@ public class SettingsPageViewModelTests
             _credentialStore,
             workspaceWrapper);
 
-        _userInterfaceService = Substitute.For<IUserInterfaceService>();
+        _commandService = Substitute.For<ICommandService>();
+        _messengerService = new MessengerService();
 
         var stringLocalizer = Substitute.For<IStringLocalizer>();
         stringLocalizer[Arg.Any<string>()].Returns(
@@ -47,7 +53,8 @@ public class SettingsPageViewModelTests
         _viewModel = new SettingsPageViewModel(
             _settingsService,
             stringLocalizer,
-            _userInterfaceService);
+            _commandService,
+            _messengerService);
     }
 
     [Test]
@@ -70,21 +77,74 @@ public class SettingsPageViewModelTests
     }
 
     [Test]
-    public void SelectingTheme_PersistsAndAppliesIt()
+    public void SelectingTheme_DispatchesSetThemeCommandWithThatTheme()
     {
         var darkOption = _viewModel.ThemeOptions.First(themeOption => themeOption.Theme == ApplicationColorTheme.Dark);
 
         _viewModel.SelectedTheme = darkOption;
 
-        _settingsService.Get(SettingCatalog.Application.Theme).Should().Be(ApplicationColorTheme.Dark);
-        _userInterfaceService.Received(1).ApplyCurrentTheme();
+        _commandService.Received(1).Execute<ISetThemeCommand>(
+            Arg.Is<Action<ISetThemeCommand>?>(configure => ConfiguresTheme(configure, ApplicationColorTheme.Dark)),
+            Arg.Any<string>(),
+            Arg.Any<int>());
     }
 
     [Test]
-    public void InitialisingViewModel_DoesNotPersistOrApplyATheme()
+    public void InitialisingViewModel_DoesNotSetATheme()
     {
         // Reflecting the stored theme in the combo box must not run the changed handler; construction
-        // happened in Setup, so no apply should have occurred.
-        _userInterfaceService.DidNotReceive().ApplyCurrentTheme();
+        // happened in Setup, so no command should have been dispatched.
+        _commandService.DidNotReceive().Execute<ISetThemeCommand>(
+            Arg.Any<Action<ISetThemeCommand>?>(),
+            Arg.Any<string>(),
+            Arg.Any<int>());
+    }
+
+    [Test]
+    public void ThemeChangedElsewhere_UpdatesTheSelectionWithoutDispatching()
+    {
+        // The View menu offers the same themes, so a change made there while this page is open has to be
+        // reflected here rather than leaving a stale selection.
+        _viewModel.OnLoaded();
+
+        _settingsService.Set(SettingCatalog.Application.Theme, ApplicationColorTheme.Light);
+        _messengerService.Send(new ThemeChangedMessage(UserInterfaceTheme.Light));
+
+        _viewModel.SelectedTheme!.Theme.Should().Be(ApplicationColorTheme.Light);
+
+        // Following the change must not dispatch a command of its own, which would loop back through the
+        // theme service.
+        _commandService.DidNotReceive().Execute<ISetThemeCommand>(
+            Arg.Any<Action<ISetThemeCommand>?>(),
+            Arg.Any<string>(),
+            Arg.Any<int>());
+    }
+
+    [Test]
+    public void AfterUnloading_ThemeChangesAreNoLongerFollowed()
+    {
+        _viewModel.OnLoaded();
+        _viewModel.OnUnloaded();
+
+        _settingsService.Set(SettingCatalog.Application.Theme, ApplicationColorTheme.Light);
+        _messengerService.Send(new ThemeChangedMessage(UserInterfaceTheme.Light));
+
+        _viewModel.SelectedTheme!.Theme.Should().Be(ApplicationColorTheme.System);
+    }
+
+    /// <summary>
+    /// Runs a captured configure action against a stand-in command to see which theme it would set.
+    /// </summary>
+    private static bool ConfiguresTheme(Action<ISetThemeCommand>? configure, ApplicationColorTheme expectedTheme)
+    {
+        if (configure is null)
+        {
+            return false;
+        }
+
+        var command = Substitute.For<ISetThemeCommand>();
+        configure(command);
+
+        return command.Theme == expectedTheme;
     }
 }

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -462,14 +462,20 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
     private void UpdateTabStripVisibility(LayoutMode layoutMode)
     {
-        // In Presentation mode, hide the tab strip and toolbar to show only the document content.
-        // In all other modes, show the tab strip and toolbar.
+        // In Presentation mode, hide the tab strip to show only the document content.
         bool showTabStrip = layoutMode != LayoutMode.Presentation;
         SectionContainer.UpdateTabStripVisibility(showTabStrip);
 
+        // The toolbar carries the collapse button, which only means something while the area sits beside
+        // the others. Focus and Presentation give it the whole panel, so there is no edge left to collapse
+        // into and the button is hidden rather than left offering an action it cannot perform.
+        var toolbarVisibility = layoutMode == LayoutMode.Default
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+
         foreach (var toolbar in _areaToolbars.Values)
         {
-            toolbar.Visibility = showTabStrip ? Visibility.Visible : Visibility.Collapsed;
+            toolbar.Visibility = toolbarVisibility;
         }
     }
 


### PR DESCRIPTION
This pull request introduces significant improvements to the macOS menubar in the Celbridge application, especially around the View menu and theme selection. It replaces the previous "Exit Presentation" approach with a more flexible layout and theme management system, adds new View and Theme menu items, and refactors menu state handling for better user feedback (e.g., check marks for selected layouts/themes). Additionally, new interfaces and commands are introduced to support theme changes.

Key changes include:

**macOS Menubar and View Menu Enhancements:**
- Added a new "View" menu to the macOS menubar, with options for switching layouts (Default, Focus, Presentation), toggling panel visibility (Left, Bottom, Right), entering full screen, resetting layout, and selecting application theme. The "Exit Presentation" menu item is removed in favor of switching layouts directly. [[1]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6R127-R152) [[2]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6L127-L130) [[3]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6R180-R185) [[4]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6L30-R40) [[5]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6L312-R466) [[6]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6R480-R492) [[7]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40L1116-R1116) [[8]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40R1169-R1186) [[9]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40L1205-L1207)

**Theme Selection Support:**
- Introduced a new `ISetThemeCommand` interface and `SetThemeCommand` implementation, along with updates to `IUserInterfaceService` to support selecting and applying application color themes. [[1]](diffhunk://#diff-a7b58ffda97b1e3e9a19e93934785b2f0dabf02d4dd6e206bc23e7300560cd60R1-R15) [[2]](diffhunk://#diff-3089830fabc864e122c83a146a734fefaeae9ddd8e3716df70bcbb45be56b3afR1-R2) [[3]](diffhunk://#diff-3089830fabc864e122c83a146a734fefaeae9ddd8e3716df70bcbb45be56b3afR39-R43) [[4]](diffhunk://#diff-2bd212d2cb5fa96d37783729ddc2a09e131c5c8808431e4455478ee60bb53ef5R1-R25)

**Menu Item State and Check Mark Logic:**
- Refactored menu item state management: replaced simple enable/disable validation with a new `MacMenuItemState` record, allowing items to show check marks for the current selection (e.g., active layout or theme). Updated menu interop to use this new state. [[1]](diffhunk://#diff-bfea62894061809eb3c85443e4f6dd8a1ceb08c30fc06aacc1b9b3e868bbabffR57-R72) [[2]](diffhunk://#diff-bfea62894061809eb3c85443e4f6dd8a1ceb08c30fc06aacc1b9b3e868bbabffL96-R113) [[3]](diffhunk://#diff-bfea62894061809eb3c85443e4f6dd8a1ceb08c30fc06aacc1b9b3e868bbabffL125-R144) [[4]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6L203-R347) [[5]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6L168-R200)

**Resource String Updates:**
- Updated and added resource strings for new menu items, including View, panels, and theme options, and clarified the exit from Presentation mode. [[1]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40L1116-R1116) [[2]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40R1169-R1186) [[3]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40L1205-L1207)

These changes collectively provide a more intuitive and flexible menu experience for macOS users, with clearer layout and theme controls and improved menu item feedback.