### PR TITLE
Move project helpers to Celbridge.Projects

### DIFF
--- a/Source/Core/Celbridge.Projects/Helpers/JsonPointerToml.cs
+++ b/Source/Core/Celbridge.Projects/Helpers/JsonPointerToml.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using Tomlyn.Model;
 
-namespace Celbridge.Projects.Services;
+namespace Celbridge.Projects;
 
 /// <summary>
 /// Minimal JSON Pointer style reader over a Tomlyn table.

--- a/Source/Core/Celbridge.Projects/Helpers/PageManifestParser.cs
+++ b/Source/Core/Celbridge.Projects/Helpers/PageManifestParser.cs
@@ -2,7 +2,7 @@ using Celbridge.Utilities;
 using Tomlyn;
 using Tomlyn.Model;
 
-namespace Celbridge.Projects.Services;
+namespace Celbridge.Projects;
 
 /// <summary>
 /// Reads a page manifest (pages.toml): the required [publish].path that names the served path of a page's

--- a/Source/Core/Celbridge.Projects/Helpers/ProjectConfigParser.cs
+++ b/Source/Core/Celbridge.Projects/Helpers/ProjectConfigParser.cs
@@ -3,7 +3,7 @@ using Tomlyn;
 using Tomlyn.Model;
 using Tomlyn.Parsing;
 
-namespace Celbridge.Projects.Services;
+namespace Celbridge.Projects;
 
 /// <summary>
 /// Static utility class for parsing Celbridge project configuration files (v2 schema).

--- a/Source/Core/Celbridge.Projects/Helpers/ProjectConfigReconciler.cs
+++ b/Source/Core/Celbridge.Projects/Helpers/ProjectConfigReconciler.cs
@@ -1,6 +1,6 @@
 using Celbridge.Packages;
 
-namespace Celbridge.Projects.Services;
+namespace Celbridge.Projects;
 
 /// <summary>
 /// Reconciles a parsed .celbridge against the packages discovered on disk. Required and recommended

--- a/Source/Core/Celbridge.Projects/Helpers/ProjectConfigSerializer.cs
+++ b/Source/Core/Celbridge.Projects/Helpers/ProjectConfigSerializer.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Text;
 
-namespace Celbridge.Projects.Services;
+namespace Celbridge.Projects;
 
 /// <summary>
 /// Serializes a project config to canonical, deterministic TOML. The same resolved model always

--- a/Source/Core/Celbridge.Projects/Helpers/ProjectDataFolder.cs
+++ b/Source/Core/Celbridge.Projects/Helpers/ProjectDataFolder.cs
@@ -1,4 +1,4 @@
-namespace Celbridge.Projects.Services;
+namespace Celbridge.Projects;
 
 /// <summary>
 /// Resolves and validates the project data folder: the folder inside .celbridge/ that a project's local

--- a/Source/Core/Celbridge.Projects/Helpers/ProjectDataFolder.cs
+++ b/Source/Core/Celbridge.Projects/Helpers/ProjectDataFolder.cs
@@ -27,6 +27,17 @@ public static class ProjectDataFolder
             return false;
         }
 
