### PR TITLE
Build the Python wheel reproducibly

### DIFF
--- a/Source/Workspace/Celbridge.Python/build.py
+++ b/Source/Workspace/Celbridge.Python/build.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Build Celbridge packages and copy wheels to Celbridge.Python Assets folder."""
 
+import os
 import shutil
 import subprocess
 import sys
@@ -10,6 +11,11 @@ from pathlib import Path
 # with anything older, and the interpreter running this script is not always the newest one installed
 # (on macOS it is usually the system Python), so a newer one is looked up when this one is too old.
 MINIMUM_PYTHON = (3, 10)
+
+# Zip entries record the time each file was packaged, so two builds of identical sources differ byte
+# for byte and the committed wheel shows as modified after every rebuild. Pinning SOURCE_DATE_EPOCH
+# makes the wheel reproducible. The value is arbitrary because nothing reads these timestamps.
+WHEEL_TIMESTAMP = "1704067200"  # 2024-01-01T00:00:00Z
 
 CANDIDATE_INTERPRETERS = [
     "python3.13",
@@ -50,6 +56,21 @@ def find_interpreter():
     return None
 
 
+def normalize_line_endings(pkg_dir):
+    """Rewrite any CRLF source file in the package as LF, returning the paths that were changed."""
+    normalized = []
+
+    for path in sorted(pkg_dir.rglob("*.py")):
+        content = path.read_bytes()
+        if b"\r\n" not in content:
+            continue
+
+        path.write_bytes(content.replace(b"\r\n", b"\n"))
+        normalized.append(path)
+
+    return normalized
+
+
 def build_wheel(interpreter, pkg_dir):
     """Build a wheel for the given package."""
     dist = pkg_dir / "dist"
@@ -77,6 +98,15 @@ def main():
     root = Path(__file__).parent
     packages = [root / "packages/celbridge"]
     assets = root / "Assets/Python"
+
+    # A wheel stores each source file as raw bytes, so a source with CRLF on disk puts CRLF inside
+    # the wheel. .gitattributes only applies eol=lf when a file is checked out, so a working tree
+    # older than that rule still holds CRLF and produces a different wheel from the same commit.
+    # Normalising here keeps the wheel identical regardless of the checkout it was built from.
+    os.environ.setdefault("SOURCE_DATE_EPOCH", WHEEL_TIMESTAMP)
+    for pkg in packages:
+        for path in normalize_line_endings(pkg):
+            print(f"Converted {path.name} from CRLF to LF")
 
     # Flushed because pip writes straight to the same stream, so an unflushed line lands after its output.
     print(f"Building wheels with {interpreter}...", flush=True)


### PR DESCRIPTION
## What

`build.py` now normalises line endings across the package sources and pins `SOURCE_DATE_EPOCH`, so the wheel is byte-identical no matter which machine or checkout builds it.

## Why

Two independent causes made the committed wheel churn.

**1. Line endings.** A wheel stores each source as raw bytes, so a working tree holding CRLF produces a different wheel from the same commit. `.gitattributes` applies `eol=lf` only when a file is *checked out* — it never rewrites files already in a working tree. The evidence is a clean split across all 24 sources in the committed wheel:

| endings | last commit range |
|---|---|
| CRLF (16 files) | 2026-03-30 → **2026-06-18** |
| LF (8 files) | **2026-07-02** → 2026-08-13 |

The `eol=lf` rule landed 2026-07-03 (fb87b02b). Every CRLF file predates it, with no exceptions — so the wheel was built on a checkout older than the rule.

**2. Timestamps.** Zip entries record packaging time, so two builds of identical sources differ byte for byte *even on one machine*. Only 5 `dist-info` entries differ, purely in timestamps — entry content is identical. This would keep the wheel churning even after the line endings were fixed.

## Verification

- Injected CRLF into three sources to simulate a stale checkout, rebuilt: result **byte-identical** to the clean-tree build (`6b4ccb0d…`).
- Two consecutive builds now produce identical bytes; previously they never did.
- Regenerated wheel is content-identical to the committed one: **0 entries differ** after normalising line endings, 0 CRLF remaining.
- `.NET` build of `Celbridge.Python.csproj` succeeds; Python suite **70 passed**.

## Reviewer notes

- **The wheel is deliberately not updated in this PR.** The next build regenerates it, and that one-time change can land separately.
- **The first build on a stale checkout converts sources in place** and prints each file it changed. That is the intended one-time correction, but it will look surprising if unexpected. Those files show in `git status` as modified with an empty diff, and committing them is a no-op, since `text=auto` already normalises content into the index.
- `SOURCE_DATE_EPOCH` uses `setdefault`, so an existing value (e.g. from CI) still wins.
