### PR TITLE
Gate command queue while modal dialog open

### DIFF
--- a/Source/Core/Celbridge.Commands/Services/CommandService.cs
+++ b/Source/Core/Celbridge.Commands/Services/CommandService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Celbridge.Dialog;
 using Celbridge.Logging;
 using Celbridge.Messaging;
 using Celbridge.Resources;
@@ -18,6 +19,7 @@ public class CommandService : ICommandService
     private readonly IMessengerService _messengerService;
     private readonly ISettingsService _settingsService;
     private readonly IWorkspaceWrapper _workspaceWrapper;
+    private readonly IDialogService _dialogService;
 
     private record QueuedCommand(IExecutableCommand Command);
 
@@ -46,7 +48,8 @@ public class CommandService : ICommandService
         ILogSerializer logSerializer,
         IMessengerService messengerService,
         ISettingsService settingsService,
-        IWorkspaceWrapper workspaceWrapper)
+        IWorkspaceWrapper workspaceWrapper,
+        IDialogService dialogService)
     {
         _serviceProvider = serviceProvider;
         _logger = logger;
@@ -54,6 +57,7 @@ public class CommandService : ICommandService
         _messengerService = messengerService;
         _settingsService = settingsService;
         _workspaceWrapper = workspaceWrapper;
+        _dialogService = dialogService;
     }
 
     public Result Execute<T>(
@@ -225,12 +229,19 @@ public class CommandService : ICommandService
                 _logger.LogError(updateResult, "Failed to update application");
             }
 