+        // Control characters for the same reason: Windows carries them in the invalid-character set
+        // and Linux does not, and this name is read from a committed file that has to resolve the
+        // same way wherever the project is opened.
+        foreach (var character in folderName)
+        {
+            if (char.IsControl(character))
+            {
+                return false;
+            }
+        }
+
         if (folderName == "."
             || folderName == "..")
         {

--- a/Source/Tests/Packages/FileTypeProviderTests.cs
+++ b/Source/Tests/Packages/FileTypeProviderTests.cs
@@ -3,7 +3,6 @@ using Celbridge.Packages;
 using Celbridge.UserInterface;
 using Celbridge.Messaging;
 using Celbridge.Projects;
-using Celbridge.Projects.Services;
 using Celbridge.Resources;
 using Celbridge.Resources.Services;
 using Celbridge.Settings;

--- a/Source/Tests/Packages/PackageRegistryTests.cs
+++ b/Source/Tests/Packages/PackageRegistryTests.cs
@@ -4,7 +4,6 @@ using Celbridge.Packages;
 using Celbridge.UserInterface;
 using Celbridge.UserInterface.Services;
 using Celbridge.Projects;
-using Celbridge.Projects.Services;
 using Celbridge.Resources;
 using Celbridge.Resources.Services;
 using Celbridge.Settings;

--- a/Source/Tests/Projects/PageManifestParserTests.cs
+++ b/Source/Tests/Projects/PageManifestParserTests.cs
@@ -1,4 +1,4 @@
-using Celbridge.Projects.Services;
+using Celbridge.Projects;
 
 namespace Celbridge.Tests.Projects;
 

--- a/Source/Tests/Projects/ProjectConfigParserTests.cs
+++ b/Source/Tests/Projects/ProjectConfigParserTests.cs
@@ -1,5 +1,4 @@
 using Celbridge.Projects;
-using Celbridge.Projects.Services;
 using Celbridge.Tests.FileSystem;
 
 namespace Celbridge.Tests.Projects;

--- a/Source/Tests/Projects/ProjectConfigReconcilerTests.cs
+++ b/Source/Tests/Projects/ProjectConfigReconcilerTests.cs
@@ -1,6 +1,5 @@
 using Celbridge.Packages;
 using Celbridge.Projects;
-using Celbridge.Projects.Services;
 
 namespace Celbridge.Tests.Projects;
 

--- a/Source/Tests/Projects/ProjectDataFolderTests.cs
+++ b/Source/Tests/Projects/ProjectDataFolderTests.cs
@@ -27,9 +27,20 @@ public class ProjectDataFolderTests
     [TestCase("..")]
     [TestCase("../escape")]
     [TestCase("nested/folder")]
-    [TestCase("nested\folder")]
+    [TestCase(@"nested\folder")]
     public void IsValidFolderName_AnythingThatIsNotASingleSegment_IsRejected(string folderName)
     {
+        ProjectDataFolder.IsValidFolderName(folderName).Should().BeFalse();
+    }
+
+    [Test]
+    public void IsValidFolderName_AControlCharacter_IsRejected()
+    {
+        // Built from the code point rather than an escape: a backslash-f in a non-verbatim string is
+        // a form feed, which is what made the separator case above silently test something else.
+        // Windows rejects control characters through the invalid-file-name set and Linux does not.
+        var folderName = "data" + (char)12 + "folder";
+
         ProjectDataFolder.IsValidFolderName(folderName).Should().BeFalse();
     }
 

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/FeatureFlagsSectionViewModel.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/FeatureFlagsSectionViewModel.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
 using Celbridge.Projects;
-using Celbridge.Projects.Services;
 using Celbridge.Settings;
 using Microsoft.Extensions.Localization;
 

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/FileEditorsSectionViewModel.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/FileEditorsSectionViewModel.cs
@@ -2,7 +2,6 @@ using System.Collections.ObjectModel;
 using Celbridge.Logging;
 using Celbridge.Packages;
 using Celbridge.Projects;
-using Celbridge.Projects.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.Extensions.Localization;
 

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/InformationSectionViewModel.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/InformationSectionViewModel.cs
@@ -1,5 +1,4 @@
 using Celbridge.Projects;
-using Celbridge.Projects.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Celbridge.ProjectSettings.ViewModels;

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/PackagesSectionViewModel.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/PackagesSectionViewModel.cs
@@ -5,7 +5,6 @@ using Celbridge.Documents;
 using Celbridge.Logging;
 using Celbridge.Packages;
 using Celbridge.Projects;
-using Celbridge.Projects.Services;
 using Celbridge.UserInterface.Helpers;
 
 namespace Celbridge.ProjectSettings.ViewModels;

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/PagesSectionViewModel.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/PagesSectionViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
 using Celbridge.Packages;
-using Celbridge.Projects.Services;
+using Celbridge.Projects;
 using Celbridge.Resources;
 
 namespace Celbridge.ProjectSettings.ViewModels;


### PR DESCRIPTION
This commit moves the project parsing, reconciliation, serialization, and manifest helper types out of Celbridge.Projects.Services into the root Celbridge.Projects namespace and the Helpers folder. It updates the affected tests and project settings view models to use the new imports, keeping the project model utilities organized as shared helpers instead of service-layer types.