### PR TITLE
Refine ProjectSwitcher layout and limit recent projects to five

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -351,8 +351,8 @@
   <data name="ProjectHealth_Healthy" xml:space="preserve">
     <value>Loaded with no issues</value>
   </data>
-  <data name="TitleBar_ViewLoadReport" xml:space="preserve">
-    <value>View Load Report</value>
+  <data name="TitleBar_ProjectLoadReport" xml:space="preserve">
+    <value>Project Load Report</value>
   </data>
   <data name="ProjectHealth_Warnings_One" xml:space="preserve">
     <value>Loaded with 1 warning</value>

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ProjectSwitcher.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ProjectSwitcher.xaml
@@ -25,12 +25,30 @@
           VerticalContentAlignment="Stretch"
           Visibility="{x:Bind ViewModel.IsWorkspaceLoaded, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
 
-    <!-- Attached to the whole button so it drops down aligned to the button's left edge. Every item after
-         the recent projects header is rebuilt each time the menu opens. -->
+    <!-- Attached to the whole button so it drops down aligned to the button's left edge. The projects the
+         menu switches to lead it, and the less frequently used items follow. The recent project rows are the
+         only items built at runtime, inserted below the recent projects header each time the menu opens. -->
     <FlyoutBase.AttachedFlyout>
       <MenuFlyout x:Name="ProjectMenuFlyout"
                   Placement="BottomEdgeAlignedLeft">
 
+        <controls:MenuSectionHeaderItem x:Name="CurrentProjectHeader"
+                                        Text="{x:Bind CurrentProjectHeaderString}"
+                                        Style="{StaticResource MenuSectionHeaderItemStyle}"/>
+
+        <controls:ProjectMenuItem x:Name="CurrentProjectItem"
+                                  Style="{StaticResource ProjectMenuItemStyle}"
+                                  Click="ReturnToCurrentProject"/>
+
+        <MenuFlyoutSeparator x:Name="CurrentProjectSeparator"/>
+
+        <controls:MenuSectionHeaderItem x:Name="RecentProjectsHeader"
+                                        Text="{x:Bind RecentProjectsHeaderString}"
+                                        Style="{StaticResource MenuSectionHeaderItemStyle}"/>
+
+        <MenuFlyoutSeparator/>
+
+        <!-- The same four commands the File menu carries, in the same order, so the two surfaces read alike. -->
         <MenuFlyoutItem Text="{x:Bind NewProjectString}"
                         Click="NewProject">
           <MenuFlyoutItem.Icon>
@@ -59,29 +77,17 @@
           </MenuFlyoutItem.Icon>
         </MenuFlyoutItem>
 
-        <MenuFlyoutSeparator x:Name="CurrentProjectSeparator"/>
+        <MenuFlyoutSeparator x:Name="ProjectLoadReportSeparator"/>
 
-        <controls:MenuSectionHeaderItem x:Name="CurrentProjectHeader"
-                                        Text="{x:Bind CurrentProjectHeaderString}"
-                                        Style="{StaticResource MenuSectionHeaderItemStyle}"/>
-
-        <controls:ProjectMenuItem x:Name="CurrentProjectItem"
-                                  Style="{StaticResource ProjectMenuItemStyle}"
-                                  Click="ReturnToCurrentProject"/>
-
-        <!-- The deliberate route back to the load report, in every state including a healthy one. Named
-             for what it does: the health itself is stated by the button beside the switcher. -->
-        <MenuFlyoutItem x:Name="ProjectHealthItem"
-                        Click="OpenProjectHealthReport">
+        <!-- The only route to the report after a clean load: the health button beside the switcher stays
+             collapsed, and the logs: root the report is written to is not enumerated in the Explorer. -->
+        <MenuFlyoutItem x:Name="ProjectLoadReportItem"
+                        Text="{x:Bind ProjectLoadReportString}"
+                        Click="OpenProjectLoadReport">
           <MenuFlyoutItem.Icon>
-            <controls:Icon x:Name="ProjectHealthIcon"/>
+            <controls:Icon Symbol="Report"/>
           </MenuFlyoutItem.Icon>
         </MenuFlyoutItem>
-
-        <MenuFlyoutSeparator/>
-
-        <controls:MenuSectionHeaderItem Text="{x:Bind RecentProjectsHeaderString}"
-                                        Style="{StaticResource MenuSectionHeaderItemStyle}"/>
       </MenuFlyout>
     </FlyoutBase.AttachedFlyout>
 

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ProjectSwitcher.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ProjectSwitcher.xaml.cs
@@ -14,9 +14,9 @@ public sealed partial class ProjectSwitcher : UserControl
     private readonly IMessengerService _messengerService;
     private readonly IStringLocalizer _stringLocalizer;
 