+            // An open dialog is the user being asked a question, so the queue waits for the answer. Only
+            // the dequeue waits: the application update above keeps ticking, so document auto-save and
+            // settings flushes carry on while the dialog is up. Anything the dialog itself needs to run
+            // goes through ExecuteImmediate, which does not touch the queue.
+            bool dialogIsOpen = _dialogService.IsDialogOpen;
+
             // Find the first command that is ready to execute
             IExecutableCommand? command = null;
 
             lock (_lock)
             {
-                if (_commandQueue.Count > 0)
+                if (!dialogIsOpen &&
+                    _commandQueue.Count > 0)
                 {
                     var item = _commandQueue[0];
                     command = item.Command;
@@ -327,8 +338,11 @@ public class CommandService : ICommandService
             }
 
             // Park until a command arrives so an idle app does no work between ticks. A pending
-            // command skips the wait entirely, so a burst still drains at full speed.
-            if (queueIsEmpty)
+            // command skips the wait entirely, so a burst still drains at full speed. A queue held by an
+            // open dialog parks on the same interval rather than spinning, since closing the dialog does
+            // not signal the semaphore.
+            if (queueIsEmpty ||
+                _dialogService.IsDialogOpen)
             {
                 await _commandEnqueued.WaitAsync(IdleTickInterval);
             }

--- a/Source/Core/Celbridge.Foundation/Dialog/IDialogService.cs
+++ b/Source/Core/Celbridge.Foundation/Dialog/IDialogService.cs
@@ -21,6 +21,12 @@ public enum DialogKind
 public interface IDialogService
 {
     /// <summary>
+    /// True while a modal dialog is on screen. The progress dialog is not counted, because it is raised
+    /// by the commands that are running rather than shown in place of them.
+    /// </summary>
+    bool IsDialogOpen { get; }
+
+    /// <summary>
     /// Display an Alert Dialog with configurable title and message text.
     /// </summary>
     Task ShowAlertDialogAsync(string titleText, string messageText);

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSMainMenu.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSMainMenu.cs
@@ -1,4 +1,5 @@
 using Celbridge.Commands;
+using Celbridge.Dialog;
 using Celbridge.Documents;
 using Celbridge.Explorer;
 using Celbridge.Settings;
@@ -250,6 +251,15 @@ internal static class MacOSMainMenu
     {
         // The standard Edit verbs and Full Screen are responder-chain Selector items (see Install), so
         // AppKit handles their state. This only covers the Command items below.
+
+        // An in-window dialog covers the hamburger menu but leaves the menu bar live, so every command
+        // here stays pickable while one is open. Grey the whole bar out for the dialog's lifetime,
+        // leaving Quit alone. AppKit re-asks on each open, so this needs no invalidation.
+        if (tag != TagQuit &&
+            ServiceLocator.AcquireService<IDialogService>().IsDialogOpen)
+        {
+            return MacMenuItemState.Disabled;
+        }
 
         // Reload and Close act on the open project, so they are enabled only while a workspace is loaded.
         // Every other project command is always available. Mirrors the hamburger menu's gating.

--- a/Source/Core/Celbridge.UserInterface/Services/Dialogs/DialogService.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/Dialogs/DialogService.cs
@@ -22,9 +22,8 @@ public class DialogService : IDialogService
     private bool _suppressProgressDialog;
     private List<IProgressDialogToken> _progressDialogTokens = [];
 
-    // Only one dialog can be on screen at a time, and the settings dialog stays up until the user closes
-    // it. The macOS menu bar stays live while it is open, so the Settings item can be picked again.
-    private bool _isSettingsDialogOpen;
+    // Read by the command loop, which does not run on the UI thread that writes it.
+    private volatile bool _isDialogOpen;
 
     public DialogService(
         ILogger<DialogService> logger,
@@ -43,8 +42,16 @@ public class DialogService : IDialogService
         _messengerService.Register<WorkspaceUnloadedMessage>(this, OnWorkspaceUnloaded);
     }
 
+    public bool IsDialogOpen => _isDialogOpen;
+
     public async Task ShowAlertDialogAsync(string titleText, string messageText)
     {
+        if (IsDialogOpen)
+        {
+            RefuseSecondDialog();
+            return;
+        }
+
         var dialog = _dialogFactory.CreateAlertDialog(titleText, messageText);
         _answerScheduler.OnDialogShown(DialogKind.Alert);
         await ShowDialogAsync(async () =>
@@ -56,6 +63,11 @@ public class DialogService : IDialogService
 
     public async Task<Result<bool>> ShowConfirmationDialogAsync(string titleText, string messageText, ConfirmationDialogOptions? options = null)
     {
+        if (IsDialogOpen)
+        {
+            return RefuseSecondDialog();
+        }
+
         var dialog = _dialogFactory.CreateConfirmationDialog(titleText, messageText, options);
         _answerScheduler.OnDialogShown(DialogKind.Confirmation);
         var showResult = await ShowDialogAsync(dialog.ShowDialogAsync);
@@ -77,13 +89,13 @@ public class DialogService : IDialogService
 
     public async Task ShowSettingsDialogAsync()
     {
-        if (_isSettingsDialogOpen)
+        if (IsDialogOpen)
         {
+            RefuseSecondDialog();
             return;
         }
 
         var dialog = _dialogFactory.CreateSettingsDialog();
-        _isSettingsDialogOpen = true;
 
         try
         {
@@ -98,10 +110,17 @@ public class DialogService : IDialogService
             // Callers start this without awaiting it, so a failure here has nowhere else to surface.
             _logger.LogError(exception, "Failed to show the settings dialog");
         }
-        finally
-        {
-            _isSettingsDialogOpen = false;
-        }
+    }
+
+    // Logs and fails a request to show a dialog while another one is on screen. The command queue and the
+    // macOS menu bar are both held while a dialog is open, so this should be unreachable. It is the
+    // backstop that turns whatever slips through into a diagnosable failure rather than a ContentDialog
+    // throw.
+    private Result.FailureResult RefuseSecondDialog([CallerMemberName] string dialogName = "")
+    {
+        _logger.LogError("Cannot show dialog '{DialogName}' because another dialog is already open", dialogName);
+
+        return Result.Fail($"Cannot show dialog '{dialogName}' because another dialog is already open.");
     }
 
     private void ReleaseProgressDialog(IProgressDialogToken token)
@@ -122,6 +141,7 @@ public class DialogService : IDialogService
 
     private async Task<T> ShowDialogAsync<T>(Func<Task<T>> showDialog, [CallerMemberName] string dialogName = "")
     {
+        _isDialogOpen = true;
         SetProgressDialogSuppressed(true);
         using var occlusionMonitorScope = MacOSModalOcclusionMonitor.BeginDialogScope(dialogName);
 
@@ -135,6 +155,9 @@ public class DialogService : IDialogService
         }
         finally
         {
+            // Cleared first so the command queue starts draining as the dialog comes down.
+            _isDialogOpen = false;
+
             _messengerService.Send(new ModalDialogClosedMessage());
 
             SetProgressDialogSuppressed(false);
@@ -188,12 +211,22 @@ public class DialogService : IDialogService
 
     public async Task<Result<NewProjectConfig>> ShowNewProjectDialogAsync()
     {
+        if (IsDialogOpen)
+        {
+            return RefuseSecondDialog();
+        }
+
         var dialog = _dialogFactory.CreateNewProjectDialog();
         return await ShowDialogAsync(dialog.ShowDialogAsync);
     }
 
     public async Task<Result<string>> ShowInputTextDialogAsync(string titleText, string messageText, string defaultText, Range selectionRange, IValidator validator, string? submitButtonKey = null)
     {
+        if (IsDialogOpen)
+        {
+            return RefuseSecondDialog();
+        }
+
         var dialog = _dialogFactory.CreateInputTextDialog(titleText, messageText, defaultText, selectionRange, validator, submitButtonKey);
         _answerScheduler.OnDialogShown(DialogKind.InputText);
         return await ShowDialogAsync(dialog.ShowDialogAsync);
@@ -201,6 +234,11 @@ public class DialogService : IDialogService
 
     public async Task<Result<string>> ShowSecretInputDialogAsync(string titleText, string headerText, string? submitButtonKey = null)
     {
+        if (IsDialogOpen)
+        {
+            return RefuseSecondDialog();
+        }
+
         var dialog = _dialogFactory.CreateSecretInputDialog(titleText, headerText, submitButtonKey);
         _answerScheduler.OnDialogShown(DialogKind.SecretInput);
         return await ShowDialogAsync(dialog.ShowDialogAsync);
@@ -208,12 +246,22 @@ public class DialogService : IDialogService
 
     public async Task<Result<NewFileConfig>> ShowNewFileDialogAsync(string defaultFileName, Range selectionRange, IValidator validator)
     {
+        if (IsDialogOpen)
+        {
+            return RefuseSecondDialog();
+        }
+
         var dialog = _dialogFactory.CreateNewFileDialog(defaultFileName, selectionRange, validator);
         return await ShowDialogAsync(dialog.ShowDialogAsync);
     }
 
     public async Task<Result<ResourceKey>> ShowResourcePickerDialogAsync(IReadOnlyList<string> extensions, string? title = null, bool showPreview = false)
     {
+        if (IsDialogOpen)
+        {
+            return RefuseSecondDialog();
+        }
+
         if (!_workspaceWrapper.IsWorkspaceLoaded)
         {
             return Result<ResourceKey>.Fail("Cannot show resource picker: no project is currently loaded.");
@@ -226,6 +274,11 @@ public class DialogService : IDialogService
 
     public async Task<Result<ChoiceDialogResult>> ShowChoiceDialogAsync(string titleText, string messageText, IReadOnlyList<string> options, int defaultIndex = 0, ChoiceDialogCheckbox? checkbox = null, string? primaryButtonText = null, string? secondaryButtonText = null)
     {
+        if (IsDialogOpen)
+        {
+            return RefuseSecondDialog();
+        }
+
         var dialog = _dialogFactory.CreateChoiceDialog(titleText, messageText, options, defaultIndex, checkbox, primaryButtonText, secondaryButtonText);
         return await ShowDialogAsync(dialog.ShowDialogAsync);
     }

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Controls/PrivacySettingsViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Controls/PrivacySettingsViewModel.cs
@@ -91,7 +91,9 @@ public partial class PrivacySettingsViewModel : ObservableObject
         IsClearing = true;
         ShowStatus(StatusSeverity.Informational, _stringLocalizer.GetString("Settings_Privacy_Clearing"));
 
-        var clearResult = await _commandService.ExecuteAsync<IClearBrowsingDataCommand>();
+        // The settings dialog holds the command queue while it is open, so an enqueued command would
+        // never run and this await would never return.
+        var clearResult = await _commandService.ExecuteImmediate<IClearBrowsingDataCommand>();
 
         IsClearing = false;
 

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Dialogs/SettingsDialogViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Dialogs/SettingsDialogViewModel.cs
@@ -1,4 +1,5 @@
 using Celbridge.Commands;
+using Celbridge.Logging;
 using Celbridge.Settings;
 
 namespace Celbridge.UserInterface.ViewModels.Dialogs;
@@ -21,6 +22,7 @@ public sealed class ThemeOption
 
 public partial class SettingsDialogViewModel : ObservableObject
 {
+    private readonly ILogger<SettingsDialogViewModel> _logger;
     private readonly ISettingsService _settingsService;
     private readonly IStringLocalizer _stringLocalizer;
     private readonly ICommandService _commandService;
@@ -34,11 +36,13 @@ public partial class SettingsDialogViewModel : ObservableObject
     private bool _isReflectingStoredTheme;
 
     public SettingsDialogViewModel(
+        ILogger<SettingsDialogViewModel> logger,
         ISettingsService settingsService,
         IStringLocalizer stringLocalizer,
         ICommandService commandService,
         IMessengerService messengerService)
     {
+        _logger = logger;
         _settingsService = settingsService;
         _stringLocalizer = stringLocalizer;
         _commandService = commandService;
@@ -96,10 +100,22 @@ public partial class SettingsDialogViewModel : ObservableObject
             return;
         }
 
-        _commandService.Execute<ISetThemeCommand>(command =>
+        _ = ApplyThemeAsync(value.Theme);
+    }
+
+    // This dialog holds the command queue while it is open, so the theme is applied off the queue.
+    // Enqueuing it would leave the choice unapplied until the dialog closed.
+    private async Task ApplyThemeAsync(ApplicationColorTheme theme)
+    {
+        var setThemeResult = await _commandService.ExecuteImmediate<ISetThemeCommand>(command =>
         {
-            command.Theme = value.Theme;
+            command.Theme = theme;
         });
+
+        if (setThemeResult.IsFailure)
+        {
+            _logger.LogError(setThemeResult, "Failed to set the application theme");
+        }
     }
 
     private List<ThemeOption> BuildThemeOptions()

--- a/Source/Tests/Commands/CommandTests.cs
+++ b/Source/Tests/Commands/CommandTests.cs
@@ -1,5 +1,6 @@
 using Celbridge.Commands.Services;
 using Celbridge.Commands;
+using Celbridge.Dialog;
 using Celbridge.Logging.Services;
 using Celbridge.Messaging.Services;
 using Celbridge.Messaging;
@@ -69,6 +70,8 @@ public class CommandTests
 {
     private ServiceProvider? _serviceProvider;
     private ICommandService? _commandService;
+    private ISettingsService? _settingsService;
+    private IDialogService? _dialogService;
 
     [SetUp]
     public void Setup()
@@ -83,9 +86,14 @@ public class CommandTests
 
         // The command loop flushes application settings each tick; a substitute is
         // enough since these tests do not exercise settings persistence.
-        var settingsService = Substitute.For<ISettingsService>();
-        settingsService.FlushAsync().Returns(Task.FromResult(Result.Ok()));
-        services.AddSingleton(settingsService);
+        _settingsService = Substitute.For<ISettingsService>();
+        _settingsService.FlushAsync().Returns(Task.FromResult(Result.Ok()));
+        services.AddSingleton(_settingsService);
+
+        // The command loop holds its dequeue while a dialog is open.
+        _dialogService = Substitute.For<IDialogService>();
+        _dialogService.IsDialogOpen.Returns(false);
+        services.AddSingleton(_dialogService);
         services.AddTransient<TestCommand>();
         services.AddTransient<ThrowingTestCommand>();
         services.AddTransient<SuppressLogTestCommand>();
@@ -235,5 +243,78 @@ public class CommandTests
         Guard.IsNotNull(capturedCommand);
         capturedCommand.ExecuteComplete.Should().BeTrue();
         capturedCommand.CommandFlags.HasFlag(CommandFlags.SuppressCommandLog).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Execute_QueuedCommandWaitsUntilTheDialogCloses()
+    {
+        Guard.IsNotNull(_commandService);
+        Guard.IsNotNull(_dialogService);
+
+        _dialogService.IsDialogOpen.Returns(true);
+
+        TestCommand? queuedCommand = null;
+        _commandService.Execute<TestCommand>(command =>
+        {
+            queuedCommand = command;
+        });
+        Guard.IsNotNull(queuedCommand);
+
+        // Long enough for the loop to tick many times over the held queue.
+        await Task.Delay(300);
+
+        queuedCommand.ExecuteComplete.Should().BeFalse("a queued command must not run while a dialog is open");
+
+        _dialogService.IsDialogOpen.Returns(false);
+
+        for (int i = 0; i < 20; i++)
+        {
+            if (queuedCommand.ExecuteComplete)
+            {
+                break;
+            }
+            await Task.Delay(50);
+        }
+
+        queuedCommand.ExecuteComplete.Should().BeTrue("closing the dialog must release the queue");
+    }
+
+    [Test]
+    public async Task ExecuteImmediate_RunsWhileADialogIsOpen()
+    {
+        // The settings dialog runs its own commands this way. Enqueuing them under the gate would
+        // leave them pending until the dialog closed, and deadlock the ones that are awaited.
+        Guard.IsNotNull(_commandService);
+        Guard.IsNotNull(_dialogService);
+
+        _dialogService.IsDialogOpen.Returns(true);
+
+        TestCommand? immediateCommand = null;
+        var executionTask = _commandService.ExecuteImmediate<TestCommand>(command =>
+        {
+            immediateCommand = command;
+        });
+
+        var completedTask = await Task.WhenAny(executionTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        completedTask.Should().BeSameAs(executionTask, "ExecuteImmediate must not wait on the queue gate");
+
+        Guard.IsNotNull(immediateCommand);
+        immediateCommand.ExecuteComplete.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task UpdateApplication_KeepsTickingWhileADialogIsOpen()
+    {
+        // Only the dequeue is gated. The application update carries on so deferred settings writes and
+        // document auto-saves still reach disk while the dialog is up.
+        Guard.IsNotNull(_dialogService);
+        Guard.IsNotNull(_settingsService);
+
+        _dialogService.IsDialogOpen.Returns(true);
+        _settingsService.ClearReceivedCalls();
+
+        await Task.Delay(300);
+
+        await _settingsService.ReceivedWithAnyArgs().FlushAsync();
     }
 }

--- a/Source/Tests/UserInterface/PrivacySettingsViewModelTests.cs
+++ b/Source/Tests/UserInterface/PrivacySettingsViewModelTests.cs
@@ -54,7 +54,7 @@ public class PrivacySettingsViewModelTests
 
         viewModel.IsConfirmingClear.Should().BeTrue();
         viewModel.IsClearButtonVisible.Should().BeFalse();
-        _commandService.DidNotReceive().ExecuteAsync<IClearBrowsingDataCommand>(
+        _commandService.DidNotReceive().ExecuteImmediate<IClearBrowsingDataCommand>(
             Arg.Any<Action<IClearBrowsingDataCommand>?>(), Arg.Any<string>(), Arg.Any<int>());
     }
 
@@ -68,7 +68,7 @@ public class PrivacySettingsViewModelTests
 
         viewModel.IsConfirmingClear.Should().BeFalse();
 
-        await _commandService.Received(1).ExecuteAsync<IClearBrowsingDataCommand>(
+        await _commandService.Received(1).ExecuteImmediate<IClearBrowsingDataCommand>(
             Arg.Any<Action<IClearBrowsingDataCommand>?>(), Arg.Any<string>(), Arg.Any<int>());
         viewModel.StatusSeverity.Should().Be(StatusSeverity.Success);
         viewModel.StatusMessage.Should().Be("Settings_Privacy_Cleared");
@@ -85,7 +85,7 @@ public class PrivacySettingsViewModelTests
 
         viewModel.IsConfirmingClear.Should().BeFalse();
         viewModel.IsClearButtonVisible.Should().BeTrue();
-        _commandService.DidNotReceive().ExecuteAsync<IClearBrowsingDataCommand>(
+        _commandService.DidNotReceive().ExecuteImmediate<IClearBrowsingDataCommand>(
             Arg.Any<Action<IClearBrowsingDataCommand>?>(), Arg.Any<string>(), Arg.Any<int>());
         viewModel.IsStatusVisible.Should().BeFalse();
     }
@@ -118,7 +118,7 @@ public class PrivacySettingsViewModelTests
 
     private void StubClearResult(Result result)
     {
-        _commandService.ExecuteAsync<IClearBrowsingDataCommand>(
+        _commandService.ExecuteImmediate<IClearBrowsingDataCommand>(
                 Arg.Any<Action<IClearBrowsingDataCommand>?>(), Arg.Any<string>(), Arg.Any<int>())
             .Returns(Task.FromResult(result));
     }

--- a/Source/Tests/UserInterface/SettingsDialogViewModelTests.cs
+++ b/Source/Tests/UserInterface/SettingsDialogViewModelTests.cs
@@ -15,7 +15,8 @@ namespace Celbridge.Tests.UserInterface;
 /// <summary>
 /// Unit tests for the Settings dialog view model. The stored theme is read through the real SettingsService
 /// over an in-memory settings store fake. Selecting a theme dispatches ISetThemeCommand rather than writing
-/// the setting here, so that is asserted against a substitute command service. A real MessengerService
+/// the setting here, so that is asserted against a substitute command service. The dispatch goes through
+/// ExecuteImmediate because the dialog holds the command queue while it is open. A real MessengerService
 /// carries the theme-changed broadcast the dialog follows.
 /// </summary>
 [TestFixture]
@@ -44,6 +45,12 @@ public class SettingsDialogViewModelTests
             workspaceWrapper);
 
         _commandService = Substitute.For<ICommandService>();
+        _commandService.ExecuteImmediate<ISetThemeCommand>(
+                Arg.Any<Action<ISetThemeCommand>?>(),
+                Arg.Any<string>(),
+                Arg.Any<int>())
+            .Returns(Task.FromResult(Result.Ok()));
+
         _messengerService = new MessengerService();
 
         var stringLocalizer = Substitute.For<IStringLocalizer>();
@@ -51,6 +58,7 @@ public class SettingsDialogViewModelTests
             callInfo => new LocalizedString(callInfo.Arg<string>(), callInfo.Arg<string>()));
 
         _viewModel = new SettingsDialogViewModel(
+            new NullLogger<SettingsDialogViewModel>(),
             _settingsService,
             stringLocalizer,
             _commandService,
@@ -83,7 +91,7 @@ public class SettingsDialogViewModelTests
 
         _viewModel.SelectedTheme = darkOption;
 
-        _commandService.Received(1).Execute<ISetThemeCommand>(
+        _commandService.Received(1).ExecuteImmediate<ISetThemeCommand>(
             Arg.Is<Action<ISetThemeCommand>?>(configure => ConfiguresTheme(configure, ApplicationColorTheme.Dark)),
             Arg.Any<string>(),
             Arg.Any<int>());
@@ -94,7 +102,7 @@ public class SettingsDialogViewModelTests
     {
         // Reflecting the stored theme in the combo box must not run the changed handler; construction
         // happened in Setup, so no command should have been dispatched.
-        _commandService.DidNotReceive().Execute<ISetThemeCommand>(
+        _commandService.DidNotReceive().ExecuteImmediate<ISetThemeCommand>(
             Arg.Any<Action<ISetThemeCommand>?>(),
             Arg.Any<string>(),
             Arg.Any<int>());
@@ -114,7 +122,7 @@ public class SettingsDialogViewModelTests
 
         // Following the change must not dispatch a command of its own, which would loop back through the
         // theme service.
-        _commandService.DidNotReceive().Execute<ISetThemeCommand>(
+        _commandService.DidNotReceive().ExecuteImmediate<ISetThemeCommand>(
             Arg.Any<Action<ISetThemeCommand>?>(),
             Arg.Any<string>(),
             Arg.Any<int>());


### PR DESCRIPTION
Prevent dequeuing commands while a modal dialog is shown. Adds IDialogService.IsDialogOpen and plumbs IDialogService into CommandService so the dequeue is held when a dialog is open while the application update path continues to tick. DialogService now tracks a volatile _isDialogOpen flag, refuses second dialogs, and sets/clears the flag in ShowDialogAsync. Commands that must run while a dialog is shown use ExecuteImmediate (Settings and Privacy changes). macOS menu handling disables most menu items while a modal dialog is open. Tests updated and new tests added to cover the gating and ExecuteImmediate behavior.