### PR TITLE
Park the command loop instead of polling every millisecond

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -418,6 +418,9 @@ solution-config.props
 
 .idea/
 
+# Junie (JetBrains AI agent) workspace config, including its generated MCP server list
+.junie/
+
 # Celbridge temp files
 .celbridge/
 

--- a/Source/Core/Celbridge.Commands/Services/CommandService.cs
+++ b/Source/Core/Celbridge.Commands/Services/CommandService.cs
@@ -32,6 +32,13 @@ public class CommandService : ICommandService
 
     private static readonly TimeSpan WatchdogWarningInterval = TimeSpan.FromSeconds(5);
 
+    // How long the command loop parks when the queue is empty. Enqueuing a command signals
+    // _commandEnqueued, so this interval only bounds how often the application update ticks,
+    // not how quickly a command starts.
+    private static readonly TimeSpan IdleTickInterval = TimeSpan.FromMilliseconds(16);
+
+    private readonly SemaphoreSlim _commandEnqueued = new(0, 1);
+
     public CommandService(
         IServiceProvider serviceProvider,
         ICommandLogger logger,
@@ -316,7 +323,18 @@ public class CommandService : ICommandService
                 }
             }
 
-            await Task.Delay(1);
+            bool queueIsEmpty;
+            lock (_lock)
+            {
+                queueIsEmpty = _commandQueue.Count == 0;
+            }
+
+            // Park until a command arrives so an idle app does no work between ticks. A pending
+            // command skips the wait entirely, so a burst still drains at full speed.
+            if (queueIsEmpty)
+            {
+                await _commandEnqueued.WaitAsync(IdleTickInterval);
+            }
         }
     }
 
@@ -326,6 +344,13 @@ public class CommandService : ICommandService
     // and repeats it while the operation stays blocked so a permanent hang keeps reporting itself.
     private async Task<Result> ExecuteWithWatchdogAsync(Task<Result> operation, string operationName)
     {
+        // The application update completes synchronously on almost every tick, so allocating the
+        // watchdog timer and cancellation source before checking would dominate the idle cost.
+        if (operation.IsCompleted)
+        {
+            return await operation;
+        }
+
         using var watchdogCancellation = new CancellationTokenSource();
         var startElapsed = _stopwatch.Elapsed;
 
@@ -364,6 +389,19 @@ public class CommandService : ICommandService
             }
 
             _commandQueue.Add(new QueuedCommand(command));
+        }
+
+        // Wake the command loop if it is parked. The semaphore is capped at one permit, so a
+        // release while one is already pending would throw rather than queue a redundant wake.
+        if (_commandEnqueued.CurrentCount == 0)
+        {
+            try
+            {
+                _commandEnqueued.Release();
+            }
+            catch (SemaphoreFullException)
+            {
+            }
         }
 
         return Result.Ok();

--- a/Source/Core/Celbridge.Commands/Services/CommandService.cs
+++ b/Source/Core/Celbridge.Commands/Services/CommandService.cs
@@ -23,7 +23,8 @@ public class CommandService : ICommandService
 
     private readonly List<QueuedCommand> _commandQueue = new();
 
-    private object _lock = new object();
+    // The single monitor guarding _commandQueue. Every read and write of the queue takes it.
+    private readonly object _lock = new();
 
     private readonly Stopwatch _stopwatch = new();
     private double _lastWorkspaceUpdateTime = 0;
@@ -212,10 +213,6 @@ public class CommandService : ICommandService
         {
             if (_stopped)
             {
-                lock (_commandQueue)
-                {
-                    _commandQueue.Clear();
-                }
                 _stopped = false;
                 break;
             }


### PR DESCRIPTION
## What

Two changes to `CommandService`, both about work it did at idle.

**1. Park the command loop** (`e27a902f`). The loop ran `while (true)` paced by `await Task.Delay(1)`. On macOS that resolves to ~1.2 ms, so it ran ~823 times/second at idle, allocating a `CancellationTokenSource` and arming a 5 s watchdog on every pass to guard work that had already completed synchronously. It now parks on a `SemaphoreSlim` that `EnqueueCommand` signals, with a 16 ms idle tick, and the watchdog fast-paths when the operation is already complete.

**2. Leave one monitor** (`c41b804b`). The stop path cleared the queue under `lock (_commandQueue)` while every other access took `_lock` — different monitors, so the clear was unsynchronised against a concurrent `EnqueueCommand`. The clear turned out to be redundant: the loop `break`s on the next line, so no queued command would run either way, and the service is discarded in both cases that reach there (a fresh `ServiceProvider` per test, process exit in the app). Removing it drops the second monitor rather than synchronising it. `_lock` is now `readonly`.

## Measured

`dotnet-counters` at idle, Debug build, net10.0-desktop / osx-arm64:

| | before | after |
|---|---|---|
| Thread-pool work items | 717 /s | 33 /s |
| Allocation rate | 2.36 MB/s | 425 KB/s |
| Gen-0 collections | 0.29 /s | 0.00 /s |
| Kernel (system) CPU | 0.11 s/s | 0.03 s/s |

Tests: 2187 passed, 2 skipped, 0 failed — unchanged across both commits.

## Reviewer notes

- **Only measured on macOS.** The loop is shared code and this changes Windows timing too. On Windows `Task.Delay(1)` rounds up to the ~15.6 ms OS timer granularity, so the loop was already running at ~64 Hz there and the new 16 ms idle tick should be close to a no-op — but that is inference, not measurement. Worth a sanity check on the packaged Windows head.
- This does **not** fix macOS idle CPU overall. Idle is dominated by Uno's Skia render loop, not by this. The app settles to ~2% either way; this change is worth having on its own merits.
- `StopExecution` is deliberately kept. `CommandTests` builds a fresh `ServiceProvider` per test, so `TearDown`'s `StopExecution()` is the only thing ending each test's loop — the flag is load-bearing even though the app-side path barely matters.
- An earlier revision of this description raised a possible re-entrancy problem if `contentFrame.Loaded` fired twice and started a second loop. That is **withdrawn**: the frame is fetched once and never reparented or re-added, so nothing can produce a second `StartExecution()`. It was raised before that was checked.