-    // The items declared in XAML: the project actions, the current-project section and the recent-projects
-    // header. They are kept across rebuilds, and every item added after them is rebuilt on each open.
-    private readonly int _staticFlyoutItemCount;
+    // The recent project rows built on the last open, kept so they can be removed before the next one.
+    // Everything else in the menu is declared in XAML and stays in place.
+    private readonly List<MenuFlyoutItemBase> _recentProjectItems = new();
 
     private readonly IProjectHealthService _projectHealthService;
 
@@ -28,6 +28,7 @@ public sealed partial class ProjectSwitcher : UserControl
     private string OpenProjectString => _stringLocalizer.GetString("MainMenu_OpenProject");
     private string ReloadProjectString => _stringLocalizer.GetString("MainMenu_ReloadProject");
     private string CloseProjectString => _stringLocalizer.GetString("MainMenu_CloseProject");
+    private string ProjectLoadReportString => _stringLocalizer.GetString("TitleBar_ProjectLoadReport");
     private string CurrentProjectHeaderString => _stringLocalizer.GetString("TitleBar_CurrentProjectHeader");
     private string RecentProjectsHeaderString => _stringLocalizer.GetString("TitleBar_RecentProjectsHeader");
 
@@ -40,8 +41,6 @@ public sealed partial class ProjectSwitcher : UserControl
         ViewModel = ServiceLocator.AcquireService<ProjectSwitcherViewModel>();
 
         this.InitializeComponent();
-
-        _staticFlyoutItemCount = ProjectMenuFlyout.Items.Count;
 
         this.DataContext = ViewModel;
 
@@ -79,10 +78,11 @@ public sealed partial class ProjectSwitcher : UserControl
 
     private void OnProjectMenuFlyoutOpening(object? sender, object e)
     {
-        while (ProjectMenuFlyout.Items.Count > _staticFlyoutItemCount)
+        foreach (var recentProjectItem in _recentProjectItems)
         {
-            ProjectMenuFlyout.Items.RemoveAt(_staticFlyoutItemCount);
+            ProjectMenuFlyout.Items.Remove(recentProjectItem);
         }
+        _recentProjectItems.Clear();
 
         var viewModel = _applicationMenuViewModel;
         if (viewModel is null)
@@ -97,7 +97,8 @@ public sealed partial class ProjectSwitcher : UserControl
             CurrentProjectHeader.Visibility = Visibility.Collapsed;
             CurrentProjectItem.Visibility = Visibility.Collapsed;
             CurrentProjectSeparator.Visibility = Visibility.Collapsed;
-            ProjectHealthItem.Visibility = Visibility.Collapsed;
+            ProjectLoadReportSeparator.Visibility = Visibility.Collapsed;
+            ProjectLoadReportItem.Visibility = Visibility.Collapsed;
         }
         else
         {
@@ -109,7 +110,7 @@ public sealed partial class ProjectSwitcher : UserControl
             CurrentProjectItem.Visibility = Visibility.Visible;
             CurrentProjectSeparator.Visibility = Visibility.Visible;
 
-            UpdateProjectHealthItem();
+            UpdateProjectLoadReportItem();
         }
 
         var recentProjects = viewModel.GetRecentProjects();
@@ -120,16 +121,26 @@ public sealed partial class ProjectSwitcher : UserControl
                 Text = _stringLocalizer.GetString("Menu_NoRecentProjects"),
                 IsEnabled = false
             };
-            ProjectMenuFlyout.Items.Add(emptyItem);
-            return;
+            _recentProjectItems.Add(emptyItem);
+        }
+        else
+        {
+            RecentProjectsMenu.Populate(
+                _recentProjectItems,
+                recentProjects,
+                OpenRecentProjectFromSwitcher,
+                _stringLocalizer.GetString("MainMenu_ClearRecentProjects"),
+                viewModel.ClearRecentProjects);
         }
 
-        RecentProjectsMenu.Populate(
-            ProjectMenuFlyout.Items,
-            recentProjects,
-            OpenRecentProjectFromSwitcher,
-            _stringLocalizer.GetString("MainMenu_ClearRecentProjects"),
-            viewModel.ClearRecentProjects);
+        // The rows belong to the recent projects header, so they go in below it rather than at the end of the
+        // menu, where the project commands sit.
+        var insertIndex = ProjectMenuFlyout.Items.IndexOf(RecentProjectsHeader) + 1;
+        foreach (var recentProjectItem in _recentProjectItems)
+        {
+            ProjectMenuFlyout.Items.Insert(insertIndex, recentProjectItem);
+            insertIndex++;
+        }
     }
 
     private void NewProject(object sender, RoutedEventArgs e)
@@ -177,23 +188,23 @@ public sealed partial class ProjectSwitcher : UserControl
         commandService.Execute<IActivateDocumentCommand>(command => command.FileResource = activeDocument);
     }
 
-    private void UpdateProjectHealthItem()
+    private void UpdateProjectLoadReportItem()
     {
         var health = _projectHealthService.CurrentHealth;
         if (health is null)
         {
-            // Nothing was recorded for this load, so there is no report to open.
-            ProjectHealthItem.Visibility = Visibility.Collapsed;
+            // Nothing was recorded for this load, so there is no report to open. The separator goes with the
+            // item, which is last in the menu and would otherwise leave it dangling.
+            ProjectLoadReportSeparator.Visibility = Visibility.Collapsed;
+            ProjectLoadReportItem.Visibility = Visibility.Collapsed;
             return;
         }
 
-        ProjectHealthItem.Text = _stringLocalizer.GetString("TitleBar_ViewLoadReport");
-        ProjectHealthIcon.Symbol = IconSymbol.Report;
-
-        ProjectHealthItem.Visibility = Visibility.Visible;
+        ProjectLoadReportSeparator.Visibility = Visibility.Visible;
+        ProjectLoadReportItem.Visibility = Visibility.Visible;
     }
 
-    private void OpenProjectHealthReport(object sender, RoutedEventArgs e)
+    private void OpenProjectLoadReport(object sender, RoutedEventArgs e)
     {
         var reportResource = _projectHealthService.CurrentHealth?.Resource ?? ResourceKey.Empty;
         if (reportResource.IsEmpty)

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ProjectSwitcher.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ProjectSwitcher.xaml.cs
@@ -11,6 +11,11 @@ namespace Celbridge.UserInterface.Views;
 
 public sealed partial class ProjectSwitcher : UserControl
 {
+    // The switcher is the fast path to a recent project, so it shows only the most recent few. The complete
+    // list is in the File menu's Open Recent submenu. Capping the rows fixes the menu's height, so the
+    // commands below them stay on screen however many projects the history holds.
+    private const int MaxRecentProjectsShown = 5;
+
     private readonly IMessengerService _messengerService;
     private readonly IStringLocalizer _stringLocalizer;
 
@@ -125,9 +130,11 @@ public sealed partial class ProjectSwitcher : UserControl
         }
         else
         {
+            var shownProjects = recentProjects.Take(MaxRecentProjectsShown).ToList();
+
             RecentProjectsMenu.Populate(
                 _recentProjectItems,
-                recentProjects,
+                shownProjects,
                 OpenRecentProjectFromSwitcher,
                 _stringLocalizer.GetString("MainMenu_ClearRecentProjects"),
                 viewModel.ClearRecentProjects);


### PR DESCRIPTION
This pull request refactors and improves the `ProjectSwitcher` control, focusing on clarifying menu structure, improving the handling of recent projects, and renaming the "Project Health" menu item and related code to "Project Load Report" for greater clarity and consistency.

**Menu structure and UI improvements:**

* The order and grouping of items in the project switcher menu have been revised: the current project and recent projects are now clearly separated, with recent projects capped at five entries and inserted directly under their header for a more predictable menu height and layout. [[1]](diffhunk://#diff-639048062812c3cdd204c271cc8b6c5aa3811139a68bb2cdc4a7e26ccb167ff6L28-R51) [[2]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201R14-R24) [[3]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201L123-R152)
* The code now maintains a list of dynamically generated recent project menu items (`_recentProjectItems`), which are rebuilt each time the menu opens, improving menu state management. [[1]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201R14-R24) [[2]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201L82-R90) [[3]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201L123-R152)

**Renaming and consistency:**

* The "Project Health" menu item and related strings have been renamed to "Project Load Report" throughout the UI and codebase, including resource strings, menu item names, and handler methods, for clearer user communication. [[1]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40L354-R355) [[2]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201R36) [[3]](diffhunk://#diff-639048062812c3cdd204c271cc8b6c5aa3811139a68bb2cdc4a7e26ccb167ff6L62-L84) [[4]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201L100-R106) [[5]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201L112-R118) [[6]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201L180-R214)

**Code cleanup and simplification:**

* Removed the `_staticFlyoutItemCount` tracking in favor of directly managing recent project items, simplifying menu item lifecycle management. [[1]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201L44-L45) [[2]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201L82-R90)
* Updated the logic for showing/hiding the "Project Load Report" menu item and its separator to ensure they only appear when a report is available, improving UI correctness. [[1]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201L100-R106) [[2]](diffhunk://#diff-291d6e03dea5e53169f6a87feed926facb1470cfe143755c794e86586d2a3201L180-R214)