### PR TITLE
Refactor Utility Rail and Panel Layout with State Improvements

### DIFF
--- a/.claude/skills/fix-branch-comments/SKILL.md
+++ b/.claude/skills/fix-branch-comments/SKILL.md
@@ -31,7 +31,7 @@ These rules need no judgement, so decide them in the shell rather than spending 
 ```bash
 WL=/tmp/comment-worklist.txt
 echo "== prose semicolons =="
-grep -nE '(///|//|#).*;[[:space:]]*$|(///|//|#).*[a-z]; [a-z]' "$WL"
+grep -nE '(///|//|#).*;[[:space:]]*$|(///|//|#).*[[:alnum:])"'"'"']; [[:alnum:]]' "$WL"
 echo "== banned doc constructs =="
 grep -nE '<remarks>|<c>|<list>|<item>|/// <param' "$WL"
 echo "== section markers =="

--- a/.claude/skills/fix-branch-comments/SKILL.md
+++ b/.claude/skills/fix-branch-comments/SKILL.md
@@ -1,72 +1,107 @@
 ---
 name: fix-branch-comments
-description: Review and fix code comments across every file modified on the current branch, enforcing the Celbridge comment conventions (full stops not semicolons, no <remarks>, no history / doc cross-refs / restated calls, terse inline comments, contract-only interface xmldoc). Use only when the user asks to "fix comments", "clean up comments", "review branch comments", or invokes /fix-branch-comments — do not offer it proactively.
+description: Review and fix the code comments this branch added or rewrote, enforcing the Celbridge comment conventions (full stops not semicolons, no <remarks>, no history / doc cross-refs / restated calls, terse inline comments, contract-only interface xmldoc). Use only when the user asks to "fix comments", "clean up comments", "review branch comments", or invokes /fix-branch-comments — do not offer it proactively.
 ---
 
 # Fix branch comments
 
-Comments drift from the conventions in CLAUDE.md as a branch is built, especially in files written or rewritten whole. Rather than policing every edit inline, this skill makes one pass over the branch: it reviews every comment in the files the branch touched and rewrites or removes the ones that break the rules, keeping any genuinely useful information by moving it to the right place.
+Comments drift from the conventions in CLAUDE.md as a branch is built. This skill makes one pass before the PR: it reviews the comments the branch wrote and rewrites or removes the ones that break the rules, keeping any genuinely useful information by moving it to the right place.
 
-Scope is **every comment in every file the branch modified**, not only the changed lines — a file the branch touches should leave this pass clean throughout. Files the branch did not modify are left alone.
+## Scope
 
-## Run the review in subagents, not the main context
+**Only comments the branch added or rewrote.** Not whole files, not comments the branch left alone. A file the branch barely touched contributes only the lines it touched.
 
-The review reads whole files, so doing it inline would pull the entire text of every touched file into the main conversation. Do not. The main agent only computes the file list and relays a terse summary; **all reading and editing happens in background subagents**, whose contexts are thrown away afterward.
+This is the difference between reading a few hundred comment lines and reading every line of every file the branch opened, and it also keeps the resulting diff inside the change under review.
 
-1. **Compute the file list (main agent — this is the only cheap part that stays here).** Committed, uncommitted, and new, relative to the base branch (`main` unless the user names another):
+## 1. Build the worklist
 
-   ```bash
-   BASE=$(git merge-base main HEAD)
-   { git diff --name-only "$BASE" HEAD; git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u
-   ```
+Main agent, shell only. The script is tested — run it, do not re-derive it inline:
 
-   Then **filter to hand-written text files**: keep `.cs`, `.py`, hand-authored `.js`/`.ts`, and any touched `.md`. Drop generated and vendored files, which never get hand-reviewed: anything under `obj/`, `bin/`, `node_modules/`, `/lib/`, `/min/`; `*.g.cs`, `*.designer.cs`; minified bundles (`*.min.js`, `*.map`); and lockfiles (`package-lock.json`). If the kept list is empty, report that and stop.
+```bash
+bash .claude/skills/fix-branch-comments/extract-comments.sh > /tmp/comment-worklist.txt
+wc -l < /tmp/comment-worklist.txt
+```
 
-2. **Fan out the review to background subagents, batched.** Split the kept files into batches of ~8 and launch one `general-purpose` subagent per batch (a single batch is fine for a small change set). Give each subagent: its file list, the **Conventions to enforce** section below verbatim, and the instruction to read every comment in each assigned file, apply the conventions, edit in place, and **return only a terse summary** — one line per file: `path — N edits: <short note per edit type>`, or `path — clean`. The subagent must not read files outside its list, must not `git add`/commit, and must not return file contents or full before/after diffs.
+Each line is `path:line<TAB>text`. A multi-line comment appears once, anchored on its opening line. If the worklist is empty, report that and stop.
 
-3. **Relay the combined terse summaries** to the user, grouped by file, so they can review the actual edits in GitHub Desktop. Do not re-read the edited files in the main agent.
+## 2. Pre-compute the mechanical hits
+
+These rules need no judgement, so decide them in the shell rather than spending a read on them:
+
+```bash
+WL=/tmp/comment-worklist.txt
+echo "== prose semicolons =="
+grep -nE '(///|//|#).*;[[:space:]]*$|(///|//|#).*[a-z]; [a-z]' "$WL"
+echo "== banned doc constructs =="
+grep -nE '<remarks>|<c>|<list>|<item>|/// <param' "$WL"
+echo "== section markers =="
+grep -nE '// ?-- ' "$WL"
+echo "== regions (checked against the diff, not the worklist) =="
+git diff -U0 "$(git merge-base main HEAD)" -- '*.cs' | grep -E '^\+[[:space:]]*#(region|endregion)'
+echo "== arrows and emoji =="
+grep -nE '→|⇒|←|✓|✗|✔|✖' "$WL"
+echo "== phrasing tells, judge each =="
+grep -niE 'rather than|instead of|unlike |as opposed to|so that|so callers|which is why|used by|called by|populated during|set via|used to|previously|no longer|there is no|future maintainers|see [A-Z][a-zA-Z]+[.]|per the |Phase [0-9]|TDD|design doc' "$WL"
+```
+
+Everything above the tells is a violation to fix. The tells are a **priority list, not a filter** — those phrasings are the tells the conventions below name most often, but every line in the worklist still gets read.
+
+## 3. Review in one subagent
+
+The review opens files, so it does not belong in the main context. Launch **one** `general-purpose` subagent (split by file into two only if the worklist exceeds ~250 lines) and give it:
+
+- the worklist contents,
+- the shell output from step 2,
+- the **Conventions to enforce** section below, verbatim.
+
+Instruct it to:
+
+- Work only on the worklist anchors. Comments outside the worklist are out of scope even when they look wrong, and even in the same file.
+- Read each anchor with `Read` using `offset`/`limit` to see the full comment and the code beneath it. Do not read whole files.
+- Fix the mechanical hits from step 2 first, then judge the rest.
+- Edit in place. Never `git add`, never commit.
+- Return **only** a terse summary, one line per file: `path — N edits: <short note per edit type>`, or `path — clean`. No file contents, no diffs.
+
+## 4. Report
+
+Relay the combined summaries grouped by file so the user can review the edits in GitHub Desktop. Do not re-read the edited files in the main agent.
 
 ## Conventions to enforce
 
-Pass this whole section to each subagent. It applies to all in-repo prose a future reader meets without the surrounding conversation: `//`, `///`, `/** */`, Python docstrings, and any touched markdown or design docs.
+Pass this whole section to the subagent. It applies to all in-repo prose a future reader meets without the surrounding conversation: `//`, `///`, `/** */`, XAML `<!-- -->`, Python docstrings, and any touched markdown.
 
 ### Mechanics
-- **Full stops, never semicolons, in English prose.** (C# statement terminators are unaffected.) This is the most-corrected rule — scan every `//`, `///`, and docstring line, including a `;` at a line-end.
+- **Full stops, never semicolons, in English prose.** C# statement terminators are unaffected. This is the most-corrected rule, and the most common slip is leaving a pre-existing semicolon on a line you reflowed for another reason.
 - **No `<remarks>` blocks**, no inline doc tags (`<c>`, `<list>`, `<item>`), no `/// <param>` — except MCP tool methods in `Celbridge.Tools`, where the SDK source generator requires `<param>`.
-- No emojis, arrows, or other special characters (`->` as ASCII in prose is fine; `→ ⇒ ✓ ✗` and emoji are not).
-- No `#region` / `#endregion`, no section-marker comments (`// -- Initialization --`).
-
-The first three are greppable; a subagent should scan its batch with these before the read-through:
-
-```bash
-# Prose semicolons in C#/JS line comments and doc comments (judge each; prose only)
-grep -rnE '^\s*(///|//).*;' <files>
-# Banned XML doc constructs
-grep -rnE '<remarks>|<c>|<list>|<item>|/// <param' <files>
-# Region and section markers
-grep -rnE '#(region|endregion)|^\s*// ?-- ' <files>
-```
+- No emoji or special characters. ASCII `->` in prose is fine; `→ ⇒ ✓ ✗` are not.
+- No `#region` / `#endregion`, no section markers (`// -- Initialization --`).
 
 ### XML doc scope
-- **Foundation** interface members and public types always carry a concise `<summary>` (one or two sentences, *what* it does).
-- **Concrete-class members: skip xmldoc by default** — the interface already documents them. Keep a member comment only for non-obvious behaviour (threading constraints, hidden side effects, subtle invariants).
-- **Interface xmldoc is the caller contract only.** Delete populate-path ("set via X", "populated during Y"), cross-refs to sibling APIs, perf rationale ("so callers can…"), naming of consumers, and anything that just restates what an enum or return type already says.
-- A `<summary>` says *what*, not *why it was designed this way*. Two short sentences at most; do not pad to restate the member name.
+- **Foundation** interface members and public types always carry a concise `<summary>`, one or two sentences saying *what* it does.
+- **Concrete-class members: skip xmldoc by default.** The interface already documents them. Keep one only for non-obvious behaviour: threading constraints, hidden side effects, subtle invariants.
+- **Interface xmldoc is the caller contract only.** Delete populate paths ("set via X", "populated during Y"), cross-references to sibling APIs, perf rationale ("so callers can…"), named consumers, and anything restating what an enum or return type already says.
+- A `<summary>` says *what*, not *why it was designed this way*.
+
+### Class summaries
+- A class summary says what the type **is**, at the altitude of the whole type.
+- **Test: would this sentence have been written a month ago, before the current change?** A summary that details the aspect the branch happened to touch is recency bias, not documentation. That aspect belongs on the member that owns it, if anywhere.
+- Do not describe how consumers bind to or drive the type. That drifts as consumers change.
 
 ### Keep out of comments entirely
 - **History** — "used to", "previously tried", "removed for".
-- **Cross-references** — to docs, proposals, or phases (named *or* vague: "per the design doc", "lands in Phase 3"), and to other classes or files by name.
-- **Design-doc rationale** — the "so that…" why belongs in the commit message.
+- **Cross-references** — to docs, proposals, or phases, named *or* vague ("per the design doc", "lands in Phase 3"), and to other classes or files by name.
+- **Design rationale** — the "so that…" why belongs in the commit message. The tell is contrastive phrasing: "unlike", "rather than", "instead of", "not X".
 - **Absences and warding** — "there is no X because…", "future maintainers should not…".
-- **Inferable examples** — the parenthetical list the reader can read straight off the code.
-- **Restate-the-call pointers** — e.g. `// The credential store is selected per platform (see Platform/)` above a self-named `PlatformServiceConfiguration.ConfigureServices(...)` call. Delete it; the call and folder are self-documenting.
-- **Stale descriptions** of behaviour an earlier design had — when a refactor changed the behaviour, the comment must change with it.
+- **Consumer lists** — who reads a value, even when it is only two consumers. The exception is a cross-language sync obligation the reader cannot discover from the code, e.g. "Mirrored by the --cel-rail-width design token".
+- **Inferable examples** — the parenthetical the reader can read straight off the code. Keep a list only when it is the closed type union a signature hides, not examples of a category.
+- **Restate-the-call pointers** — e.g. `// The credential store is selected per platform (see Platform/)` above a self-named `PlatformServiceConfiguration.ConfigureServices(...)`.
+- **Stale descriptions** of behaviour an earlier design had.
 
 ### Inline body comments
-- Terse. Only what a first-time reader cannot read off the code. Do not narrate the change, recap rationale visible in the surrounding code, or enumerate edge cases the reader can infer. A comment approaching paragraph length means the code should be restructured instead.
+Terse. Only what a first-time reader cannot read off the code. Do not narrate the change, recap rationale visible in the surrounding code, or enumerate edge cases the reader can infer. A comment approaching paragraph length means the code should be restructured instead.
 
 ### Relocate, do not just delete, genuinely useful information
-When a `<remarks>` wall or an over-long summary contains a real fact (a threading constraint, a fragile reflected field name, why a workaround exists), move it to the single line it is about as a terse inline comment, then trim the summary. Deleting useful information is as wrong as burying it.
+When an over-long comment contains a real fact — a threading constraint, a fragile reflected field name, why a workaround exists — move it to the single line it is about as a terse inline comment, then trim. Deleting useful information is as wrong as burying it.
 
 ### The test each surviving comment must pass
 1. Would a reader who never saw the prior code understand it, and will it still be true a year from now? If no, delete.
@@ -74,7 +109,6 @@ When a `<remarks>` wall or an over-long summary contains a real fact (a threadin
 
 ## Rules
 
-- Do not `git add` and do not commit. The user reviews diffs in GitHub Desktop before staging (per CLAUDE.md).
-- Touch only comments. This pass does not change code behaviour; if a comment is wrong because the code is wrong, surface that to the user rather than rewriting the code here.
-- Do not invent rules. Enforce exactly the conventions above (sourced from CLAUDE.md and the comment-style memory); when a comment is merely plain rather than wrong, leave it.
-- Stay inside files the branch modified. Do not sweep the whole repo.
+- Do not `git add` and do not commit. The user reviews diffs in GitHub Desktop before staging.
+- Touch only comments. If a comment is wrong because the code is wrong, surface that to the user rather than rewriting the code here.
+- Do not invent rules. Enforce exactly the conventions above; when a comment is merely plain rather than wrong, leave it.

--- a/.claude/skills/fix-branch-comments/extract-comments.sh
+++ b/.claude/skills/fix-branch-comments/extract-comments.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Emits every comment line the branch added or rewrote, one per line, as:
+#
+#   path:line<TAB>text
+#
+# A multi-line comment is emitted once, anchored on its opening line. Reading the
+# file at that anchor shows the whole comment.
+#
+# Usage: extract-comments.sh [base-branch]   (default: main)
+
+set -uo pipefail
+
+BASE=$(git merge-base "${1:-main}" HEAD) || exit 1
+
+KEEP='[.](cs|xaml|py|js|ts|md)$'
+DROP='(^|/)(obj|bin|node_modules)/|[.]g[.]cs$|[.]designer[.]cs$|[.]min[.]js$|package-lock[.]json$'
+
+# The comment opener differs by language, and matching the wrong one produces
+# noise that reads like a finding: # is a heading in markdown and a preprocessor
+# directive in C#, neither of which is a comment.
+opener_for() {
+  case "$1" in
+    *.md | *.xaml) printf '%s' '^[[:space:]]*<!--' ;;
+    *.py)          printf '%s' '^[[:space:]]*#' ;;
+    *)             printf '%s' '^[[:space:]]*(///|//)' ;;
+  esac
+}
+export -f opener_for
+
+# Tracked files. One range, base to working tree, so a line changed in a commit
+# and then again in the working tree is counted once at its current text.
+git diff -U0 "$BASE" -- . | awk -v keep="$KEEP" -v drop="$DROP" '
+  function opener_for(path) {
+    if (path ~ /[.](md|xaml)$/) return "^[ \t]*<!--"
+    if (path ~ /[.]py$/)        return "^[ \t]*#"
+    return "^[ \t]*(///|//)"
+  }
+  /^\+\+\+ b\// {
+    file = substr($0, 7)
+    ok = (file ~ keep) && (file !~ drop)
+    opener = opener_for(file)
+    next
+  }
+  /^\+\+\+ / { ok = 0; next }
+  /^@@/ {
+    match($0, /\+[0-9]+/)
+    line = substr($0, RSTART + 1, RLENGTH - 1) + 0
+    next
+  }
+  /^\+/ {
+    if (ok) {
+      text = substr($0, 2)
+      if (text ~ opener) printf "%s:%d\t%s\n", file, line, text
+    }
+    line++
+  }
+'
+
+# Untracked files are new in full, so every comment in them is one the branch added.
+git ls-files --others --exclude-standard \
+  | { grep -E "$KEEP" || true; } \
+  | { grep -vE "$DROP" || true; } \
+  | while read -r file; do
+      grep -nE "$(opener_for "$file")" -- "$file" \
+        | sed "s|^\([0-9]*\):|$file:\1\t|"
+    done
+
+exit 0

--- a/Source/Core/Celbridge.DesignTokens/DesignTokens.json
+++ b/Source/Core/Celbridge.DesignTokens/DesignTokens.json
@@ -139,7 +139,7 @@
     },
 
     {
-      "comment": "Vertical icon rail sizing, mirroring the workspace utility rail (WorkspaceConstants.UtilityPanelRailWidth, which sizes the panel's rail column, and UtilityButton.xaml's cell and button). The column carries the whole band up to the panel beside it, with no gutter between the two, so the square button centred in a square cell is what holds the channel open. Keep the three in sync when any changes.",
+      "comment": "Vertical icon rail sizing, mirroring the workspace utility rail (WorkspaceConstants.UtilityRailWidth, which sizes the rail control, and UtilityButton.xaml's cell and button). The column carries the whole band up to whatever sits beside it, with no gutter between the two, so the square button centred in a square cell is what holds the channel open. Keep the three in sync when any changes.",
       "tokens": {
         "rail-width": {
           "targets": ["css"],

--- a/Source/Core/Celbridge.Foundation/Workspace/IUtilityPanel.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IUtilityPanel.cs
@@ -53,14 +53,15 @@ public interface IUtilityPanel
     EditorId ActiveUtilityId { get; }
 
     /// <summary>
-    /// The smallest width the panel can be laid out at: the rail, the channel beside it, and the floor for
-    /// the surface it hosts.
+    /// The smallest width the panel can be laid out at: the floor for the surface it hosts. The rail is a
+    /// column of its own beside the panel and composes separately.
     /// </summary>
     double MinimumWidth { get; }
 
     /// <summary>
     /// Reveals a utility wherever it currently lives: activates its document tab when it is docked as a document,
-    /// otherwise selects its rail surface in the Utility Panel. A no-op when no utility has that id.
+    /// otherwise selects its rail surface in the Utility Panel, presenting the panel when it is collapsed. A
+    /// no-op when no utility has that id.
     /// </summary>
     void ShowUtility(EditorId utilityId);
 

--- a/Source/Core/Celbridge.Foundation/Workspace/IUtilityPanel.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IUtilityPanel.cs
@@ -53,11 +53,6 @@ public interface IUtilityPanel
     EditorId ActiveUtilityId { get; }
 
     /// <summary>
-    /// The smallest width the panel can be laid out at: the floor for the surface it hosts.
-    /// </summary>
-    double MinimumWidth { get; }
-
-    /// <summary>
     /// Reveals a utility wherever it currently lives: activates its document tab when it is docked as a document,
     /// otherwise selects its rail surface in the Utility Panel, presenting the panel when it is collapsed. A
     /// no-op when no utility has that id.

--- a/Source/Core/Celbridge.Foundation/Workspace/IUtilityPanel.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IUtilityPanel.cs
@@ -53,8 +53,7 @@ public interface IUtilityPanel
     EditorId ActiveUtilityId { get; }
 
     /// <summary>
-    /// The smallest width the panel can be laid out at: the floor for the surface it hosts. The rail is a
-    /// column of its own beside the panel and composes separately.
+    /// The smallest width the panel can be laid out at: the floor for the surface it hosts.
     /// </summary>
     double MinimumWidth { get; }
 
@@ -78,17 +77,11 @@ public interface IUtilityPanel
     void ClearCustomUtilities();
 
     /// <summary>
-    /// Updates a custom utility's rail button to reflect its current dock location. When docked as a
-    /// Document the button shows a docked cue and its click activates documentResource's tab. When in the
-    /// UtilityPanel the button returns to normal, its click shows the panel surface, and documentResource
-    /// is ignored.
+    /// Tells the panel where a custom utility now lives, so the rail and the panel's surface follow it.
+    /// documentResource is the document hosting the utility while the location is Document, and is otherwise
+    /// ignored.
     /// </summary>
     void SetUtilityDockLocation(EditorId utilityId, DockLocation location, ResourceKey documentResource);
-
-    /// <summary>
-    /// Briefly flashes a utility's rail button to draw attention to it. A no-op when no utility has that id.
-    /// </summary>
-    void FlashUtility(EditorId utilityId);
 
     /// <summary>
     /// Restores the previously active rail surface from workspace settings, falling back to Explorer when the

--- a/Source/Core/Celbridge.Foundation/Workspace/WorkspaceConstants.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/WorkspaceConstants.cs
@@ -32,10 +32,11 @@ public static class WorkspaceConstants
     public const double SectionTabStripHeight = 40;
 
     /// <summary>
-    /// Width of the icon rail down the side of the Utility Panel. Spans the whole band across to the panel
-    /// beside it, which its buttons are centred in. Mirrored by the --cel-rail-width design token.
+    /// Width of the Utility Rail, the icon strip down the left of the workspace. Spans the whole band across
+    /// to whatever sits beside it, which its buttons are centred in. Mirrored by the --cel-rail-width design
+    /// token.
     /// </summary>
-    public const double UtilityPanelRailWidth = 40;
+    public const double UtilityRailWidth = 40;
 
     /// <summary>
     /// Default width of the Utility Panel.

--- a/Source/Core/Celbridge.UserInterface/Helpers/AttentionFlash.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/AttentionFlash.cs
@@ -3,11 +3,10 @@ using Microsoft.UI.Xaml.Media.Animation;
 namespace Celbridge.UserInterface.Helpers;
 
 /// <summary>
-/// Runs the shared attention flash: a brief accent-colour pulse on an overlay element that draws the eye to a
-/// surface which just appeared or moved (a docked utility tab, a document tab moved by a section-count change,
-/// or a utility rail button freed by an undock). The caller owns an overlay element with Opacity 0 and passes
-/// it in; the returned storyboard is already running, and the caller keeps it so a repeated flash can stop the
-/// previous one.
+/// Runs the shared attention flash: a brief accent-colour pulse on an overlay element that draws the eye to
+/// something which just appeared, moved, or was asked for. The caller owns an overlay element with Opacity 0
+/// and passes it in. The returned storyboard is already running, and the caller keeps it so a repeated flash
+/// can stop the previous one.
 /// </summary>
 public static class AttentionFlash
 {
@@ -37,12 +36,12 @@ public static class AttentionFlash
         });
         animation.KeyFrames.Add(new LinearDoubleKeyFrame
         {
-            KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(560)),
+            KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(640)),
             Value = 0.55
         });
         animation.KeyFrames.Add(new LinearDoubleKeyFrame
         {
-            KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(920)),
+            KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(1000)),
             Value = 0.0
         });
 

--- a/Source/Core/Celbridge.UserInterface/Helpers/SpotlightLandmarks.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/SpotlightLandmarks.cs
@@ -20,9 +20,9 @@ internal static class SpotlightLandmarks
             new("new-file-button", WorkspaceSurface.UtilityPanel),
             new("new-folder-button", WorkspaceSurface.UtilityPanel),
             new("collapse-folders-button", WorkspaceSurface.UtilityPanel),
-            new("explorer-utility-button", WorkspaceSurface.UtilityPanel),
-            new("search-utility-button", WorkspaceSurface.UtilityPanel),
-            new("project-settings-utility-button", WorkspaceSurface.UtilityPanel),
+            new("explorer-utility-button", null),
+            new("search-utility-button", null),
+            new("project-settings-utility-button", null),
             new("search-input", WorkspaceSurface.UtilityPanel),
             new("search-run-button", WorkspaceSurface.UtilityPanel),
             new("search-history-button", WorkspaceSurface.UtilityPanel),
@@ -54,7 +54,7 @@ internal static class SpotlightLandmarks
         // rather than listed above.
         foreach (var link in CommunityLinks.All)
         {
-            registry.RegisterLandmark(new LandmarkDescriptor(link.LandmarkId, WorkspaceSurface.UtilityPanel));
+            registry.RegisterLandmark(new LandmarkDescriptor(link.LandmarkId, null));
         }
     }
 }

--- a/Source/Core/Celbridge.UserInterface/Helpers/WorkspaceMinimumSize.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/WorkspaceMinimumSize.cs
@@ -27,7 +27,7 @@ public static class WorkspaceMinimumSize
     /// The smallest size the workspace can be laid out at in the layout a workspace opens with: the Utility
     /// Rail, plus the surfaces the given visibility shows, each unsplit and holding the floor composed from the
     /// authored chrome, with the channels between them and the one above the document areas. Nothing here is
-    /// measured, so this holds before any workspace exists, which is where the window minimum is applied.
+    /// measured, so this holds before any workspace exists.
     /// </summary>
     public static Size ComposeDefaultLayout(WorkspaceSurface visibleSurfaces, double gutterSize)
     {
@@ -60,9 +60,8 @@ public static class WorkspaceMinimumSize
         double documentAreasWidth = ComposeAdjacent(sectionMinimum.Width, sideMinimumWidth, gutterSize);
         double width = ComposeAdjacent(utilityPanelMinimumWidth, documentAreasWidth, gutterSize);
 
-        // The Utility Rail is chrome the workspace always shows rather than a surface the visibility collapses,
-        // and it meets whatever sits beside it directly: the channel the user sees is the gap the rail leaves
-        // around its buttons.
+        // The rail is always on screen and meets whatever sits beside it directly, so its width is added
+        // without a channel.
         width += WorkspaceConstants.UtilityRailWidth;
 
         double documentAreasHeight = ComposeAdjacent(sectionMinimum.Height, bottomMinimumHeight, gutterSize);

--- a/Source/Core/Celbridge.UserInterface/Helpers/WorkspaceMinimumSize.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/WorkspaceMinimumSize.cs
@@ -24,10 +24,10 @@ public static class WorkspaceMinimumSize
     }
 
     /// <summary>
-    /// The smallest size the workspace can be laid out at in the layout a workspace opens with: the surfaces
-    /// the given visibility shows, each unsplit and holding the floor composed from the authored chrome, with
-    /// the channels between them and the one above the document areas. Nothing here is measured, so this
-    /// holds before any workspace exists, which is where the window minimum is applied.
+    /// The smallest size the workspace can be laid out at in the layout a workspace opens with: the Utility
+    /// Rail, plus the surfaces the given visibility shows, each unsplit and holding the floor composed from the
+    /// authored chrome, with the channels between them and the one above the document areas. Nothing here is
+    /// measured, so this holds before any workspace exists, which is where the window minimum is applied.
     /// </summary>
     public static Size ComposeDefaultLayout(WorkspaceSurface visibleSurfaces, double gutterSize)
     {
@@ -53,13 +53,18 @@ public static class WorkspaceMinimumSize
         if (visibleSurfaces.HasFlag(WorkspaceSurface.UtilityPanel))
         {
             // The panel's content area is carved out like a section and draws the same edge down each side, so
-            // it holds the same width floor. What the panel adds is the rail beside it, which meets the content
-            // directly: the channel the user sees is the gap the rail leaves around its buttons.
-            utilityPanelMinimumWidth = WorkspaceConstants.UtilityPanelRailWidth + sectionMinimum.Width;
+            // it holds the same width floor.
+            utilityPanelMinimumWidth = sectionMinimum.Width;
         }
 
         double documentAreasWidth = ComposeAdjacent(sectionMinimum.Width, sideMinimumWidth, gutterSize);
         double width = ComposeAdjacent(utilityPanelMinimumWidth, documentAreasWidth, gutterSize);
+
+        // The Utility Rail is chrome the workspace always shows rather than a surface the visibility collapses,
+        // and it meets whatever sits beside it directly: the channel the user sees is the gap the rail leaves
+        // around its buttons.
+        width += WorkspaceConstants.UtilityRailWidth;
+
         double documentAreasHeight = ComposeAdjacent(sectionMinimum.Height, bottomMinimumHeight, gutterSize);
 
         return new Size(width, documentAreasHeight);

--- a/Source/Core/Celbridge.UserInterface/Helpers/WorkspaceMinimumSize.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/WorkspaceMinimumSize.cs
@@ -24,6 +24,18 @@ public static class WorkspaceMinimumSize
     }
 
     /// <summary>
+    /// The smallest width the Utility Panel can be laid out at: the document floor plus the edges its content
+    /// area draws down each side, which it carves out like a document section.
+    /// </summary>
+    public static double ComposeUtilityPanelWidth()
+    {
+        double edges = WorkspaceConstants.SectionEdgeThickness * 2;
+        var panelChrome = new Size(edges, edges);
+
+        return ComposeSection(panelChrome).Width;
+    }
+
+    /// <summary>
     /// The smallest size the workspace can be laid out at in the layout a workspace opens with: the Utility
     /// Rail, plus the surfaces the given visibility shows, each unsplit and holding the floor composed from the
     /// authored chrome, with the channels between them and the one above the document areas. Nothing here is
@@ -52,9 +64,7 @@ public static class WorkspaceMinimumSize
         double utilityPanelMinimumWidth = 0;
         if (visibleSurfaces.HasFlag(WorkspaceSurface.UtilityPanel))
         {
-            // The panel's content area is carved out like a section and draws the same edge down each side, so
-            // it holds the same width floor.
-            utilityPanelMinimumWidth = sectionMinimum.Width;
+            utilityPanelMinimumWidth = ComposeUtilityPanelWidth();
         }
 
         double documentAreasWidth = ComposeAdjacent(sectionMinimum.Width, sideMinimumWidth, gutterSize);

--- a/Source/Core/Celbridge.UserInterface/Services/LayoutManager.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/LayoutManager.cs
@@ -17,7 +17,6 @@ public class LayoutManager : IWindowModeService, ILayoutService
 
     private LayoutMode _layoutMode = LayoutMode.Default;
     private bool _isFullScreen;
-    private WorkspaceSurface _surfaceVisibility = WorkspaceSurface.All;
     private BottomAreaAlignment _bottomAreaAlignment = WorkspaceConstants.BottomAreaAlignment;
 
     public LayoutManager(
@@ -103,17 +102,7 @@ public class LayoutManager : IWindowModeService, ILayoutService
         }
     }
 
-    public WorkspaceSurface SurfaceVisibility
-    {
-        get => _surfaceVisibility;
-        private set
-        {
-            if (_surfaceVisibility != value)
-            {
-                _surfaceVisibility = value;
-            }
-        }
-    }
+    public WorkspaceSurface SurfaceVisibility { get; private set; } = WorkspaceSurface.All;
 
     public bool IsUtilityPanelVisible => SurfaceVisibility.HasFlag(WorkspaceSurface.UtilityPanel);
 
@@ -277,10 +266,8 @@ public class LayoutManager : IWindowModeService, ILayoutService
         var oldVisibility = SurfaceVisibility;
         SurfaceVisibility = newVisibility;
 
-        // Only persist if explicitly requested (user-initiated changes)
-        // and not in Presentation mode (temporary presentation state)
-        if (shouldPersist &&
-            _layoutMode != LayoutMode.Presentation)
+        // Mode-driven visibility is transient, and its callers say so by not asking for a persist.
+        if (shouldPersist)
         {
             PersistPreferredSurfaceVisibility(newVisibility);
         }

--- a/Source/Core/Celbridge.UserInterface/Services/LayoutManager.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/LayoutManager.cs
@@ -123,11 +123,25 @@ public class LayoutManager : IWindowModeService, ILayoutService
 
     public void SetSurfaceVisibility(WorkspaceSurface surface, bool isVisible)
     {
-        var newVisibility = isVisible
-            ? SurfaceVisibility | surface
-            : SurfaceVisibility & ~surface;
+        // Manually changing panel visibility means the user is customizing the layout, so leave any
+        // Focus/Presentation mode and return to the Default layout.
+        bool isLeavingLayoutMode = _layoutMode != LayoutMode.Default;
 
-        if (newVisibility == SurfaceVisibility)
+        // Those modes hide every surface transiently, so the change is composed against the panels the user
+        // prefers rather than against the empty layout the mode was showing. Composing against the mode's own
+        // visibility would persist it as the preference, losing the panels the mode had hidden.
+        var currentVisibility = SurfaceVisibility;
+        if (isLeavingLayoutMode)
+        {
+            currentVisibility = PreferredSurfaceVisibility;
+        }
+
+        var newVisibility = isVisible
+            ? currentVisibility | surface
+            : currentVisibility & ~surface;
+
+        if (newVisibility == SurfaceVisibility
+            && !isLeavingLayoutMode)
         {
             return;
         }
@@ -135,9 +149,7 @@ public class LayoutManager : IWindowModeService, ILayoutService
         // This is a user-initiated change, so it should persist
         UpdateSurfaceVisibility(newVisibility, shouldPersist: true);
 
-        // Manually changing panel visibility means the user is customizing the layout, so leave any
-        // Focus/Presentation mode and return to the Default layout.
-        if (_layoutMode != LayoutMode.Default)
+        if (isLeavingLayoutMode)
         {
             SetLayoutModeInternal(LayoutMode.Default);
         }

--- a/Source/Core/Celbridge.UserInterface/Services/LayoutManager.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/LayoutManager.cs
@@ -127,9 +127,8 @@ public class LayoutManager : IWindowModeService, ILayoutService
         // Focus/Presentation mode and return to the Default layout.
         bool isLeavingLayoutMode = _layoutMode != LayoutMode.Default;
 
-        // Those modes hide every surface transiently, so the change is composed against the panels the user
-        // prefers rather than against the empty layout the mode was showing. Composing against the mode's own
-        // visibility would persist it as the preference, losing the panels the mode had hidden.
+        // Those modes hide every surface transiently, so the change is composed against the visibility the
+        // user prefers.
         var currentVisibility = SurfaceVisibility;
         if (isLeavingLayoutMode)
         {

--- a/Source/Core/Celbridge.UserInterface/Services/SpotlightService.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/SpotlightService.cs
@@ -8,6 +8,7 @@ public sealed class SpotlightService : ISpotlightService
     private readonly ILogger<SpotlightService> _logger;
     private readonly IMessengerService _messengerService;
     private readonly ILayoutService _layoutService;
+    private readonly IWindowModeService _windowModeService;
     private readonly ISpotlightRegistry _landmarkRegistry;
 
     // Reveal providers keyed by landmark id. Only landmarks that need preparation beyond the
@@ -32,11 +33,13 @@ public sealed class SpotlightService : ISpotlightService
         ILogger<SpotlightService> logger,
         IMessengerService messengerService,
         ILayoutService layoutService,
+        IWindowModeService windowModeService,
         ISpotlightRegistry landmarkRegistry)
     {
         _logger = logger;
         _messengerService = messengerService;
         _layoutService = layoutService;
+        _windowModeService = windowModeService;
         _landmarkRegistry = landmarkRegistry;
 
         _messengerService.Register<WorkspaceUnloadedMessage>(this, OnWorkspaceUnloadedMessage);
@@ -89,6 +92,14 @@ public sealed class SpotlightService : ISpotlightService
         if (_presenter is null)
         {
             return Result.Fail($"Cannot show spotlight on '{target}': the workspace UI is not available.");
+        }
+
+        // A spotlight reveals whatever surface its landmark sits on, which would take the user out of the
+        // presentation they are giving. Leaving Presentation mode is theirs to decide, and a spotlight is
+        // cosmetic, so the request is refused instead.
+        if (_windowModeService.LayoutMode == LayoutMode.Presentation)
+        {
+            return Result.Fail($"Cannot show spotlight on '{target}': the application is in Presentation mode.");
         }
 
         // Clear the previous spotlight (undoing its transient reveal) before preparing the new one.

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml.cs
@@ -34,7 +34,7 @@ public sealed partial class ApplicationToolbar : UserControl
 
         ToolbarRow.Height = new Microsoft.UI.Xaml.GridLength(ToolbarHeight);
 
-        AppIconColumn.Width = new Microsoft.UI.Xaml.GridLength(WorkspaceConstants.UtilityPanelRailWidth);
+        AppIconColumn.Width = new Microsoft.UI.Xaml.GridLength(WorkspaceConstants.UtilityRailWidth);
 
         var platformInfo = ServiceLocator.AcquireService<IPlatformInfo>();
         if (platformInfo.ReservesWindowCaptionButtons)

--- a/Source/Tests/Documents/SectionChromeCalculatorTests.cs
+++ b/Source/Tests/Documents/SectionChromeCalculatorTests.cs
@@ -56,9 +56,24 @@ public class SectionChromeCalculatorTests
     }
 
     [Test]
-    public void HiddenUtilityPanel_MainLeavesItsLeftEdgeBare()
+    public void HiddenUtilityPanel_MainStillFacesTheRailBesideIt()
     {
         _layoutState.SetUtilityPanelPresented(false);
+        var calculator = CreateCalculator();
+
+        var areaChrome = calculator.CalculateAreaChrome(DocumentArea.Main, Radius);
+
+        // The rail stays on screen when the panel collapses, so the left edge still faces a neighbour.
+        areaChrome.Primary.Edges.Should().Be(new Thickness(1, 1, 1, 1));
+        areaChrome.Primary.Corners.Should().Be(new CornerRadius(Radius, Radius, Radius, Radius));
+    }
+
+    [Test]
+    public void HiddenUtilityColumn_MainLeavesItsLeftEdgeBare()
+    {
+        // Presentation mode takes the rail as well as the panel, leaving the application border on that side.
+        _layoutState.SetUtilityPanelPresented(false);
+        _layoutState.SetUtilityRailPresented(false);
         var calculator = CreateCalculator();
 
         var areaChrome = calculator.CalculateAreaChrome(DocumentArea.Main, Radius);
@@ -130,17 +145,17 @@ public class SectionChromeCalculatorTests
     }
 
     [Test]
-    public void LeftAlignedBottomArea_BottomLeavesItsLeftEdgeBare()
+    public void LeftAlignedBottomArea_BottomStopsBesideTheRail()
     {
         _layoutState.SetBottomAreaAlignment(BottomAreaAlignment.Left);
         var calculator = CreateCalculator();
 
         var areaChrome = calculator.CalculateAreaChrome(DocumentArea.Bottom, Radius);
 
-        // The Bottom area now runs under the Utility Panel to the application border, so it no longer
-        // faces the panel across a gutter. Its right edge still faces the Side area.
-        areaChrome.Primary.Edges.Should().Be(new Thickness(0, 1, 1, 0));
-        areaChrome.Primary.Corners.Should().Be(new CornerRadius(0, Radius, 0, 0));
+        // The Bottom area now runs under the Utility Panel, but never under the rail, so its left edge faces
+        // the rail instead of reaching the application border. Its right edge still faces the Side area.
+        areaChrome.Primary.Edges.Should().Be(new Thickness(1, 1, 1, 0));
+        areaChrome.Primary.Corners.Should().Be(new CornerRadius(Radius, Radius, 0, 0));
     }
 
     [Test]
@@ -159,16 +174,16 @@ public class SectionChromeCalculatorTests
     }
 
     [Test]
-    public void JustifiedBottomArea_BottomLeavesBothSideEdgesBare()
+    public void JustifiedBottomArea_BottomLeavesItsRightEdgeBare()
     {
         _layoutState.SetBottomAreaAlignment(BottomAreaAlignment.Justify);
         var calculator = CreateCalculator();
 
         var areaChrome = calculator.CalculateAreaChrome(DocumentArea.Bottom, Radius);
 
-        // Only the top edge faces a gutter, so no corner has two edges to round between.
-        areaChrome.Primary.Edges.Should().Be(new Thickness(0, 1, 0, 0));
-        areaChrome.Primary.Corners.Should().Be(new CornerRadius(0, 0, 0, 0));
+        // It runs under both neighbours to the border on the right, and stops beside the rail on the left.
+        areaChrome.Primary.Edges.Should().Be(new Thickness(1, 1, 0, 0));
+        areaChrome.Primary.Corners.Should().Be(new CornerRadius(Radius, 0, 0, 0));
     }
 
     [Test]

--- a/Source/Tests/Documents/SectionChromeCalculatorTests.cs
+++ b/Source/Tests/Documents/SectionChromeCalculatorTests.cs
@@ -152,8 +152,8 @@ public class SectionChromeCalculatorTests
 
         var areaChrome = calculator.CalculateAreaChrome(DocumentArea.Bottom, Radius);
 
-        // The Bottom area now runs under the Utility Panel, but never under the rail, so its left edge faces
-        // the rail instead of reaching the application border. Its right edge still faces the Side area.
+        // The Bottom area now runs under the Utility Panel, but never under the rail, so its left edge still
+        // faces the rail. Its right edge faces the Side area.
         areaChrome.Primary.Edges.Should().Be(new Thickness(1, 1, 1, 0));
         areaChrome.Primary.Corners.Should().Be(new CornerRadius(Radius, Radius, 0, 0));
     }

--- a/Source/Tests/UserInterface/LayoutManagerTests.cs
+++ b/Source/Tests/UserInterface/LayoutManagerTests.cs
@@ -258,7 +258,7 @@ public class LayoutManagerTests
         _layoutManager.RequestLayoutTransition(LayoutTransition.Focus);
 
         // Focus hides every surface transiently, so showing one from there returns to the layout the user
-        // prefers with that surface shown, rather than to the mode's empty layout plus that one surface.
+        // prefers with that surface shown.
         _layoutManager.SetSurfaceVisibility(WorkspaceSurface.UtilityPanel, true);
 
         _layoutManager.SurfaceVisibility.Should().Be(WorkspaceSurface.UtilityPanel | WorkspaceSurface.BottomArea);

--- a/Source/Tests/UserInterface/LayoutManagerTests.cs
+++ b/Source/Tests/UserInterface/LayoutManagerTests.cs
@@ -252,6 +252,21 @@ public class LayoutManagerTests
     }
 
     [Test]
+    public void SetSurfaceVisibility_InFocusMode_KeepsThePanelsTheModeHid()
+    {
+        _layoutManager.SetSurfaceVisibility(WorkspaceSurface.SideArea, false);
+        _layoutManager.RequestLayoutTransition(LayoutTransition.Focus);
+
+        // Focus hides every surface transiently, so showing one from there returns to the layout the user
+        // prefers with that surface shown, rather than to the mode's empty layout plus that one surface.
+        _layoutManager.SetSurfaceVisibility(WorkspaceSurface.UtilityPanel, true);
+
+        _layoutManager.SurfaceVisibility.Should().Be(WorkspaceSurface.UtilityPanel | WorkspaceSurface.BottomArea);
+        _workspaceSettings.PreferredSurfaceVisibility.Should()
+            .Be(WorkspaceSurface.UtilityPanel | WorkspaceSurface.BottomArea);
+    }
+
+    [Test]
     public void SetSurfaceVisibility_SameState_NoChange()
     {
         bool messageReceived = false;

--- a/Source/Tests/UserInterface/LayoutManagerTests.cs
+++ b/Source/Tests/UserInterface/LayoutManagerTests.cs
@@ -267,6 +267,20 @@ public class LayoutManagerTests
     }
 
     [Test]
+    public void SetSurfaceVisibility_InPresentationMode_PersistsTheComposedLayout()
+    {
+        // Preferred is now UtilityPanel and BottomArea, with SideArea hidden.
+        _layoutManager.SetSurfaceVisibility(WorkspaceSurface.SideArea, false);
+        _layoutManager.RequestLayoutTransition(LayoutTransition.Presentation);
+
+        // Showing SideArea from Presentation composes a visibility the stored preference does not hold.
+        _layoutManager.SetSurfaceVisibility(WorkspaceSurface.SideArea, true);
+
+        _layoutManager.SurfaceVisibility.Should().Be(WorkspaceSurface.All);
+        _workspaceSettings.PreferredSurfaceVisibility.Should().Be(WorkspaceSurface.All);
+    }
+
+    [Test]
     public void SetSurfaceVisibility_SameState_NoChange()
     {
         bool messageReceived = false;

--- a/Source/Tests/UserInterface/SpotlightServiceTests.cs
+++ b/Source/Tests/UserInterface/SpotlightServiceTests.cs
@@ -1,4 +1,5 @@
 using Celbridge.Messaging;
+using Celbridge.UserInterface;
 using Celbridge.UserInterface.Services;
 using Celbridge.Workspace;
 
@@ -10,6 +11,7 @@ public class SpotlightServiceTests
     private ILogger<SpotlightService> _logger = null!;
     private IMessengerService _messengerService = null!;
     private ILayoutService _layoutService = null!;
+    private IWindowModeService _windowModeService = null!;
     private ISpotlightRegistry _landmarkRegistry = null!;
 
     [SetUp]
@@ -18,13 +20,14 @@ public class SpotlightServiceTests
         _logger = Substitute.For<ILogger<SpotlightService>>();
         _messengerService = Substitute.For<IMessengerService>();
         _layoutService = Substitute.For<ILayoutService>();
+        _windowModeService = Substitute.For<IWindowModeService>();
         _landmarkRegistry = Substitute.For<ISpotlightRegistry>();
     }
 
     [Test]
     public void RegisterPresenter_ThenClear_HidesThePresenter()
     {
-        var service = new SpotlightService(_logger, _messengerService, _layoutService, _landmarkRegistry);
+        var service = new SpotlightService(_logger, _messengerService, _layoutService, _windowModeService, _landmarkRegistry);
         var presenter = new StubSpotlightPresenter();
 
         service.RegisterPresenter(presenter);
@@ -36,7 +39,7 @@ public class SpotlightServiceTests
     [Test]
     public void RegisterPresenter_ReplacesPreviousPresenter()
     {
-        var service = new SpotlightService(_logger, _messengerService, _layoutService, _landmarkRegistry);
+        var service = new SpotlightService(_logger, _messengerService, _layoutService, _windowModeService, _landmarkRegistry);
         var first = new StubSpotlightPresenter();
         var second = new StubSpotlightPresenter();
 
@@ -52,7 +55,7 @@ public class SpotlightServiceTests
     [Test]
     public void UnregisterPresenter_NotCurrent_IsIgnored()
     {
-        var service = new SpotlightService(_logger, _messengerService, _layoutService, _landmarkRegistry);
+        var service = new SpotlightService(_logger, _messengerService, _layoutService, _windowModeService, _landmarkRegistry);
         var first = new StubSpotlightPresenter();
         var second = new StubSpotlightPresenter();
 
@@ -68,7 +71,7 @@ public class SpotlightServiceTests
     [Test]
     public void UnregisterPresenter_Current_ClearsTheSlot()
     {
-        var service = new SpotlightService(_logger, _messengerService, _layoutService, _landmarkRegistry);
+        var service = new SpotlightService(_logger, _messengerService, _layoutService, _windowModeService, _landmarkRegistry);
         var presenter = new StubSpotlightPresenter();
 
         service.RegisterPresenter(presenter);
@@ -77,6 +80,31 @@ public class SpotlightServiceTests
 
         // No presenter is registered, so clearing drives nothing.
         presenter.HideCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task ShowSpotlightAsync_InPresentationMode_IsRefused()
+    {
+        // A landmark that gates on a surface, so without the Presentation guard the reveal below would
+        // fire and take the user out of the mode.
+        _landmarkRegistry
+            .TryGetLandmark("search-input", out Arg.Any<LandmarkDescriptor?>())
+            .Returns(call =>
+            {
+                call[1] = new LandmarkDescriptor("search-input", WorkspaceSurface.UtilityPanel);
+                return true;
+            });
+        _windowModeService.LayoutMode.Returns(LayoutMode.Presentation);
+
+        var service = new SpotlightService(_logger, _messengerService, _layoutService, _windowModeService, _landmarkRegistry);
+        service.RegisterPresenter(new StubSpotlightPresenter());
+
+        var result = await service.ShowSpotlightAsync("search-input", "Search", 0);
+
+        // Revealing the landmark's surface would drop the user out of their presentation, which is theirs
+        // to leave.
+        result.IsFailure.Should().BeTrue();
+        _layoutService.DidNotReceiveWithAnyArgs().SetSurfaceVisibility(default, default);
     }
 
     private sealed class StubSpotlightPresenter : ISpotlightPresenter

--- a/Source/Tests/UserInterface/UtilityPanelViewModelTests.cs
+++ b/Source/Tests/UserInterface/UtilityPanelViewModelTests.cs
@@ -123,6 +123,32 @@ public class UtilityPanelViewModelTests
     }
 
     [Test]
+    public void SetPanelVisible_Collapsed_ClearsEveryMarkWhileKeepingTheSelection()
+    {
+        _viewModel.SelectUtility(BuiltInUtilityIds.Explorer);
+
+        _viewModel.SetPanelVisible(false);
+
+        // Nothing on the rail is marked while the panel is off screen, because the selection has no surface to
+        // point at, but the selection is kept so the next reveal returns to it.
+        _explorer.IsSelected.Should().BeFalse();
+        _explorer.IsFocused.Should().BeFalse();
+        _viewModel.SelectedUtilityId.Should().Be(BuiltInUtilityIds.Explorer);
+    }
+
+    [Test]
+    public void SetPanelVisible_Revealed_MarksTheSelectionAgain()
+    {
+        _viewModel.SelectUtility(BuiltInUtilityIds.Explorer);
+        _viewModel.SetPanelVisible(false);
+
+        _viewModel.SetPanelVisible(true);
+
+        _explorer.IsSelected.Should().BeTrue();
+        _search.IsSelected.Should().BeFalse();
+    }
+
+    [Test]
     public void SetDocked_MarksTheItemDocked()
     {
         var notepad = _viewModel.AddItem(NotepadUtilityId, WorkspacePanelId.CustomUtility);

--- a/Source/Tests/UserInterface/UtilityPanelViewModelTests.cs
+++ b/Source/Tests/UserInterface/UtilityPanelViewModelTests.cs
@@ -4,10 +4,7 @@ using Celbridge.WorkspaceUI.ViewModels;
 namespace Celbridge.Tests.UserInterface;
 
 /// <summary>
-/// Unit tests for UtilityPanelViewModel, the rail mark state machine. Both marks describe the Utility Panel,
-/// so the cases are: which item the panel is showing, whether the keyboard is in it (optimistic on selection,
-/// suppressing the transient switch bounce, honouring real focus once it settles), and the items that carry
-/// no mark at all.
+/// Unit tests for UtilityPanelViewModel, the rail mark state machine.
 /// </summary>
 [TestFixture]
 public class UtilityPanelViewModelTests
@@ -141,8 +138,7 @@ public class UtilityPanelViewModelTests
         var notepad = _viewModel.AddItem(NotepadUtilityId, WorkspacePanelId.CustomUtility);
         _viewModel.SelectUtility(NotepadUtilityId);
 
-        // Docking hands the utility to a document tab, so the panel's marks stop being its to carry, even
-        // though it was the panel's utility a moment ago.
+        // Docking hands the utility to a document tab, so the panel's marks stop being its to carry.
         _viewModel.SetDocked(NotepadUtilityId, true);
 
         notepad.IsSelected.Should().BeFalse();
@@ -156,8 +152,7 @@ public class UtilityPanelViewModelTests
 
         _viewModel.SetPanelVisible(false);
 
-        // A collapsed panel is showing nothing, so there is nothing to mark. The selection survives for the
-        // next time it opens.
+        // A collapsed panel is showing nothing, so there is nothing to mark.
         _explorer.IsSelected.Should().BeFalse();
         _explorer.IsFocused.Should().BeFalse();
         _viewModel.SelectedUtilityId.Should().Be(BuiltInUtilityIds.Explorer);

--- a/Source/Tests/UserInterface/UtilityPanelViewModelTests.cs
+++ b/Source/Tests/UserInterface/UtilityPanelViewModelTests.cs
@@ -4,9 +4,10 @@ using Celbridge.WorkspaceUI.ViewModels;
 namespace Celbridge.Tests.UserInterface;
 
 /// <summary>
-/// Unit tests for UtilityPanelViewModel, the rail selection/focus state machine. Focus on the accent rules:
-/// optimistic focus on selection, suppression of the transient switch bounce, and honouring real focus once
-/// the selection settles.
+/// Unit tests for UtilityPanelViewModel, the rail mark state machine. Both marks describe the Utility Panel,
+/// so the cases are: which item the panel is showing, whether the keyboard is in it (optimistic on selection,
+/// suppressing the transient switch bounce, honouring real focus once it settles), and the items that carry
+/// no mark at all.
 /// </summary>
 [TestFixture]
 public class UtilityPanelViewModelTests
@@ -123,21 +124,47 @@ public class UtilityPanelViewModelTests
     }
 
     [Test]
-    public void SetPanelVisible_Collapsed_ClearsEveryMarkWhileKeepingTheSelection()
+    public void SetDocked_MarksTheItemDocked()
+    {
+        var notepad = _viewModel.AddItem(NotepadUtilityId, WorkspacePanelId.CustomUtility);
+
+        _viewModel.SetDocked(NotepadUtilityId, true);
+        notepad.IsDocked.Should().BeTrue();
+
+        _viewModel.SetDocked(NotepadUtilityId, false);
+        notepad.IsDocked.Should().BeFalse();
+    }
+
+    [Test]
+    public void DockedUtility_CarriesNoMark()
+    {
+        var notepad = _viewModel.AddItem(NotepadUtilityId, WorkspacePanelId.CustomUtility);
+        _viewModel.SelectUtility(NotepadUtilityId);
+
+        // Docking hands the utility to a document tab, so the panel's marks stop being its to carry, even
+        // though it was the panel's utility a moment ago.
+        _viewModel.SetDocked(NotepadUtilityId, true);
+
+        notepad.IsSelected.Should().BeFalse();
+        notepad.IsFocused.Should().BeFalse();
+    }
+
+    [Test]
+    public void CollapsedPanel_ClearsEveryMarkAndKeepsTheSelection()
     {
         _viewModel.SelectUtility(BuiltInUtilityIds.Explorer);
 
         _viewModel.SetPanelVisible(false);
 
-        // Nothing on the rail is marked while the panel is off screen, because the selection has no surface to
-        // point at, but the selection is kept so the next reveal returns to it.
+        // A collapsed panel is showing nothing, so there is nothing to mark. The selection survives for the
+        // next time it opens.
         _explorer.IsSelected.Should().BeFalse();
         _explorer.IsFocused.Should().BeFalse();
         _viewModel.SelectedUtilityId.Should().Be(BuiltInUtilityIds.Explorer);
     }
 
     [Test]
-    public void SetPanelVisible_Revealed_MarksTheSelectionAgain()
+    public void RevealedPanel_MarksItsUtilityAgain()
     {
         _viewModel.SelectUtility(BuiltInUtilityIds.Explorer);
         _viewModel.SetPanelVisible(false);
@@ -149,15 +176,14 @@ public class UtilityPanelViewModelTests
     }
 
     [Test]
-    public void SetDocked_MarksTheItemDocked()
+    public void SelectUtility_NotAwaitingFocus_MarksTheUtilityWithoutTheAccent()
     {
-        var notepad = _viewModel.AddItem(NotepadUtilityId, WorkspacePanelId.CustomUtility);
+        // A selection that is not taking the keyboard, such as restoring the panel's utility while another
+        // panel holds focus. Awaiting a focus that will never arrive would leave the accent stuck on.
+        _viewModel.SelectUtility(BuiltInUtilityIds.Explorer, awaitFocus: false);
 
-        _viewModel.SetDocked(NotepadUtilityId, true);
-        notepad.IsDocked.Should().BeTrue();
-
-        _viewModel.SetDocked(NotepadUtilityId, false);
-        notepad.IsDocked.Should().BeFalse();
+        _explorer.IsSelected.Should().BeTrue();
+        _explorer.IsFocused.Should().BeFalse();
     }
 
     [Test]

--- a/Source/Tests/UserInterface/WorkspaceMinimumSizeTests.cs
+++ b/Source/Tests/UserInterface/WorkspaceMinimumSizeTests.cs
@@ -95,10 +95,12 @@ public class WorkspaceMinimumSizeTests
 
         var minimumSize = WorkspaceMinimumSize.ComposeDefaultLayout(WorkspaceSurface.All, GutterSize);
 
-        // The Utility Panel, the Main area and the Side area across, with a channel between each pair. The
-        // panel's own rail meets its content directly, so no channel is counted between those two.
-        double utilityPanelWidth = WorkspaceConstants.UtilityPanelRailWidth + sectionWidth;
-        minimumSize.Width.Should().Be(utilityPanelWidth + GutterSize + sectionWidth + GutterSize + sectionWidth);
+        // The Utility Panel, the Main area and the Side area across, with a channel between each pair, and the
+        // Utility Rail down the left of them. The rail meets the panel directly, so no channel is counted
+        // between those two.
+        double expectedWidth = WorkspaceConstants.UtilityRailWidth +
+            sectionWidth + GutterSize + sectionWidth + GutterSize + sectionWidth;
+        minimumSize.Width.Should().Be(expectedWidth);
 
         // The Main area above the Bottom area. The application toolbar carries the channel above them.
         minimumSize.Height.Should().Be(sectionHeight + GutterSize + sectionHeight);
@@ -111,6 +113,7 @@ public class WorkspaceMinimumSizeTests
 
         var mainAreaOnly = WorkspaceMinimumSize.ComposeDefaultLayout(WorkspaceSurface.None, GutterSize);
 
-        mainAreaOnly.Width.Should().Be(sectionWidth);
+        // The rail is chrome rather than a surface, so it is still there once every surface has gone.
+        mainAreaOnly.Width.Should().Be(WorkspaceConstants.UtilityRailWidth + sectionWidth);
     }
 }

--- a/Source/Tests/WorkspaceUI/WorkspaceSurfaceComposerTests.cs
+++ b/Source/Tests/WorkspaceUI/WorkspaceSurfaceComposerTests.cs
@@ -21,6 +21,7 @@ public class WorkspaceSurfaceComposerTests
     private static readonly Size BottomAreaMinimum = new(487, 200);
     private static readonly Size SideAreaMinimum = new(220, 430);
     private const double UtilityPanelMinimum = 280;
+    private const double UtilityRailWidth = 40;
 
     // A workspace with room to spare, so the clamps are deciding how the surplus is shared out rather than
     // running out of space.
@@ -36,8 +37,10 @@ public class WorkspaceSurfaceComposerTests
         var composer = CreateComposer(CreatePresentation());
 
         // The Main and Bottom areas share a column, so it holds the wider of the two, with the Utility Panel
-        // and the Side area beside it.
-        double expectedWidth = UtilityPanelMinimum +
+        // and the Side area beside it, and the rail down the left of the lot. The rail meets the panel
+        // directly, so no channel is counted between those two.
+        double expectedWidth = UtilityRailWidth +
+            UtilityPanelMinimum +
             GutterSize +
             BottomAreaMinimum.Width +
             GutterSize +
@@ -54,8 +57,24 @@ public class WorkspaceSurfaceComposerTests
     {
         var composer = CreateComposer(CreatePresentation(isUtilityPanelPresented: false));
 
+        // The rail is not part of the panel, so collapsing the panel leaves the rail holding the left of the
+        // workspace on its own.
         composer.UtilityPanelMinimumWidth.Should().Be(0);
-        composer.MinimumSize.Width.Should().Be(BottomAreaMinimum.Width + GutterSize + SideAreaMinimum.Width);
+        composer.MinimumSize.Width.Should().Be(
+            UtilityRailWidth + BottomAreaMinimum.Width + GutterSize + SideAreaMinimum.Width);
+    }
+
+    [Test]
+    public void MinimumSize_DropsAHiddenUtilityRail()
+    {
+        var composer = CreateComposer(CreatePresentation(isUtilityRailPresented: false));
+
+        double expectedWidth = UtilityPanelMinimum +
+            GutterSize +
+            BottomAreaMinimum.Width +
+            GutterSize +
+            SideAreaMinimum.Width;
+        composer.MinimumSize.Width.Should().Be(expectedWidth);
     }
 
     [Test]
@@ -67,7 +86,8 @@ public class WorkspaceSurfaceComposerTests
         composer.BottomAreaMinimumHeight.Should().Be(0);
         composer.MainColumnMinimumWidth.Should().Be(MainAreaMinimum.Width);
 
-        double expectedWidth = UtilityPanelMinimum +
+        double expectedWidth = UtilityRailWidth +
+            UtilityPanelMinimum +
             GutterSize +
             MainAreaMinimum.Width +
             GutterSize +
@@ -89,7 +109,8 @@ public class WorkspaceSurfaceComposerTests
 
         composer.MainColumnMinimumWidth.Should().Be(splitMainAreaMinimum.Width);
 
-        double expectedWidth = UtilityPanelMinimum +
+        double expectedWidth = UtilityRailWidth +
+            UtilityPanelMinimum +
             GutterSize +
             splitMainAreaMinimum.Width +
             GutterSize +
@@ -104,7 +125,8 @@ public class WorkspaceSurfaceComposerTests
 
         composer.MainColumnMinimumWidth.Should().Be(MainAreaMinimum.Width);
 
-        double expectedWidth = UtilityPanelMinimum +
+        double expectedWidth = UtilityRailWidth +
+            UtilityPanelMinimum +
             GutterSize +
             MainAreaMinimum.Width +
             GutterSize +
@@ -128,7 +150,8 @@ public class WorkspaceSurfaceComposerTests
         composer.MinimumSize.Height.Should().Be(expectedHeight);
 
         // The Bottom area takes the Side area's column, so the row it sits in is the wider of the two.
-        composer.MinimumSize.Width.Should().Be(UtilityPanelMinimum + GutterSize + BottomAreaMinimum.Width);
+        composer.MinimumSize.Width.Should().Be(
+            UtilityRailWidth + UtilityPanelMinimum + GutterSize + BottomAreaMinimum.Width);
     }
 
     [Test]
@@ -142,7 +165,8 @@ public class WorkspaceSurfaceComposerTests
 
         // Nothing sits beside the Bottom area, so the surfaces above it set the width and its own extent only
         // takes over once it is the wider of the two.
-        double expectedWidth = UtilityPanelMinimum +
+        double expectedWidth = UtilityRailWidth +
+            UtilityPanelMinimum +
             GutterSize +
             MainAreaMinimum.Width +
             GutterSize +
@@ -162,7 +186,8 @@ public class WorkspaceSurfaceComposerTests
             composer.MainColumnMinimumWidth,
             composer.SideAreaMinimumWidth,
             GutterSize);
-        double trackWidths = WorkspaceMinimumSize.ComposeAdjacent(
+        double railWidth = presentation.IsUtilityRailPresented ? UtilityRailWidth : 0;
+        double trackWidths = railWidth + WorkspaceMinimumSize.ComposeAdjacent(
             composer.UtilityPanelMinimumWidth,
             documentAreaWidths,
             GutterSize);
@@ -344,6 +369,7 @@ public class WorkspaceSurfaceComposerTests
         yield return CreatePresentation(bottomAreaSpansSideArea: true);
         yield return CreatePresentation(bottomAreaSpansUtilityPanel: true, bottomAreaSpansSideArea: true);
         yield return CreatePresentation(isUtilityPanelPresented: false);
+        yield return CreatePresentation(isUtilityRailPresented: false);
         yield return CreatePresentation(isBottomAreaPresented: false);
         yield return CreatePresentation(isSideAreaPresented: false);
         yield return CreatePresentation(
@@ -352,20 +378,21 @@ public class WorkspaceSurfaceComposerTests
             isUtilityPanelPresented: false);
     }
 
-    // What the Main area's column is left with once the pixel-sized surfaces either side of it have taken
-    // their share of the workspace.
+    // What the Main area's column is left with once the rail and the pixel-sized surfaces either side of it
+    // have taken their share of the workspace.
     private static double ResolveMainColumnWidth(
         double workspaceWidth,
         double utilityPanelWidth,
         double sideAreaWidth)
     {
-        return workspaceWidth - utilityPanelWidth - GutterSize - sideAreaWidth - GutterSize;
+        return workspaceWidth - UtilityRailWidth - utilityPanelWidth - GutterSize - sideAreaWidth - GutterSize;
     }
 
     private static WorkspaceSurfacePresentation CreatePresentation(
         bool isBottomAreaPresented = true,
         bool isSideAreaPresented = true,
         bool isUtilityPanelPresented = true,
+        bool isUtilityRailPresented = true,
         bool bottomAreaSpansUtilityPanel = false,
         bool bottomAreaSpansSideArea = false)
     {
@@ -374,6 +401,7 @@ public class WorkspaceSurfaceComposerTests
             IsBottomAreaPresented: isBottomAreaPresented,
             IsSideAreaPresented: isSideAreaPresented,
             IsUtilityPanelPresented: isUtilityPanelPresented,
+            IsUtilityRailPresented: isUtilityRailPresented,
             BottomAreaSpansUtilityPanel: bottomAreaSpansUtilityPanel,
             BottomAreaSpansSideArea: bottomAreaSpansSideArea);
     }
@@ -392,6 +420,7 @@ public class WorkspaceSurfaceComposerTests
             BottomAreaMinimumSize: BottomAreaMinimum,
             SideAreaMinimumSize: SideAreaMinimum,
             UtilityPanelMinimumWidth: UtilityPanelMinimum,
+            UtilityRailWidth: UtilityRailWidth,
             GutterSize: GutterSize,
             WorkspaceExtent: new Size(workspaceWidth, workspaceHeight),
             UtilityPanelWidth: utilityPanelWidth,

--- a/Source/Workspace/Celbridge.Documents/Helpers/SectionChromeCalculator.cs
+++ b/Source/Workspace/Celbridge.Documents/Helpers/SectionChromeCalculator.cs
@@ -81,15 +81,15 @@ public class SectionChromeCalculator
     // and the neighbour it ran under gains a bottom edge instead.
     private Thickness ResolveAreaEdges(DocumentArea area)
     {
-        double facingUtilityPanel = ResolveEdge(_layoutState.IsUtilityPanelPresented);
+        double facingUtilityColumn = ResolveEdge(_layoutState.IsUtilityColumnPresented);
 
         if (area == DocumentArea.Side)
         {
-            // The Side area's left edge faces the main column, or the Utility Panel when no other area is
-            // presented alongside it.
+            // The Side area's left edge faces the main column, or the Utility Rail and Panel when no other
+            // area is presented alongside it.
             bool isMainColumnPresented = _layoutState.IsAreaPresented(DocumentArea.Main) ||
                 _layoutState.IsAreaPresented(DocumentArea.Bottom);
-            double sideLeft = ResolveEdge(isMainColumnPresented || _layoutState.IsUtilityPanelPresented);
+            double sideLeft = ResolveEdge(isMainColumnPresented || _layoutState.IsUtilityColumnPresented);
             double sideBottom = ResolveEdge(_layoutState.BottomAreaSpansSideArea);
 
             return new Thickness(sideLeft, EdgeThickness, 0, sideBottom);
@@ -99,8 +99,10 @@ public class SectionChromeCalculator
 
         if (area == DocumentArea.Bottom)
         {
-            double bottomLeft = ResolveEdge(_layoutState.IsUtilityPanelPresented &&
-                !_layoutState.BottomAreaSpansUtilityPanel);
+            // The Bottom area's alignment can take it across the Utility Panel, but never across the rail, so
+            // the rail is still there to face on that side once it has.
+            double bottomLeft = ResolveEdge(_layoutState.IsUtilityRailPresented ||
+                (_layoutState.IsUtilityPanelPresented && !_layoutState.BottomAreaSpansUtilityPanel));
             double bottomRight = ResolveEdge(_layoutState.IsAreaPresented(DocumentArea.Side) &&
                 !_layoutState.BottomAreaSpansSideArea);
 
@@ -109,7 +111,7 @@ public class SectionChromeCalculator
 
         double facingBottom = ResolveEdge(_layoutState.IsAreaPresented(DocumentArea.Bottom));
 
-        return new Thickness(facingUtilityPanel, EdgeThickness, facingSide, facingBottom);
+        return new Thickness(facingUtilityColumn, EdgeThickness, facingSide, facingBottom);
     }
 
     private static double ResolveEdge(bool facesNeighbour)

--- a/Source/Workspace/Celbridge.Documents/Services/AreaLayoutState.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/AreaLayoutState.cs
@@ -4,8 +4,8 @@ namespace Celbridge.Documents.Services;
 
 /// <summary>
 /// The live layout state of the document areas: per-area split and ratio, which areas the user has visible,
-/// and the transient isolation and Utility Rail and Panel presentation. Holds the layout rules over that state;
-/// applying it to the visual tree is the section container's job. Mutations return whether the state
+/// and the transient isolation and Utility Rail and Panel presentation. Holds the layout rules over that
+/// state. Applying it to the visual tree is the section container's job. Mutations return whether the state
 /// changed, so the caller knows when to re-apply the layout.
 /// </summary>
 public class AreaLayoutState

--- a/Source/Workspace/Celbridge.Documents/Services/AreaLayoutState.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/AreaLayoutState.cs
@@ -5,8 +5,7 @@ namespace Celbridge.Documents.Services;
 /// <summary>
 /// The live layout state of the document areas: per-area split and ratio, which areas the user has visible,
 /// and the transient isolation and Utility Rail and Panel presentation. Holds the layout rules over that
-/// state. Applying it to the visual tree is the section container's job. Mutations return whether the state
-/// changed, so the caller knows when to re-apply the layout.
+/// state. Mutations return whether the state changed.
 /// </summary>
 public class AreaLayoutState
 {
@@ -47,8 +46,7 @@ public class AreaLayoutState
     public bool IsUtilityRailPresented => _isUtilityRailPresented;
 
     /// <summary>
-    /// Whether anything is showing in the band left of the document areas, which is what an area on that side
-    /// draws its left edge against.
+    /// Whether anything is showing in the band left of the document areas.
     /// </summary>
     public bool IsUtilityColumnPresented => _isUtilityRailPresented || _isUtilityPanelPresented;
 

--- a/Source/Workspace/Celbridge.Documents/Services/AreaLayoutState.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/AreaLayoutState.cs
@@ -4,7 +4,7 @@ namespace Celbridge.Documents.Services;
 
 /// <summary>
 /// The live layout state of the document areas: per-area split and ratio, which areas the user has visible,
-/// and the transient isolation and Utility Panel presentation. Holds the layout rules over that state;
+/// and the transient isolation and Utility Rail and Panel presentation. Holds the layout rules over that state;
 /// applying it to the visual tree is the section container's job. Mutations return whether the state
 /// changed, so the caller knows when to re-apply the layout.
 /// </summary>
@@ -18,6 +18,7 @@ public class AreaLayoutState
 
     private DocumentArea? _isolatedArea;
     private bool _isUtilityPanelPresented = true;
+    private bool _isUtilityRailPresented = true;
     private BottomAreaAlignment _bottomAreaAlignment = WorkspaceConstants.BottomAreaAlignment;
 
     public AreaLayoutState()
@@ -39,6 +40,17 @@ public class AreaLayoutState
     /// Whether the Utility Panel is showing alongside the document areas.
     /// </summary>
     public bool IsUtilityPanelPresented => _isUtilityPanelPresented;
+
+    /// <summary>
+    /// Whether the Utility Rail is showing down the left of the workspace.
+    /// </summary>
+    public bool IsUtilityRailPresented => _isUtilityRailPresented;
+
+    /// <summary>
+    /// Whether anything is showing in the band left of the document areas, which is what an area on that side
+    /// draws its left edge against.
+    /// </summary>
+    public bool IsUtilityColumnPresented => _isUtilityRailPresented || _isUtilityPanelPresented;
 
     /// <summary>
     /// How far the Bottom area spans across the workspace.
@@ -260,6 +272,18 @@ public class AreaLayoutState
         }
 
         _isUtilityPanelPresented = isPresented;
+
+        return true;
+    }
+
+    public bool SetUtilityRailPresented(bool isPresented)
+    {
+        if (_isUtilityRailPresented == isPresented)
+        {
+            return false;
+        }
+
+        _isUtilityRailPresented = isPresented;
 
         return true;
     }

--- a/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
@@ -228,10 +228,7 @@ public class UtilityService : IUtilityService, IDisposable
 
         var utilityPanel = _workspaceWrapper.WorkspaceService.UtilityPanel;
 
-        // The utility's surface has left the Utility Panel, so show Explorer so the panel is not left blank.
-        utilityPanel.ShowUtility(BuiltInUtilityIds.Explorer);
-
-        // Tell the rail this utility is a document, so its button dims and its click activates the tab.
+        // Tell the rail this utility now lives in a document tab.
         utilityPanel.SetUtilityDockLocation(panelView.UtilityId, DockLocation.Document, panelView.FileResource);
 
         FlashDocumentTab(panelView.FileResource);
@@ -261,9 +258,6 @@ public class UtilityService : IUtilityService, IDisposable
 
         // Present the utility at its destination, mirroring the dock as a document, which activates the tab.
         utilityPanel.ShowUtility(panelView.UtilityId);
-
-        // Flash the rail button so the move is obvious.
-        utilityPanel.FlashUtility(panelView.UtilityId);
 
         return Result.Ok();
     }

--- a/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
@@ -228,7 +228,6 @@ public class UtilityService : IUtilityService, IDisposable
 
         var utilityPanel = _workspaceWrapper.WorkspaceService.UtilityPanel;
 
-        // Tell the rail this utility now lives in a document tab.
         utilityPanel.SetUtilityDockLocation(panelView.UtilityId, DockLocation.Document, panelView.FileResource);
 
         FlashDocumentTab(panelView.FileResource);

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentAreaLayout.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentAreaLayout.cs
@@ -152,8 +152,7 @@ public sealed class DocumentAreaLayout
     }
 
     /// <summary>
-    /// Sets whether the Utility Rail is showing down the left of the workspace. Like the panel beside it, the
-    /// rail is what an area on that side draws its left edge against.
+    /// Sets whether the Utility Rail is showing down the left of the workspace.
     /// </summary>
     public void SetUtilityRailPresented(bool isPresented)
     {

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentAreaLayout.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentAreaLayout.cs
@@ -152,6 +152,18 @@ public sealed class DocumentAreaLayout
     }
 
     /// <summary>
+    /// Sets whether the Utility Rail is showing down the left of the workspace. Like the panel beside it, the
+    /// rail is what an area on that side draws its left edge against.
+    /// </summary>
+    public void SetUtilityRailPresented(bool isPresented)
+    {
+        if (_layoutState.SetUtilityRailPresented(isPresented))
+        {
+            ApplyWorkspaceLayout();
+        }
+    }
+
+    /// <summary>
     /// Sets how far the Bottom area spans across the workspace: the Main area only, or across the Utility
     /// Panel, the Side area, or both. The surfaces it runs across stop above it.
     /// </summary>
@@ -575,6 +587,7 @@ public sealed class DocumentAreaLayout
             IsBottomAreaPresented: _layoutState.IsAreaPresented(DocumentArea.Bottom),
             IsSideAreaPresented: _layoutState.IsAreaPresented(DocumentArea.Side),
             IsUtilityPanelPresented: _layoutState.IsUtilityPanelPresented,
+            IsUtilityRailPresented: _layoutState.IsUtilityRailPresented,
             BottomAreaSpansUtilityPanel: _layoutState.BottomAreaSpansUtilityPanel,
             BottomAreaSpansSideArea: _layoutState.BottomAreaSpansSideArea);
 

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -12,6 +12,11 @@ namespace Celbridge.Documents.Views;
 
 using IWorkspacePanelLogger = Logging.ILogger<WorkspacePanel>;
 
+/// <summary>
+/// A document's focus claim held back until the collapsed area holding it has been revealed.
+/// </summary>
+internal sealed record PendingRevealFocus(ResourceKey Document, DocumentArea Area);
+
 public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 {
     private readonly IServiceProvider _serviceProvider;
@@ -27,9 +32,8 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
     private bool _isShuttingDown = false;
 
-    // The document whose focus claim is waiting on a collapsed area being revealed. A document off screen
-    // cannot take the keyboard, so the claim waits for the area to be laid out.
-    private ResourceKey _pendingRevealFocusDocument = ResourceKey.Empty;
+    // A document off screen cannot take the keyboard, so its claim waits for the area to be laid out.
+    private PendingRevealFocus? _pendingRevealFocus;
 
     public WorkspacePanelViewModel ViewModel { get; }
 
@@ -118,15 +122,19 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
         ViewModel.OnActiveDocumentChanged(documentResource);
 
-        bool isAreaRevealing = RevealActivatedDocumentArea(documentResource, reason);
+        var revealingArea = RevealActivatedDocumentArea(documentResource, reason);
+
+        // This activation supersedes any claim still waiting on a reveal, so at most one is ever held and it
+        // is always the newest.
+        _pendingRevealFocus = null;
 
         // The keyboard follows the active document, so every path that changes it carries focus without
         // having to remember to: opening, closing onto the next tab, moving a tab between sections.
         if (ActiveDocumentFocusPolicy.ShouldCarryFocus(documentResource, reason))
         {
-            if (isAreaRevealing)
+            if (revealingArea is not null)
             {
-                _pendingRevealFocusDocument = documentResource;
+                _pendingRevealFocus = new PendingRevealFocus(documentResource, revealingArea.Value);
             }
             else
             {
@@ -135,26 +143,26 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         }
     }
 
-    // Opens the collapsed area holding the document that just became active. Returns whether a reveal was
-    // asked for, which the caller waits out before moving the keyboard into the area. A restore is left
-    // alone: the workspace restores its own surface visibility.
-    private bool RevealActivatedDocumentArea(ResourceKey documentResource, ActiveDocumentChangeReason reason)
+    // Opens the collapsed area holding the document that just became active, returning the area being
+    // revealed, or null when nothing needed revealing. A restore is left alone: the workspace restores its
+    // own surface visibility.
+    private DocumentArea? RevealActivatedDocumentArea(ResourceKey documentResource, ActiveDocumentChangeReason reason)
     {
         if (documentResource.IsEmpty
             || reason != ActiveDocumentChangeReason.Activated)
         {
-            return false;
+            return null;
         }
 
         var area = SectionContainer.ActiveSection.GetArea();
         if (ViewModel.IsAreaVisible(area))
         {
-            return false;
+            return null;
         }
 
         ViewModel.SetAreaVisible(area, true);
 
-        return true;
+        return area;
     }
 
     private void OnSectionDocumentsLayoutChanged(DocumentSectionView sectionView, List<ResourceKey> documents)
@@ -544,12 +552,14 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
         ApplyAreaVisibility();
 
-        var revealedDocument = _pendingRevealFocusDocument;
-        _pendingRevealFocusDocument = ResourceKey.Empty;
-
-        if (!revealedDocument.IsEmpty)
+        // Every surface reports through this message, so one about another area says nothing about a claim
+        // still waiting on this one.
+        var pendingFocus = _pendingRevealFocus;
+        if (pendingFocus is not null
+            && ViewModel.IsAreaVisible(pendingFocus.Area))
         {
-            FocusActivatedDocument(revealedDocument);
+            _pendingRevealFocus = null;
+            FocusActivatedDocument(pendingFocus.Document);
         }
     }
 

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -348,6 +348,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         // into Focus or Presentation.
         ApplyIsolatedArea(_windowModeService.LayoutMode);
         UpdateTabStripVisibility(_windowModeService.LayoutMode);
+        UpdateUtilityRailVisibility(_windowModeService.LayoutMode);
 
         RegisterAsResourceDropTarget();
     }
@@ -443,6 +444,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
     {
         ApplyIsolatedArea(message.LayoutMode);
         UpdateTabStripVisibility(message.LayoutMode);
+        UpdateUtilityRailVisibility(message.LayoutMode);
 
         // Entering a mode that hides the side panels can leave keyboard focus on a now-hidden panel
         // (e.g. the Explorer), which stops app shortcuts like F11 from being delivered until the user
@@ -490,6 +492,14 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         {
             toolbar.Visibility = toolbarVisibility;
         }
+    }
+
+    // The rail is chrome the workspace always offers rather than a surface the user collapses, so it follows
+    // the application toolbar: Focus keeps it and Presentation strips back to the document content alone.
+    // Keeping it in Focus also leaves the Utility Panel one click away from that mode.
+    private void UpdateUtilityRailVisibility(LayoutMode layoutMode)
+    {
+        SectionContainer.Areas.SetUtilityRailPresented(layoutMode != LayoutMode.Presentation);
     }
 
     private void OnSurfaceVisibilityChanged(object recipient, SurfaceVisibilityChangedMessage message)

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -27,6 +27,10 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
     private bool _isShuttingDown = false;
 
+    // The document whose focus claim is waiting on a collapsed area being revealed. A document off screen
+    // cannot take the keyboard, so the claim waits for the area to be laid out.
+    private ResourceKey _pendingRevealFocusDocument = ResourceKey.Empty;
+
     public WorkspacePanelViewModel ViewModel { get; }
 
     // Manages the document sections inside the surface container's area grids.
@@ -114,12 +118,43 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
         ViewModel.OnActiveDocumentChanged(documentResource);
 
+        bool isAreaRevealing = RevealActivatedDocumentArea(documentResource, reason);
+
         // The keyboard follows the active document, so every path that changes it carries focus without
         // having to remember to: opening, closing onto the next tab, moving a tab between sections.
         if (ActiveDocumentFocusPolicy.ShouldCarryFocus(documentResource, reason))
         {
-            FocusActivatedDocument(documentResource);
+            if (isAreaRevealing)
+            {
+                _pendingRevealFocusDocument = documentResource;
+            }
+            else
+            {
+                FocusActivatedDocument(documentResource);
+            }
         }
+    }
+
+    // Opens the collapsed area holding the document that just became active. Returns whether a reveal was
+    // asked for, which the caller waits out before moving the keyboard into the area. A restore is left
+    // alone: the workspace restores its own surface visibility.
+    private bool RevealActivatedDocumentArea(ResourceKey documentResource, ActiveDocumentChangeReason reason)
+    {
+        if (documentResource.IsEmpty
+            || reason != ActiveDocumentChangeReason.Activated)
+        {
+            return false;
+        }
+
+        var area = SectionContainer.ActiveSection.GetArea();
+        if (ViewModel.IsAreaVisible(area))
+        {
+            return false;
+        }
+
+        ViewModel.SetAreaVisible(area, true);
+
+        return true;
     }
 
     private void OnSectionDocumentsLayoutChanged(DocumentSectionView sectionView, List<ResourceKey> documents)
@@ -508,6 +543,14 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         }
 
         ApplyAreaVisibility();
+
+        var revealedDocument = _pendingRevealFocusDocument;
+        _pendingRevealFocusDocument = ResourceKey.Empty;
+
+        if (!revealedDocument.IsEmpty)
+        {
+            FocusActivatedDocument(revealedDocument);
+        }
     }
 
     // Shows or hides the collapsible areas to match the workspace surface visibility. Hiding an area

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -494,9 +494,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         }
     }
 
-    // The rail is chrome the workspace always offers rather than a surface the user collapses, so it follows
-    // the application toolbar: Focus keeps it and Presentation strips back to the document content alone.
-    // Keeping it in Focus also leaves the Utility Panel one click away from that mode.
+    // Presentation mode strips back to the document content alone, so it is the only mode that hides the rail.
     private void UpdateUtilityRailVisibility(LayoutMode layoutMode)
     {
         SectionContainer.Areas.SetUtilityRailPresented(layoutMode != LayoutMode.Presentation);

--- a/Source/Workspace/Celbridge.Explorer/Commands/SelectResourceCommand.cs
+++ b/Source/Workspace/Celbridge.Explorer/Commands/SelectResourceCommand.cs
@@ -5,18 +5,14 @@ namespace Celbridge.Explorer.Commands;
 
 public class SelectResourceCommand : CommandBase, ISelectResourceCommand
 {
-    private readonly ICommandService _commandService;
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
     public ResourceKey Resource { get; set; }
 
     public bool ShowExplorerPanel { get; set; } = true;
 
-    public SelectResourceCommand(
-        ICommandService commandService,
-        IWorkspaceWrapper workspaceWrapper)
+    public SelectResourceCommand(IWorkspaceWrapper workspaceWrapper)
     {
-        _commandService = commandService;
         _workspaceWrapper = workspaceWrapper;
     }
 
@@ -32,15 +28,6 @@ public class SelectResourceCommand : CommandBase, ISelectResourceCommand
 
         if (ShowExplorerPanel)
         {
-            _commandService.Execute<ISetSurfaceVisibilityCommand>(command =>
-            {
-                command.Surfaces = WorkspaceSurface.UtilityPanel;
-                command.IsVisible = true;
-            });
-
-            // Switch the Utility Panel to the Explorer tab. Making the Utility Panel visible is not
-            // enough on its own: the Explorer content stays collapsed while another utility (such as
-            // Search) is the active tab, so the selected resource would not be shown.
             var utilityPanel = _workspaceWrapper.WorkspaceService.UtilityPanel;
             utilityPanel.ShowUtility(BuiltInUtilityIds.Explorer);
         }

--- a/Source/Workspace/Celbridge.Search/Commands/ShowSearchCommand.cs
+++ b/Source/Workspace/Celbridge.Search/Commands/ShowSearchCommand.cs
@@ -5,7 +5,7 @@ namespace Celbridge.Search.Commands;
 
 public class ShowSearchCommand : CommandBase, IShowSearchCommand
 {
-    private readonly ILayoutService _layoutService;
+    private readonly IWorkspaceWrapper _workspaceWrapper;
 
     public string SearchText { get; set; } = string.Empty;
 
@@ -18,18 +18,16 @@ public class ShowSearchCommand : CommandBase, IShowSearchCommand
     public string ReplaceText { get; set; } = string.Empty;
 
     public ShowSearchCommand(
-        ILayoutService layoutService)
+        IWorkspaceWrapper workspaceWrapper)
     {
-        _layoutService = layoutService;
+        _workspaceWrapper = workspaceWrapper;
     }
 
     public override async Task<Result> ExecuteAsync()
     {
-        // Ensure the Utility Panel (which contains Search) is visible
-        if (!_layoutService.IsUtilityPanelVisible)
-        {
-            _layoutService.SetSurfaceVisibility(WorkspaceSurface.UtilityPanel, true);
-        }
+        // Present the Search surface, which brings the Utility Panel back when it is collapsed.
+        var utilityPanel = _workspaceWrapper.WorkspaceService.UtilityPanel;
+        utilityPanel.ShowUtility(BuiltInUtilityIds.Search);
 
         var searchPanel = ServiceLocator.AcquireService<ISearchPanel>();
 

--- a/Source/Workspace/Celbridge.WorkspaceUI/Helpers/WorkspaceSurfaceComposer.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Helpers/WorkspaceSurfaceComposer.cs
@@ -6,7 +6,7 @@ namespace Celbridge.WorkspaceUI.Helpers;
 /// <summary>
 /// The set of workspace surfaces currently presented, whether the Utility Rail is on screen beside them, and
 /// how far the Bottom area spans across its neighbours. A surface the Bottom area spans across stops above it
-/// instead of running full height; the rail is never spanned.
+/// instead of running full height. The rail is never spanned.
 /// </summary>
 public record WorkspaceSurfacePresentation(
     bool IsMainAreaPresented,

--- a/Source/Workspace/Celbridge.WorkspaceUI/Helpers/WorkspaceSurfaceComposer.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Helpers/WorkspaceSurfaceComposer.cs
@@ -4,14 +4,16 @@ using Windows.Foundation;
 namespace Celbridge.WorkspaceUI.Helpers;
 
 /// <summary>
-/// The set of workspace surfaces currently presented and how far the Bottom area spans across its
-/// neighbours. A surface the Bottom area spans across stops above it instead of running full height.
+/// The set of workspace surfaces currently presented, whether the Utility Rail is on screen beside them, and
+/// how far the Bottom area spans across its neighbours. A surface the Bottom area spans across stops above it
+/// instead of running full height; the rail is never spanned.
 /// </summary>
 public record WorkspaceSurfacePresentation(
     bool IsMainAreaPresented,
     bool IsBottomAreaPresented,
     bool IsSideAreaPresented,
     bool IsUtilityPanelPresented,
+    bool IsUtilityRailPresented,
     bool BottomAreaSpansUtilityPanel,
     bool BottomAreaSpansSideArea);
 
@@ -26,6 +28,7 @@ public record WorkspaceSurfaceMetrics(
     Size BottomAreaMinimumSize,
     Size SideAreaMinimumSize,
     double UtilityPanelMinimumWidth,
+    double UtilityRailWidth,
     double GutterSize,
     Size WorkspaceExtent,
     double? UtilityPanelWidth,
@@ -45,6 +48,7 @@ public sealed class WorkspaceSurfaceComposer
     private readonly Size _bottomAreaMinimumSize;
     private readonly Size _sideAreaMinimumSize;
     private readonly double _utilityPanelMinimumWidth;
+    private readonly double _utilityRailWidth;
 
     public WorkspaceSurfaceComposer(WorkspaceSurfacePresentation presentation, WorkspaceSurfaceMetrics metrics)
     {
@@ -62,6 +66,12 @@ public sealed class WorkspaceSurfaceComposer
         {
             _utilityPanelMinimumWidth = metrics.UtilityPanelMinimumWidth;
         }
+
+        _utilityRailWidth = 0;
+        if (presentation.IsUtilityRailPresented)
+        {
+            _utilityRailWidth = metrics.UtilityRailWidth;
+        }
     }
 
     /// <summary>
@@ -77,7 +87,9 @@ public sealed class WorkspaceSurfaceComposer
                 DocumentAreasMinimumWidth,
                 _metrics.GutterSize);
 
-            double width = Math.Max(surfacesBesideUtilityPanel, BottomRowMinimumWidth);
+            // The rail runs down the whole workspace beside every row, and meets what sits next to it directly,
+            // so it adds its width without a channel of its own.
+            double width = _utilityRailWidth + Math.Max(surfacesBesideUtilityPanel, BottomRowMinimumWidth);
 
             return new Size(width, DocumentAreasMinimumHeight + _metrics.GutterSize);
         }

--- a/Source/Workspace/Celbridge.WorkspaceUI/Helpers/WorkspaceSurfaceComposer.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Helpers/WorkspaceSurfaceComposer.cs
@@ -6,7 +6,7 @@ namespace Celbridge.WorkspaceUI.Helpers;
 /// <summary>
 /// The set of workspace surfaces currently presented, whether the Utility Rail is on screen beside them, and
 /// how far the Bottom area spans across its neighbours. A surface the Bottom area spans across stops above it
-/// instead of running full height. The rail is never spanned.
+/// instead of running full height.
 /// </summary>
 public record WorkspaceSurfacePresentation(
     bool IsMainAreaPresented,

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityItemViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityItemViewModel.cs
@@ -4,9 +4,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 namespace Celbridge.WorkspaceUI.ViewModels;
 
 /// <summary>
-/// View model for a single Utility Panel rail item (a built-in Explorer or Search surface, or a custom
-/// utility). The rail button binds its visual state to IsSelected, IsFocused, and IsDocked. The owning
-/// UtilityPanelViewModel is the only writer of those properties.
+/// View model for a single Utility Panel rail item: a built-in Explorer or Search surface, or a custom
+/// utility.
 /// </summary>
 public partial class UtilityItemViewModel : ObservableObject
 {
@@ -27,8 +26,10 @@ public partial class UtilityItemViewModel : ObservableObject
     [ObservableProperty]
     private bool _isFocused;
 
-    [ObservableProperty]
-    private bool _isDocked;
+    /// <summary>
+    /// Whether this utility is presented in a document tab rather than in the Utility Panel.
+    /// </summary>
+    public bool IsDocked { get; set; }
 
     public UtilityItemViewModel(EditorId id, WorkspacePanelId focusIdentity)
     {

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityPanelViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityPanelViewModel.cs
@@ -4,9 +4,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 namespace Celbridge.WorkspaceUI.ViewModels;
 
 /// <summary>
-/// Owns the Utility Panel rail state: the ordered rail items, which one is selected, whether the panel the
-/// selection shows in is on screen, and whether the selected surface currently holds focus. The rail buttons
-/// bind to the per-item IsSelected, IsFocused, and IsDocked flags.
+/// Owns the Utility Panel rail state: the ordered rail items, which one the panel is showing, and whether
+/// it holds the keyboard.
 /// </summary>
 public partial class UtilityPanelViewModel : ObservableObject
 {
@@ -60,29 +59,20 @@ public partial class UtilityPanelViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Selects the rail surface with the given id and shows the accent optimistically until focus settles on it.
+    /// Makes the utility with the given id the one the panel is showing. Pass awaitFocus when the surface is
+    /// about to take the keyboard, so it counts as focused until focus settles on it.
     /// </summary>
-    public void SelectUtility(EditorId id)
+    public void SelectUtility(EditorId id, bool awaitFocus = true)
     {
         _selectedUtilityId = id;
-        _awaitingSelectionFocus = true;
+        _awaitingSelectionFocus = awaitFocus;
         RefreshItemStates();
     }
 
     /// <summary>
-    /// Reports whether the Utility Panel is on screen. No rail button is marked while the panel is collapsed,
-    /// because the selection has no surface to point at, but the selection itself is kept for the next reveal.
-    /// </summary>
-    public void SetPanelVisible(bool isVisible)
-    {
-        _isPanelVisible = isVisible;
-        RefreshItemStates();
-    }
-
-    /// <summary>
-    /// Reports the currently focused workspace panel so the accent can reflect real focus. While awaiting the
-    /// selection's focus, a report for a different panel is ignored (the transient switch bounce). A report for
-    /// the selected surface settles the wait.
+    /// Reports which workspace panel currently holds focus. While awaiting a selection's focus, a report for
+    /// a different panel is ignored (the transient switch bounce); a report for the selected surface settles
+    /// the wait.
     /// </summary>
     public void ReconcileFocus(WorkspacePanelId focusedPanel)
     {
@@ -98,7 +88,7 @@ public partial class UtilityPanelViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Sets whether the utility with the given id is docked as a document, which dims its rail button.
+    /// Sets whether the utility with the given id is presented in a document tab rather than by this panel.
     /// </summary>
     public void SetDocked(EditorId id, bool isDocked)
     {
@@ -106,7 +96,17 @@ public partial class UtilityPanelViewModel : ObservableObject
         if (item is not null)
         {
             item.IsDocked = isDocked;
+            RefreshItemStates();
         }
+    }
+
+    /// <summary>
+    /// Sets whether the Utility Panel is on screen.
+    /// </summary>
+    public void SetPanelVisible(bool isVisible)
+    {
+        _isPanelVisible = isVisible;
+        RefreshItemStates();
     }
 
     private UtilityItemViewModel? FindItem(EditorId id)
@@ -131,7 +131,7 @@ public partial class UtilityPanelViewModel : ObservableObject
         }
     }
 
-    // The selected surface counts as focused when we are optimistically awaiting its focus, or when the real
+    // The shown utility counts as focused when we are optimistically awaiting its focus, or when the real
     // focused panel matches its identity.
     private bool SelectedSurfaceHasFocus
     {
@@ -154,7 +154,12 @@ public partial class UtilityPanelViewModel : ObservableObject
 
         foreach (var item in _items)
         {
-            item.IsSelected = _isPanelVisible && item.Id == _selectedUtilityId;
+            // A docked utility is presented in a document tab rather than by this panel, so the panel's marks
+            // are not its to carry.
+            item.IsSelected = _isPanelVisible
+                && !item.IsDocked
+                && item.Id == _selectedUtilityId;
+
             item.IsFocused = item.IsSelected && surfaceHasFocus;
         }
     }

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityPanelViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityPanelViewModel.cs
@@ -4,9 +4,9 @@ using CommunityToolkit.Mvvm.ComponentModel;
 namespace Celbridge.WorkspaceUI.ViewModels;
 
 /// <summary>
-/// Owns the Utility Panel rail state: the ordered rail items, which one is selected, and whether the selected
-/// surface currently holds focus. The rail buttons bind to the per-item IsSelected, IsFocused, and IsDocked
-/// flags.
+/// Owns the Utility Panel rail state: the ordered rail items, which one is selected, whether the panel the
+/// selection shows in is on screen, and whether the selected surface currently holds focus. The rail buttons
+/// bind to the per-item IsSelected, IsFocused, and IsDocked flags.
 /// </summary>
 public partial class UtilityPanelViewModel : ObservableObject
 {
@@ -14,6 +14,7 @@ public partial class UtilityPanelViewModel : ObservableObject
 
     private EditorId _selectedUtilityId = EditorId.Empty;
     private WorkspacePanelId _focusedPanel = WorkspacePanelId.None;
+    private bool _isPanelVisible = true;
 
     // True from a selection until focus lands on the selected surface. While it is true the accent is shown
     // optimistically and focus reports for other panels are ignored, which suppresses the transient bounce as
@@ -65,6 +66,16 @@ public partial class UtilityPanelViewModel : ObservableObject
     {
         _selectedUtilityId = id;
         _awaitingSelectionFocus = true;
+        RefreshItemStates();
+    }
+
+    /// <summary>
+    /// Reports whether the Utility Panel is on screen. No rail button is marked while the panel is collapsed,
+    /// because the selection has no surface to point at, but the selection itself is kept for the next reveal.
+    /// </summary>
+    public void SetPanelVisible(bool isVisible)
+    {
+        _isPanelVisible = isVisible;
         RefreshItemStates();
     }
 
@@ -143,7 +154,7 @@ public partial class UtilityPanelViewModel : ObservableObject
 
         foreach (var item in _items)
         {
-            item.IsSelected = item.Id == _selectedUtilityId;
+            item.IsSelected = _isPanelVisible && item.Id == _selectedUtilityId;
             item.IsFocused = item.IsSelected && surfaceHasFocus;
         }
     }

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityPanelViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/UtilityPanelViewModel.cs
@@ -71,7 +71,7 @@ public partial class UtilityPanelViewModel : ObservableObject
 
     /// <summary>
     /// Reports which workspace panel currently holds focus. While awaiting a selection's focus, a report for
-    /// a different panel is ignored (the transient switch bounce); a report for the selected surface settles
+    /// a different panel is ignored (the transient switch bounce). A report for the selected surface settles
     /// the wait.
     /// </summary>
     public void ReconcileFocus(WorkspacePanelId focusedPanel)

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityButton.xaml
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityButton.xaml
@@ -20,15 +20,14 @@
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SelectedUnfocused">
-                    <!-- Selected but the utility panel is unfocused: a neutral fill, still reading as the
-                         surface on screen. -->
+                    <!-- The utility the panel is showing, without the keyboard: a neutral fill. -->
                     <VisualState.Setters>
                         <Setter Target="ButtonFill.Background" Value="{ThemeResource ButtonActiveBackgroundBrush}" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SelectedFocused">
-                    <!-- Selected and focused: the accent fills the button, with the glyph in the tone chosen
-                         to read against it. ThemeResource keeps both correct across a theme switch. -->
+                    <!-- Holding the keyboard: the accent fills the button, with the glyph in the tone
+                         chosen to read against it. -->
                     <VisualState.Setters>
                         <Setter Target="ButtonFill.Background" Value="{ThemeResource AccentBrush}" />
                         <Setter Target="IconElement.Foreground" Value="{ThemeResource AccentTextBrush}" />
@@ -46,18 +45,6 @@
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Background="Transparent"
-                IsHitTestVisible="False" />
-
-        <!-- Attention flash overlay, pulsed to the accent color by FlashAttention (e.g. when this utility is
-             undocked and the button becomes available again). Behind the icon and not hit-testable. -->
-        <Border x:Name="AttentionOverlay"
-                Width="32"
-                Height="32"
-                CornerRadius="{StaticResource IconButtonCornerRadius}"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                Background="{ThemeResource AccentBrush}"
-                Opacity="0"
                 IsHitTestVisible="False" />
 
         <!-- Click target over the whole cell, so the channel either side of the button stays clickable. Its

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityButton.xaml
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityButton.xaml
@@ -47,6 +47,18 @@
                 Background="Transparent"
                 IsHitTestVisible="False" />
 
+        <!-- Attention flash overlay, pulsed to the accent color by FlashAttention. Over the fill and under the
+             glyph, and not hit-testable. -->
+        <Border x:Name="AttentionOverlay"
+                Width="32"
+                Height="32"
+                CornerRadius="{StaticResource IconButtonCornerRadius}"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Background="{ThemeResource AccentBrush}"
+                Opacity="0"
+                IsHitTestVisible="False" />
+
         <!-- Click target over the whole cell, so the channel either side of the button stays clickable. Its
              own fills are cleared to transparent because ButtonFill draws every state. -->
         <Button x:Name="ButtonElement"

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityButton.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityButton.xaml.cs
@@ -34,8 +34,7 @@ public sealed partial class UtilityButton : UserControl
     }
 
     /// <summary>
-    /// Fills the button with a neutral tone to show that the Utility Panel holds this utility. Driven by the
-    /// rail's state, not by the button's own click.
+    /// Fills the button with a neutral tone to show that the Utility Panel holds this utility.
     /// </summary>
     public bool IsSelected
     {

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityButton.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityButton.xaml.cs
@@ -1,22 +1,12 @@
 using Celbridge.UserInterface;
-using Celbridge.UserInterface.Helpers;
-using Microsoft.UI.Xaml.Media.Animation;
 
 namespace Celbridge.WorkspaceUI.Views.Controls;
 
 /// <summary>
-/// A single icon button in the Utility Panel rail. Mouse-driven and not focusable by design: clicking it
-/// raises Click, and the selection indicator is driven by the bound IsSelected and IsFocused state, independent
-/// of the click.
+/// A single icon button in the Utility Rail.
 /// </summary>
 public sealed partial class UtilityButton : UserControl
 {
-    // Icon opacity while the utility is docked, giving the button a disabled look while it stays clickable.
-    private const double DockedIconOpacity = 0.4;
-
-    // The currently running attention flash, if any. Kept so a repeated flash restarts cleanly.
-    private Storyboard? _attentionStoryboard;
-
     // Whether the pointer is over the cell. Combines with the selection inputs to pick the visual state.
     private bool _isPointerOver;
 
@@ -34,12 +24,6 @@ public sealed partial class UtilityButton : UserControl
         typeof(UtilityButton),
         new PropertyMetadata(false, OnSelectionStateChanged));
 
-    public static readonly DependencyProperty IsDockedProperty = DependencyProperty.Register(
-        nameof(IsDocked),
-        typeof(bool),
-        typeof(UtilityButton),
-        new PropertyMetadata(false, OnIsDockedChanged));
-
     public UtilityButton()
     {
         this.InitializeComponent();
@@ -50,8 +34,8 @@ public sealed partial class UtilityButton : UserControl
     }
 
     /// <summary>
-    /// Shows the selection indicator when true. Reflects the currently shown surface, driven by the rail's
-    /// selection state, not by the button's own click.
+    /// Fills the button with a neutral tone to show that the Utility Panel holds this utility. Driven by the
+    /// rail's state, not by the button's own click.
     /// </summary>
     public bool IsSelected
     {
@@ -60,24 +44,13 @@ public sealed partial class UtilityButton : UserControl
     }
 
     /// <summary>
-    /// Fills the button with the accent color to show that the shown utility has focus, and with a neutral
-    /// tone when it does not. Only meaningful while IsSelected is true.
+    /// Deepens the fill to the accent color to show that the keyboard is in the utility the panel is showing.
+    /// A refinement of IsSelected, so it has no effect on its own.
     /// </summary>
     public bool IsFocused
     {
         get => (bool)GetValue(IsFocusedProperty);
         set => SetValue(IsFocusedProperty, value);
-    }
-
-    /// <summary>
-    /// Dims the button to a disabled-looking state while its utility is docked (presented in a document tab),
-    /// reflecting that clicking it will not change the shown panel surface. The button stays interactive: a
-    /// click activates the utility's document tab.
-    /// </summary>
-    public bool IsDocked
-    {
-        get => (bool)GetValue(IsDockedProperty);
-        set => SetValue(IsDockedProperty, value);
     }
 
     public void SetIcon(IconSymbol symbol)
@@ -110,25 +83,9 @@ public sealed partial class UtilityButton : UserControl
         IssuePip.Visibility = isVisible ? Visibility.Visible : Visibility.Collapsed;
     }
 
-    /// <summary>
-    /// Briefly pulses the button to the accent color to draw the user's attention to it, then fades back out.
-    /// Used to signal that the utility's rail button has become available again after an undock.
-    /// </summary>
-    public void FlashAttention()
-    {
-        _attentionStoryboard?.Stop();
-        _attentionStoryboard = AttentionFlash.Play(AttentionOverlay);
-    }
-
     private static void OnSelectionStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         ((UtilityButton)d).UpdateSelectionVisualState();
-    }
-
-    private static void OnIsDockedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        var button = (UtilityButton)d;
-        button.IconElement.Opacity = (bool)e.NewValue ? DockedIconOpacity : 1.0;
     }
 
     private void UpdateSelectionVisualState()

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityButton.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityButton.xaml.cs
@@ -1,4 +1,6 @@
 using Celbridge.UserInterface;
+using Celbridge.UserInterface.Helpers;
+using Microsoft.UI.Xaml.Media.Animation;
 
 namespace Celbridge.WorkspaceUI.Views.Controls;
 
@@ -9,6 +11,8 @@ public sealed partial class UtilityButton : UserControl
 {
     // Whether the pointer is over the cell. Combines with the selection inputs to pick the visual state.
     private bool _isPointerOver;
+
+    private Storyboard? _attentionStoryboard;
 
     public event EventHandler<RoutedEventArgs>? Click;
 
@@ -80,6 +84,15 @@ public sealed partial class UtilityButton : UserControl
     public void SetIssuePipVisible(bool isVisible)
     {
         IssuePip.Visibility = isVisible ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    /// <summary>
+    /// Briefly pulses the button with the accent color, then fades it back out.
+    /// </summary>
+    public void FlashAttention()
+    {
+        _attentionStoryboard?.Stop();
+        _attentionStoryboard = AttentionFlash.Play(AttentionOverlay);
     }
 
     private static void OnSelectionStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityRail.xaml
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityRail.xaml
@@ -1,0 +1,44 @@
+<UserControl
+    x:Class="Celbridge.WorkspaceUI.Views.Controls.UtilityRail"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ui="using:Celbridge.UserInterface"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+
+    <!-- A custom, non-focusable icon strip, deliberately not a NavigationView. It stays on the chrome field,
+         so whatever sits beside it reads as carved out. The buttons are built by the Utility Panel, which
+         owns the rail's state, so this control holds the groups and nothing else. -->
+    <Grid x:Name="LayoutRoot"
+          Background="{ThemeResource ChromeBackgroundBrush}">
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <!-- Absorbs the height between the two groups. It collapses to nothing before the groups
+                 overlap, so a short window leaves them meeting rather than drawn on top of each other. -->
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0"
+                    Orientation="Vertical"
+                    ui:FocusTracking.PreservePanelFocus="True">
+
+            <StackPanel x:Name="UtilityItems" Orientation="Vertical" />
+
+            <!-- Launchers sit just below the utilities, set apart by a gap but still grouped with them for
+                 discoverability. They open a document rather than selecting a surface, so they are not rail
+                 items and carry no selection or focus state. -->
+            <StackPanel x:Name="LauncherItems"
+                        Orientation="Vertical"
+                        Margin="0,16,0,0" />
+        </StackPanel>
+
+        <!-- The community links, built from the link catalog. Pinned to the bottom of the rail, away from the
+             surface buttons above: these open a document elsewhere in the layout rather than selecting the
+             surface beside the rail. -->
+        <StackPanel x:Name="CommunityItems"
+                    Grid.Row="2"
+                    Orientation="Vertical"
+                    ui:FocusTracking.PreservePanelFocus="True" />
+    </Grid>
+</UserControl>

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityRail.xaml
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityRail.xaml
@@ -5,16 +5,14 @@
     xmlns:ui="using:Celbridge.UserInterface"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
 
-    <!-- A custom, non-focusable icon strip, deliberately not a NavigationView. It stays on the chrome field,
-         so whatever sits beside it reads as carved out. The buttons are built by the Utility Panel, which
-         owns the rail's state, so this control holds the groups and nothing else. -->
+    <!-- A custom, non-focusable icon strip. It stays on the chrome field, so whatever sits beside it reads
+         as carved out. This control holds the button groups only. -->
     <Grid x:Name="LayoutRoot"
           Background="{ThemeResource ChromeBackgroundBrush}">
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <!-- Absorbs the height between the two groups. It collapses to nothing before the groups
-                 overlap, so a short window leaves them meeting rather than drawn on top of each other. -->
+            <!-- Absorbs the height between the two groups. -->
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -25,17 +23,15 @@
 
             <StackPanel x:Name="UtilityItems" Orientation="Vertical" />
 
-            <!-- Launchers sit just below the utilities, set apart by a gap but still grouped with them for
-                 discoverability. They open a document rather than selecting a surface, so they are not rail
-                 items and carry no selection or focus state. -->
+            <!-- Launchers sit just below the utilities, set apart by a gap. They open a document rather than
+                 selecting a surface, so they carry no selection or focus state. -->
             <StackPanel x:Name="LauncherItems"
                         Orientation="Vertical"
                         Margin="0,16,0,0" />
         </StackPanel>
 
-        <!-- The community links, built from the link catalog. Pinned to the bottom of the rail, away from the
-             surface buttons above: these open a document elsewhere in the layout rather than selecting the
-             surface beside the rail. -->
+        <!-- The community links, pinned to the bottom of the rail. They open a document rather than
+             selecting a surface. -->
         <StackPanel x:Name="CommunityItems"
                     Grid.Row="2"
                     Orientation="Vertical"

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityRail.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityRail.xaml.cs
@@ -2,8 +2,7 @@ namespace Celbridge.WorkspaceUI.Views.Controls;
 
 /// <summary>
 /// The icon strip down the left of the workspace, holding the utility surface buttons, the launcher buttons
-/// below them, and the community links pinned to the bottom. It stays on screen while the Utility Panel
-/// beside it is hidden.
+/// below them, and the community links pinned to the bottom.
 /// </summary>
 public sealed partial class UtilityRail : UserControl
 {
@@ -11,8 +10,7 @@ public sealed partial class UtilityRail : UserControl
     {
         this.InitializeComponent();
 
-        // The rail is a fixed band rather than a resizable surface, so it carries its own width instead of
-        // taking one from the column it is hosted in.
+        // The rail sizes itself, so the column hosting it does not set a width.
         Width = WorkspaceConstants.UtilityRailWidth;
     }
 

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityRail.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityRail.xaml.cs
@@ -2,8 +2,8 @@ namespace Celbridge.WorkspaceUI.Views.Controls;
 
 /// <summary>
 /// The icon strip down the left of the workspace, holding the utility surface buttons, the launcher buttons
-/// below them, and the community links pinned to the bottom. It stays on screen while the Utility Panel beside
-/// it is hidden, so a collapsed panel is always one click from coming back.
+/// below them, and the community links pinned to the bottom. It stays on screen while the Utility Panel
+/// beside it is hidden.
 /// </summary>
 public sealed partial class UtilityRail : UserControl
 {

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityRail.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/Controls/UtilityRail.xaml.cs
@@ -1,0 +1,50 @@
+namespace Celbridge.WorkspaceUI.Views.Controls;
+
+/// <summary>
+/// The icon strip down the left of the workspace, holding the utility surface buttons, the launcher buttons
+/// below them, and the community links pinned to the bottom. It stays on screen while the Utility Panel beside
+/// it is hidden, so a collapsed panel is always one click from coming back.
+/// </summary>
+public sealed partial class UtilityRail : UserControl
+{
+    public UtilityRail()
+    {
+        this.InitializeComponent();
+
+        // The rail is a fixed band rather than a resizable surface, so it carries its own width instead of
+        // taking one from the column it is hosted in.
+        Width = WorkspaceConstants.UtilityRailWidth;
+    }
+
+    /// <summary>
+    /// Appends a button that selects a utility surface in the Utility Panel.
+    /// </summary>
+    public void AddUtilityButton(UtilityButton button)
+    {
+        UtilityItems.Children.Add(button);
+    }
+
+    /// <summary>
+    /// Removes a utility surface button. A no-op when the button is not on the rail.
+    /// </summary>
+    public void RemoveUtilityButton(UtilityButton button)
+    {
+        UtilityItems.Children.Remove(button);
+    }
+
+    /// <summary>
+    /// Appends a button that opens a document rather than selecting a utility surface.
+    /// </summary>
+    public void AddLauncherButton(UtilityButton button)
+    {
+        LauncherItems.Children.Add(button);
+    }
+
+    /// <summary>
+    /// Appends a community link button to the group pinned at the bottom of the rail.
+    /// </summary>
+    public void AddCommunityButton(UtilityButton button)
+    {
+        CommunityItems.Children.Add(button);
+    }
+}

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml
@@ -15,7 +15,7 @@
         <!-- The panel host controls sit above the hosted panel's FocusTracking.Panel declaration. A tree
              rebuild destroys the focused row and the platform bounces focus up onto the host, which has no
              panel ancestor and would otherwise clear panel focus to None. PreservePanelFocus keeps the
-             current panel during that transient bounce, matching the utility rail. -->
+             current panel during that bounce. -->
         <ContentControl x:Name="ExplorerPanelControl"
                         HorizontalContentAlignment="Stretch"
                         VerticalContentAlignment="Stretch"

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml
@@ -1,81 +1,29 @@
-﻿<UserControl
+<UserControl
     x:Class="Celbridge.WorkspaceUI.Views.UtilityPanel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:Celbridge.UserInterface.Views.Controls"
-    xmlns:rail="using:Celbridge.WorkspaceUI.Views.Controls"
     xmlns:ui="using:Celbridge.UserInterface"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
 
-    <Grid x:Name="LayoutRoot">
-        <Grid.ColumnDefinitions>
-            <!-- Sized from WorkspaceConstants in code-behind, so the rail width the panel's minimum composes
-                 from and the rail width it draws are the same value. -->
-            <ColumnDefinition x:Name="RailColumn"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
-
-        <!-- Utility rail: a custom, non-focusable icon strip, deliberately not a NavigationView. It stays on
-             the chrome field, so the panel beside it reads as carved out. -->
-        <Grid Grid.Column="0"
-              Background="{ThemeResource ChromeBackgroundBrush}">
-
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <!-- Absorbs the height between the two groups. It collapses to nothing before the groups
-                     overlap, so a short window leaves them meeting rather than drawn on top of each other. -->
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-
-            <StackPanel Grid.Row="0"
-                        Orientation="Vertical"
-                        ui:FocusTracking.PreservePanelFocus="True">
-
-                <StackPanel x:Name="RailItems" Orientation="Vertical">
-                    <rail:UtilityButton x:Name="ExplorerButton" />
-                    <rail:UtilityButton x:Name="SearchButton" />
-                </StackPanel>
-
-                <!-- Project Settings sits just below the utilities, set apart by a gap but still grouped with
-                     them for discoverability. It opens a document rather than selecting a surface, so it is
-                     not a rail item and carries no selection or focus state. -->
-                <rail:UtilityButton x:Name="ProjectSettingsButton"
-                                    Margin="0,16,0,0" />
-            </StackPanel>
-
-            <!-- The community links, built from the link catalog in code-behind. Pinned to the bottom of the
-                 rail, away from the surface buttons above: these open a document elsewhere in the layout
-                 rather than selecting the surface beside the rail. -->
-            <StackPanel x:Name="CommunityItems"
-                        Grid.Row="2"
-                        Orientation="Vertical"
+    <!-- The surface the rail selects into. Carved out of the field like a document section, so a custom utility
+         looks the same docked into a document tab. The edges and corners here are a starting point: code-behind
+         rewrites them for where the layout has put the panel. -->
+    <Grid x:Name="ContentArea"
+          Background="{ThemeResource ContentBackgroundBrush}"
+          BorderBrush="{ThemeResource PanelEdgeBrush}"
+          BorderThickness="1,1,1,0">
+        <!-- The panel host controls sit above the hosted panel's FocusTracking.Panel declaration. A tree
+             rebuild destroys the focused row and the platform bounces focus up onto the host, which has no
+             panel ancestor and would otherwise clear panel focus to None. PreservePanelFocus keeps the
+             current panel during that transient bounce, matching the utility rail. -->
+        <ContentControl x:Name="ExplorerPanelControl"
+                        HorizontalContentAlignment="Stretch"
+                        VerticalContentAlignment="Stretch"
                         ui:FocusTracking.PreservePanelFocus="True" />
-        </Grid>
-
-        <!-- Content area for the selected panel. Carved out of the field like a document section, so a custom
-             utility looks the same docked into a document tab. It meets the rail directly on the left, where
-             the gap the rail leaves around its buttons is the channel the user sees. The splitter supplies the
-             channel on the right. The bottom meets the application border and is left flush. Corners are set
-             in code-behind from PanelCornerRadius. -->
-        <Grid x:Name="ContentArea"
-              Grid.Column="1"
-              Background="{ThemeResource ContentBackgroundBrush}"
-              BorderBrush="{ThemeResource PanelEdgeBrush}"
-              BorderThickness="1,1,1,0">
-            <!-- The panel host controls sit above the hosted panel's FocusTracking.Panel declaration. A tree
-                 rebuild destroys the focused row and the platform bounces focus up onto the host, which has no
-                 panel ancestor and would otherwise clear panel focus to None. PreservePanelFocus keeps the
-                 current panel during that transient bounce, matching the utility rail above. -->
-            <ContentControl x:Name="ExplorerPanelControl"
-                            HorizontalContentAlignment="Stretch"
-                            VerticalContentAlignment="Stretch"
-                            ui:FocusTracking.PreservePanelFocus="True" />
-            <ContentControl x:Name="SearchPanelControl"
-                            HorizontalContentAlignment="Stretch"
-                            VerticalContentAlignment="Stretch"
-                            Visibility="Collapsed"
-                            ui:FocusTracking.PreservePanelFocus="True" />
-        </Grid>
+        <ContentControl x:Name="SearchPanelControl"
+                        HorizontalContentAlignment="Stretch"
+                        VerticalContentAlignment="Stretch"
+                        Visibility="Collapsed"
+                        ui:FocusTracking.PreservePanelFocus="True" />
     </Grid>
 </UserControl>

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     private readonly ICommandService _commandService;
     private readonly IProjectService _projectService;
     private readonly ILayoutService _layoutService;
+    private readonly IWorkspaceWrapper _workspaceWrapper;
 
     // The rail is hosted in a workspace column of its own, so it stays on screen while the panel is collapsed.
     // This panel still owns it: the rail holds the groups, and every button, its state and its click belong here.
@@ -119,6 +120,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         _commandService = ServiceLocator.AcquireService<ICommandService>();
         _projectService = ServiceLocator.AcquireService<IProjectService>();
         _layoutService = ServiceLocator.AcquireService<ILayoutService>();
+        _workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
 
         _rail = new UtilityRail();
         _explorerButton = new UtilityButton();
@@ -238,12 +240,6 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
             Path = new PropertyPath(nameof(UtilityItemViewModel.IsFocused)),
             Mode = BindingMode.OneWay
         });
-        button.SetBinding(UtilityButton.IsDockedProperty, new Binding
-        {
-            Source = item,
-            Path = new PropertyPath(nameof(UtilityItemViewModel.IsDocked)),
-            Mode = BindingMode.OneWay
-        });
     }
 
     private void UtilityPanel_Loaded(object sender, RoutedEventArgs e)
@@ -266,9 +262,9 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         _messengerService.Register<PackagesInitializedMessage>(this, OnPackagesInitialized);
         UpdateProjectSettingsIssuePip();
 
-        // The rail selection follows the panel's visibility, and a reveal waiting on the panel coming back
-        // claims the keyboard here. The workspace restores its visibility around this point, so it is read
-        // again rather than left at what the constructor saw.
+        // The rail marks follow the panel's visibility, and a reveal waiting on the panel coming back claims
+        // the keyboard here. The workspace restores its visibility around this point, so it is read again
+        // rather than left at what the constructor saw.
         _messengerService.Register<SurfaceVisibilityChangedMessage>(this, OnSurfaceVisibilityChanged);
         ViewModel.SetPanelVisible(_layoutService.IsUtilityPanelVisible);
     }
@@ -301,8 +297,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     // Flags the Project Settings rail button when any contribution has dropped configuration.
     private void UpdateProjectSettingsIssuePip()
     {
-        var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
-        var packageService = workspaceWrapper.WorkspaceService?.PackageService;
+        var packageService = _workspaceWrapper.WorkspaceService?.PackageService;
         var hasIssues = packageService is not null
             && packageService.GetContributionIssues().Count > 0;
 
@@ -352,8 +347,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
 
         // A lazy-load utility creates its WebView on first show. The surface is shown
         // immediately; the WebView attaches to it when initialization completes.
-        var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
-        _ = workspaceWrapper.WorkspaceService.UtilityService.EnsureUtilityInitializedAsync(utilityId);
+        _ = _workspaceWrapper.WorkspaceService.UtilityService.EnsureUtilityInitializedAsync(utilityId);
 
         // Showing a utility presents it, so a collapsed panel is brought back rather than the surface being
         // selected somewhere the user cannot see it. Focus is claimed once the reveal has been laid out,
@@ -382,15 +376,21 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     {
         bool isPanelVisible = message.SurfaceVisibility.HasFlag(WorkspaceSurface.UtilityPanel);
 
-        // The rail shows no selection while the panel it selects into is collapsed, so the accent never marks a
-        // surface that is not on screen. The selection itself is kept, so a reveal returns to it.
+        // A collapsed panel is showing nothing, so no rail item is marked. The selection is kept, so a reveal
+        // returns to it.
         ViewModel.SetPanelVisible(isPanelVisible);
+
+        // Every surface reports through this message, so one about the Bottom or Side area says nothing about
+        // a reveal still waiting on the panel. The claim is left pending until the panel is actually on screen.
+        if (!isPanelVisible)
+        {
+            return;
+        }
 
         var revealedUtilityId = _pendingRevealUtilityId;
         _pendingRevealUtilityId = EditorId.Empty;
 
-        if (!isPanelVisible
-            || revealedUtilityId.IsEmpty)
+        if (revealedUtilityId.IsEmpty)
         {
             return;
         }
@@ -408,7 +408,8 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
             });
     }
 
-    // Selects the surface in the view model (which lights the accent optimistically) and shows its content.
+    // Makes the utility the one the panel shows and shows its content. takeFocus carries the keyboard to it,
+    // and with it the optimistic accent that holds until focus settles.
     private void ShowSurface(EditorId utilityId, bool takeFocus = true)
     {
         if (!_contentControls.TryGetValue(utilityId, out var content))
@@ -416,7 +417,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
             return;
         }
 
-        ViewModel.SelectUtility(utilityId);
+        ViewModel.SelectUtility(utilityId, awaitFocus: takeFocus);
         ShowContent(utilityId, content, takeFocus);
         NotifyActiveUtilityChanged();
     }
@@ -593,19 +594,16 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         }
 
         ViewModel.SetDocked(utilityId, isDocument);
-    }
 
-    public void FlashUtility(EditorId utilityId)
-    {
-        if (!_buttons.TryGetValue(utilityId, out var button))
+        // A utility that has left for a document tab can no longer be the panel's surface, so the panel takes
+        // Explorer instead of showing an empty content host. Selected rather than presented: docking is not a
+        // reason to open a collapsed panel, and the keyboard belongs to the tab the utility just moved into.
+        if (isDocument
+            && ViewModel.SelectedUtilityId == utilityId)
         {
-            return;
+            ShowSurface(BuiltInUtilityIds.Explorer, takeFocus: false);
+            PersistSelectedUtility(BuiltInUtilityIds.Explorer.ToString());
         }
-
-        // Deferred to a low dispatcher tick so the undock reparent settles before the button pulses.
-        _ = DispatcherQueue.TryEnqueue(
-            Microsoft.UI.Dispatching.DispatcherQueuePriority.Low,
-            () => button.FlashAttention());
     }
 
     public void RestoreSelectedUtility()

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
@@ -169,7 +169,11 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         // like the community links: no rail item, no content host, no focus action.
         _projectSettingsButton.SetIcon(IconSymbol.Sliders);
         _projectSettingsButton.SetAutomationId(ProjectSettingsLandmarkId);
-        _projectSettingsButton.Click += (sender, e) => OpenProjectSettings();
+        _projectSettingsButton.Click += (sender, e) =>
+        {
+            _projectSettingsButton.FlashAttention();
+            OpenProjectSettings();
+        };
         _rail.AddLauncherButton(_projectSettingsButton);
 
         _buttons[BuiltInUtilityIds.Explorer] = _explorerButton;
@@ -212,7 +216,11 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
             railButton.SetIcon(link.Icon);
             railButton.SetAutomationId(link.LandmarkId);
 
-            railButton.Click += (sender, e) => OpenCommunityLink(link);
+            railButton.Click += (sender, e) =>
+            {
+                railButton.FlashAttention();
+                OpenCommunityLink(link);
+            };
 
             _rail.AddCommunityButton(railButton);
 
@@ -334,6 +342,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         {
             // Activate the docked utility's tab, then request an attention flash so the reveal gives visible
             // feedback even when the tab was already the active document.
+            FlashRailButton(utilityId);
             _commandService.Execute<IActivateDocumentCommand>(command => command.FileResource = documentResource);
             _messengerService.Send(new FlashDocumentMessage(documentResource));
             return;
@@ -359,6 +368,14 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
 
         ShowSurface(utilityId, takeFocus: isPanelVisible);
         PersistSelectedUtility(utilityId.ToString());
+    }
+
+    private void FlashRailButton(EditorId utilityId)
+    {
+        if (_buttons.TryGetValue(utilityId, out var railButton))
+        {
+            railButton.FlashAttention();
+        }
     }
 
     private void ShowUtilityPanel()

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
@@ -7,11 +7,9 @@ using Celbridge.Projects;
 using Celbridge.Search;
 using Celbridge.Settings;
 using Celbridge.UserInterface;
-using Celbridge.UserInterface.Helpers;
 using Celbridge.WorkspaceUI.ViewModels;
 using Celbridge.WorkspaceUI.Views.Controls;
 using Microsoft.Extensions.Localization;
-using Windows.Foundation;
 
 namespace Celbridge.WorkspaceUI.Views;
 
@@ -76,19 +74,6 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
 
     public EditorId ActiveUtilityId => ViewModel.SelectedUtilityId;
 
-    public double MinimumWidth
-    {
-        get
-        {
-            // The content area is carved out like a document section, so it composes from the same floor.
-            var contentChrome = new Size(
-                ContentArea.BorderThickness.Left + ContentArea.BorderThickness.Right,
-                ContentArea.BorderThickness.Top + ContentArea.BorderThickness.Bottom);
-
-            return WorkspaceMinimumSize.ComposeSection(contentChrome).Width;
-        }
-    }
-
     /// <summary>
     /// The rail that selects this panel's surfaces, hosted beside the panel in the workspace layout.
     /// </summary>
@@ -102,7 +87,8 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         double panelCornerRadius = (double)Application.Current.Resources["PanelCornerRadius"];
         double bottomRadius = isPresented ? panelCornerRadius : 0;
 
-        ContentArea.BorderThickness = new Thickness(1, 1, 1, isPresented ? 1 : 0);
+        double edge = WorkspaceConstants.SectionEdgeThickness;
+        ContentArea.BorderThickness = new Thickness(edge, edge, edge, isPresented ? edge : 0);
         ContentArea.CornerRadius = new CornerRadius(panelCornerRadius, panelCornerRadius, bottomRadius, bottomRadius);
     }
 

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
@@ -33,7 +33,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     private readonly IWorkspaceWrapper _workspaceWrapper;
 
     // The rail is hosted in a workspace column of its own, so it stays on screen while the panel is collapsed.
-    // This panel still owns it: the rail holds the groups, and every button, its state and its click belong here.
+    // This panel still owns it: every button, its state and its click belong here.
     private readonly UtilityRail _rail;
 
     private readonly UtilityButton _explorerButton;
@@ -262,9 +262,8 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         _messengerService.Register<PackagesInitializedMessage>(this, OnPackagesInitialized);
         UpdateProjectSettingsIssuePip();
 
-        // The rail marks follow the panel's visibility, and a reveal waiting on the panel coming back claims
-        // the keyboard here. The workspace restores its visibility around this point, so it is read again
-        // rather than left at what the constructor saw.
+        // The rail marks follow the panel's visibility. The workspace restores that visibility around this
+        // point, so it is read again here.
         _messengerService.Register<SurfaceVisibilityChangedMessage>(this, OnSurfaceVisibilityChanged);
         ViewModel.SetPanelVisible(_layoutService.IsUtilityPanelVisible);
     }
@@ -349,9 +348,8 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         // immediately; the WebView attaches to it when initialization completes.
         _ = _workspaceWrapper.WorkspaceService.UtilityService.EnsureUtilityInitializedAsync(utilityId);
 
-        // Showing a utility presents it, so a collapsed panel is brought back rather than the surface being
-        // selected somewhere the user cannot see it. Focus is claimed once the reveal has been laid out,
-        // because an off-screen surface cannot take the keyboard.
+        // Showing a utility presents it, so a collapsed panel is brought back first. Its focus claim waits
+        // for the reveal to be laid out.
         bool isPanelVisible = _layoutService.IsUtilityPanelVisible;
         if (!isPanelVisible)
         {
@@ -381,7 +379,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         ViewModel.SetPanelVisible(isPanelVisible);
 
         // Every surface reports through this message, so one about the Bottom or Side area says nothing about
-        // a reveal still waiting on the panel. The claim is left pending until the panel is actually on screen.
+        // a reveal still waiting on the panel.
         if (!isPanelVisible)
         {
             return;
@@ -595,9 +593,8 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
 
         ViewModel.SetDocked(utilityId, isDocument);
 
-        // A utility that has left for a document tab can no longer be the panel's surface, so the panel takes
-        // Explorer instead of showing an empty content host. Selected rather than presented: docking is not a
-        // reason to open a collapsed panel, and the keyboard belongs to the tab the utility just moved into.
+        // A utility that has left for a document tab can no longer be the panel's surface, so the panel falls
+        // back to Explorer. The keyboard belongs to the tab the utility just moved into.
         if (isDocument
             && ViewModel.SelectedUtilityId == utilityId)
         {

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
@@ -29,6 +29,15 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     private readonly ISpotlightRegistry _spotlightRegistry;
     private readonly ICommandService _commandService;
     private readonly IProjectService _projectService;
+    private readonly ILayoutService _layoutService;
+
+    // The rail is hosted in a workspace column of its own, so it stays on screen while the panel is collapsed.
+    // This panel still owns it: the rail holds the groups, and every button, its state and its click belong here.
+    private readonly UtilityRail _rail;
+
+    private readonly UtilityButton _explorerButton;
+    private readonly UtilityButton _searchButton;
+    private readonly UtilityButton _projectSettingsButton;
 
     // Spotlight landmark ids for the built-in rail buttons. These must match the descriptors seeded in
     // SpotlightLandmarks exactly.
@@ -55,6 +64,10 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     // the restore itself do not overwrite the saved selection before it is read.
     private bool _selectionPersistenceEnabled;
 
+    // The utility a reveal selected while the panel was collapsed. A surface off screen cannot take the
+    // keyboard, so the focus claim waits for the reveal to be laid out.
+    private EditorId _pendingRevealUtilityId = EditorId.Empty;
+
     public IExplorerPanel ExplorerPanel { get; }
     public ISearchPanel SearchPanel { get; }
 
@@ -70,11 +83,15 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
             var contentChrome = new Size(
                 ContentArea.BorderThickness.Left + ContentArea.BorderThickness.Right,
                 ContentArea.BorderThickness.Top + ContentArea.BorderThickness.Bottom);
-            double contentMinimumWidth = WorkspaceMinimumSize.ComposeSection(contentChrome).Width;
 
-            return RailColumn.Width.Value + contentMinimumWidth;
+            return WorkspaceMinimumSize.ComposeSection(contentChrome).Width;
         }
     }
+
+    /// <summary>
+    /// The rail that selects this panel's surfaces, hosted beside the panel in the workspace layout.
+    /// </summary>
+    internal UtilityRail Rail => _rail;
 
     // Whether the panel draws a bottom edge and rounded bottom corners: it does when the Bottom document
     // area runs underneath it, and meets the application border flush otherwise. Driven by the surface
@@ -94,8 +111,6 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
 
         SetBottomEdgePresented(false);
 
-        RailColumn.Width = new GridLength(WorkspaceConstants.UtilityPanelRailWidth);
-
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
         _focusService = ServiceLocator.AcquireService<IFocusService>();
         _settings = ServiceLocator.AcquireService<ISettingsService>();
@@ -103,6 +118,12 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         _spotlightRegistry = ServiceLocator.AcquireService<ISpotlightRegistry>();
         _commandService = ServiceLocator.AcquireService<ICommandService>();
         _projectService = ServiceLocator.AcquireService<IProjectService>();
+        _layoutService = ServiceLocator.AcquireService<ILayoutService>();
+
+        _rail = new UtilityRail();
+        _explorerButton = new UtilityButton();
+        _searchButton = new UtilityButton();
+        _projectSettingsButton = new UtilityButton();
 
         // Acquire panel views via DI and host them in ContentControls
         ExplorerPanel = ServiceLocator.AcquireService<IExplorerPanel>();
@@ -111,6 +132,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         SearchPanelControl.Content = SearchPanel as UIElement;
 
         ViewModel = ServiceLocator.AcquireService<UtilityPanelViewModel>();
+        ViewModel.SetPanelVisible(_layoutService.IsUtilityPanelVisible);
         DataContext = ViewModel;
 
         InitializeBuiltInButtons();
@@ -129,24 +151,27 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         var explorerItem = ViewModel.AddItem(BuiltInUtilityIds.Explorer, WorkspacePanelId.Explorer);
         var searchItem = ViewModel.AddItem(BuiltInUtilityIds.Search, WorkspacePanelId.Search);
 
-        ExplorerButton.SetIcon(IconSymbol.Folder);
-        ExplorerButton.SetAutomationId(ExplorerLandmarkId);
-        BindButton(ExplorerButton, explorerItem);
-        ExplorerButton.Click += (sender, e) => ShowUtility(BuiltInUtilityIds.Explorer);
+        _explorerButton.SetIcon(IconSymbol.Folder);
+        _explorerButton.SetAutomationId(ExplorerLandmarkId);
+        BindButton(_explorerButton, explorerItem);
+        _explorerButton.Click += (sender, e) => ShowUtility(BuiltInUtilityIds.Explorer);
+        _rail.AddUtilityButton(_explorerButton);
 
-        SearchButton.SetIcon(IconSymbol.Search);
-        SearchButton.SetAutomationId(SearchLandmarkId);
-        BindButton(SearchButton, searchItem);
-        SearchButton.Click += (sender, e) => ShowUtility(BuiltInUtilityIds.Search);
+        _searchButton.SetIcon(IconSymbol.Search);
+        _searchButton.SetAutomationId(SearchLandmarkId);
+        BindButton(_searchButton, searchItem);
+        _searchButton.Click += (sender, e) => ShowUtility(BuiltInUtilityIds.Search);
+        _rail.AddUtilityButton(_searchButton);
 
         // Project Settings opens a document rather than selecting a surface, so the button is a launcher
         // like the community links: no rail item, no content host, no focus action.
-        ProjectSettingsButton.SetIcon(IconSymbol.Sliders);
-        ProjectSettingsButton.SetAutomationId(ProjectSettingsLandmarkId);
-        ProjectSettingsButton.Click += (sender, e) => OpenProjectSettings();
+        _projectSettingsButton.SetIcon(IconSymbol.Sliders);
+        _projectSettingsButton.SetAutomationId(ProjectSettingsLandmarkId);
+        _projectSettingsButton.Click += (sender, e) => OpenProjectSettings();
+        _rail.AddLauncherButton(_projectSettingsButton);
 
-        _buttons[BuiltInUtilityIds.Explorer] = ExplorerButton;
-        _buttons[BuiltInUtilityIds.Search] = SearchButton;
+        _buttons[BuiltInUtilityIds.Explorer] = _explorerButton;
+        _buttons[BuiltInUtilityIds.Search] = _searchButton;
         _contentControls[BuiltInUtilityIds.Explorer] = ExplorerPanelControl;
         _contentControls[BuiltInUtilityIds.Search] = SearchPanelControl;
         _focusActions[BuiltInUtilityIds.Explorer] = ExplorerPanel.FocusPanel;
@@ -187,7 +212,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
 
             railButton.Click += (sender, e) => OpenCommunityLink(link);
 
-            CommunityItems.Children.Add(railButton);
+            _rail.AddCommunityButton(railButton);
 
             _communityButtons.Add(new CommunityRailButton(link, railButton));
         }
@@ -240,12 +265,19 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         // discovery pass completes.
         _messengerService.Register<PackagesInitializedMessage>(this, OnPackagesInitialized);
         UpdateProjectSettingsIssuePip();
+
+        // The rail selection follows the panel's visibility, and a reveal waiting on the panel coming back
+        // claims the keyboard here. The workspace restores its visibility around this point, so it is read
+        // again rather than left at what the constructor saw.
+        _messengerService.Register<SurfaceVisibilityChangedMessage>(this, OnSurfaceVisibilityChanged);
+        ViewModel.SetPanelVisible(_layoutService.IsUtilityPanelVisible);
     }
 
     private void UtilityPanel_Unloaded(object sender, RoutedEventArgs e)
     {
         _messengerService.Unregister<PanelFocusChangedMessage>(this);
         _messengerService.Unregister<PackagesInitializedMessage>(this);
+        _messengerService.Unregister<SurfaceVisibilityChangedMessage>(this);
         _focusService.SetPanelFocusHandler(WorkspacePanelId.Explorer, null);
         _focusService.SetPanelFocusHandler(WorkspacePanelId.Search, null);
         _focusService.SetPanelFocusHandler(WorkspacePanelId.CustomUtility, null);
@@ -274,19 +306,19 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         var hasIssues = packageService is not null
             && packageService.GetContributionIssues().Count > 0;
 
-        ProjectSettingsButton.SetIssuePipVisible(hasIssues);
+        _projectSettingsButton.SetIssuePipVisible(hasIssues);
     }
 
     private void ApplyTooltips()
     {
         var explorerTooltip = _stringLocalizer.GetString("UtilityPanel_ExplorerTooltip");
-        ExplorerButton.SetTooltip(explorerTooltip);
+        _explorerButton.SetTooltip(explorerTooltip);
 
         var searchTooltip = _stringLocalizer.GetString("UtilityPanel_SearchTooltip");
-        SearchButton.SetTooltip(searchTooltip);
+        _searchButton.SetTooltip(searchTooltip);
 
         var projectSettingsTooltip = _stringLocalizer.GetString("UtilityPanel_ProjectSettingsTooltip");
-        ProjectSettingsButton.SetTooltip(projectSettingsTooltip);
+        _projectSettingsButton.SetTooltip(projectSettingsTooltip);
 
         foreach (var communityButton in _communityButtons)
         {
@@ -323,8 +355,57 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
         _ = workspaceWrapper.WorkspaceService.UtilityService.EnsureUtilityInitializedAsync(utilityId);
 
-        ShowSurface(utilityId);
+        // Showing a utility presents it, so a collapsed panel is brought back rather than the surface being
+        // selected somewhere the user cannot see it. Focus is claimed once the reveal has been laid out,
+        // because an off-screen surface cannot take the keyboard.
+        bool isPanelVisible = _layoutService.IsUtilityPanelVisible;
+        if (!isPanelVisible)
+        {
+            _pendingRevealUtilityId = utilityId;
+            ShowUtilityPanel();
+        }
+
+        ShowSurface(utilityId, takeFocus: isPanelVisible);
         PersistSelectedUtility(utilityId.ToString());
+    }
+
+    private void ShowUtilityPanel()
+    {
+        _commandService.Execute<ISetSurfaceVisibilityCommand>(command =>
+        {
+            command.Surfaces = WorkspaceSurface.UtilityPanel;
+            command.IsVisible = true;
+        });
+    }
+
+    private void OnSurfaceVisibilityChanged(object recipient, SurfaceVisibilityChangedMessage message)
+    {
+        bool isPanelVisible = message.SurfaceVisibility.HasFlag(WorkspaceSurface.UtilityPanel);
+
+        // The rail shows no selection while the panel it selects into is collapsed, so the accent never marks a
+        // surface that is not on screen. The selection itself is kept, so a reveal returns to it.
+        ViewModel.SetPanelVisible(isPanelVisible);
+
+        var revealedUtilityId = _pendingRevealUtilityId;
+        _pendingRevealUtilityId = EditorId.Empty;
+
+        if (!isPanelVisible
+            || revealedUtilityId.IsEmpty)
+        {
+            return;
+        }
+
+        // Deferred to a low dispatcher tick so the reveal has been laid out before the surface claims the
+        // keyboard. A later selection supersedes this one, so the id is checked again on the tick.
+        _ = DispatcherQueue.TryEnqueue(
+            Microsoft.UI.Dispatching.DispatcherQueuePriority.Low,
+            () =>
+            {
+                if (ViewModel.SelectedUtilityId == revealedUtilityId)
+                {
+                    ShowSurface(revealedUtilityId);
+                }
+            });
     }
 
     // Selects the surface in the view model (which lights the accent optimistically) and shows its content.
@@ -442,9 +523,9 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
             var utilityId = utility.UtilityId;
             railButton.Click += (sender, e) => ShowUtility(utilityId);
 
-            RailItems.Children.Add(railButton);
+            _rail.AddUtilityButton(railButton);
 
-            _spotlightRegistry.RegisterLandmark(new LandmarkDescriptor(landmarkId, WorkspaceSurface.UtilityPanel));
+            _spotlightRegistry.RegisterLandmark(new LandmarkDescriptor(landmarkId, null));
 
             var contentControl = new ContentControl
             {
@@ -483,7 +564,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         foreach (var utilityId in GetCustomUtilityIds())
         {
             var railButton = _buttons[utilityId];
-            RailItems.Children.Remove(railButton);
+            _rail.RemoveUtilityButton(railButton);
 
             var contentControl = _contentControls[utilityId];
             contentControl.Content = null;

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml
@@ -17,6 +17,8 @@
     <!-- The resizable tracks carry no size here. Their defaults come from WorkspaceConstants and their
          minimums are composed from the document floor, both applied in code-behind. -->
     <Grid.ColumnDefinitions>
+      <!-- Sized by the rail that sits in it, which carries its own fixed width. -->
+      <ColumnDefinition Width="Auto"/>
       <ColumnDefinition x:Name="UtilityPanelColumn"/>
       <!-- Sized by the splitter that sits in it, and collapses with it when the Utility Panel is hidden. -->
       <ColumnDefinition Width="Auto"/>
@@ -33,10 +35,18 @@
       <RowDefinition x:Name="BottomAreaRow"/>
     </Grid.RowDefinitions>
 
+    <!-- The rail runs the full height down the left of the workspace and is never spanned by the Bottom area,
+         however that area is aligned. It meets whatever sits beside it directly, with no gutter column
+         between. -->
+    <Grid x:Name="UtilityRailHost"
+          Grid.Row="0"
+          Grid.RowSpan="3"
+          Grid.Column="0"/>
+
     <Grid x:Name="UtilityPanelHost"
           Grid.Row="0"
           Grid.RowSpan="3"
-          Grid.Column="0"
+          Grid.Column="1"
           layout:WorkspaceLayout.Surface="UtilityPanel"
           AutomationProperties.AutomationId="explorer-panel"
           Background="{ThemeResource ChromeBackgroundBrush}"/>
@@ -46,14 +56,14 @@
     <controls:Splitter x:Name="UtilityPanelSplitter"
                        Grid.Row="0"
                        Grid.RowSpan="3"
-                       Grid.Column="1"
+                       Grid.Column="2"
                        Orientation="Vertical"/>
 
     <!-- The document-area grids carry the Documents focus-tracking identity, which is why it is declared
          here per host and not on an ancestor: the Utility Panel shares this tree and keeps its own. -->
     <Grid x:Name="MainAreaGrid"
           Grid.Row="0"
-          Grid.Column="2"
+          Grid.Column="3"
           ui:FocusTracking.Panel="Documents"
           AutomationProperties.AutomationId="main-area"/>
 
@@ -61,12 +71,12 @@
          accent line on hover and drag. -->
     <controls:Splitter x:Name="BottomAreaSplitter"
                        Grid.Row="1"
-                       Grid.Column="2"
+                       Grid.Column="3"
                        Orientation="Horizontal"/>
 
     <Grid x:Name="BottomAreaGrid"
           Grid.Row="2"
-          Grid.Column="2"
+          Grid.Column="3"
           layout:WorkspaceLayout.Surface="BottomArea"
           ui:FocusTracking.Panel="Documents"
           AutomationProperties.AutomationId="bottom-area"/>
@@ -74,13 +84,13 @@
     <controls:Splitter x:Name="SideAreaSplitter"
                        Grid.Row="0"
                        Grid.RowSpan="3"
-                       Grid.Column="3"
+                       Grid.Column="4"
                        Orientation="Vertical"/>
 
     <Grid x:Name="SideAreaGrid"
           Grid.Row="0"
           Grid.RowSpan="3"
-          Grid.Column="4"
+          Grid.Column="5"
           layout:WorkspaceLayout.Surface="SideArea"
           ui:FocusTracking.Panel="Documents"
           AutomationProperties.AutomationId="side-area"/>

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml.cs
@@ -284,7 +284,7 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
             MainAreaMinimumSize: GetAreaMinimumSize(DocumentArea.Main),
             BottomAreaMinimumSize: GetAreaMinimumSize(DocumentArea.Bottom),
             SideAreaMinimumSize: GetAreaMinimumSize(DocumentArea.Side),
-            UtilityPanelMinimumWidth: _utilityPanel.MinimumWidth,
+            UtilityPanelMinimumWidth: WorkspaceMinimumSize.ComposeUtilityPanelWidth(),
             UtilityRailWidth: WorkspaceConstants.UtilityRailWidth,
             GutterSize: GutterSize,
             WorkspaceExtent: new Size(ActualWidth, ActualHeight),

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml.cs
@@ -7,18 +7,20 @@ using Windows.Foundation;
 namespace Celbridge.WorkspaceUI.Views;
 
 /// <summary>
-/// Lays out the workspace surfaces: the Utility Panel it hosts, the three document-area grids, and the
-/// splitters that size them. This control owns surface geometry only; the presentation is pushed in as a
-/// snapshot, and the sections inside the area grids are managed by the documents panel. Every floor and
-/// every maximum it applies is composed by WorkspaceSurfaceComposer.
+/// Lays out the workspace surfaces: the Utility Rail and Utility Panel it hosts, the three document-area
+/// grids, and the splitters that size them. This control owns surface geometry only; the presentation is
+/// pushed in as a snapshot, and the sections inside the area grids are managed by the documents panel. Every
+/// floor and every maximum it applies is composed by WorkspaceSurfaceComposer.
 /// </summary>
 public sealed partial class WorkspaceSurfaceContainer : UserControl
 {
-    // Positions in the workspace grid that the Bottom area's alignment moves things between. A surface
-    // beside the document areas runs the full height of the grid, and shortens to the Main area row alone
-    // once the Bottom area runs underneath it.
-    private const int UtilityPanelColumnIndex = 0;
-    private const int MainAreaColumnIndex = 2;
+    // Positions in the workspace grid: the tracks each surface sits in, which are both what the Bottom area's
+    // alignment moves things between and what the splitters resize. A surface beside the document areas runs
+    // the full height of the grid, and shortens to the Main area row alone once the Bottom area runs
+    // underneath it.
+    private const int UtilityPanelColumnIndex = 1;
+    private const int MainAreaColumnIndex = 3;
+    private const int SideAreaColumnIndex = 5;
     private const int BottomAreaRowIndex = 2;
     private const int FullHeightRowSpan = 3;
     private const int AboveBottomAreaRowSpan = 1;
@@ -34,6 +36,7 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
         IsBottomAreaPresented: true,
         IsSideAreaPresented: true,
         IsUtilityPanelPresented: true,
+        IsUtilityRailPresented: true,
         BottomAreaSpansUtilityPanel: false,
         BottomAreaSpansSideArea: false);
 
@@ -83,10 +86,12 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
         BottomAreaRow.Height = new GridLength(WorkspaceConstants.BottomAreaHeight);
 
         // The Utility Panel is part of the workspace layout rather than a sibling of it, so this
-        // container creates and hosts it.
+        // container creates and hosts it. Its rail is hosted in a column of its own, which is what keeps the
+        // rail on screen while the panel is collapsed.
         var utilityPanel = ServiceLocator.AcquireService<IUtilityPanel>();
         _utilityPanel = (UtilityPanel)utilityPanel;
         UtilityPanelHost.Children.Add(_utilityPanel);
+        UtilityRailHost.Children.Add(_utilityPanel.Rail);
 
         InitializeSurfaceSplitters();
 
@@ -141,6 +146,7 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
         BottomAreaGrid.Visibility = isBottomPresented ? Visibility.Visible : Visibility.Collapsed;
         SideAreaGrid.Visibility = isSidePresented ? Visibility.Visible : Visibility.Collapsed;
         UtilityPanelHost.Visibility = isUtilityPanelPresented ? Visibility.Visible : Visibility.Collapsed;
+        UtilityRailHost.Visibility = presentation.IsUtilityRailPresented ? Visibility.Visible : Visibility.Collapsed;
 
         // A splitter only earns its place between two presented surfaces.
         bool showBottomSplitter = isMainPresented && isBottomPresented;
@@ -282,6 +288,7 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
             BottomAreaMinimumSize: GetAreaMinimumSize(DocumentArea.Bottom),
             SideAreaMinimumSize: GetAreaMinimumSize(DocumentArea.Side),
             UtilityPanelMinimumWidth: _utilityPanel.MinimumWidth,
+            UtilityRailWidth: WorkspaceConstants.UtilityRailWidth,
             GutterSize: GutterSize,
             WorkspaceExtent: new Size(ActualWidth, ActualHeight),
             UtilityPanelWidth: ResolveTrackWidth(UtilityPanelColumn.Width),
@@ -339,6 +346,8 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
         Grid.SetColumn(BottomAreaSplitter, bottomColumn);
         Grid.SetColumnSpan(BottomAreaSplitter, bottomColumnSpan);
 
+        // The rail is not spanned however the Bottom area is aligned, so it keeps its full-height row span and
+        // its bottom group stays pinned to the bottom of the window.
         int utilityPanelRowSpan = spansUtilityPanel ? AboveBottomAreaRowSpan : FullHeightRowSpan;
         Grid.SetRowSpan(UtilityPanelHost, utilityPanelRowSpan);
         Grid.SetRowSpan(UtilityPanelSplitter, utilityPanelRowSpan);
@@ -352,9 +361,8 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
         _utilityPanel.SetBottomEdgePresented(spansUtilityPanel);
     }
 
-    // The tracks the splitters resize are indexed into the one workspace grid. Bottom and Side are
-    // measured from the far edge, so their deltas are inverted; the Utility Panel is measured from the
-    // near edge.
+    // Bottom and Side are measured from the far edge, so their deltas are inverted; the Utility Panel is
+    // measured from the near edge.
     private void InitializeSurfaceSplitters()
     {
         // Each splitter is held between its surface's own floor and the space the arrangement leaves it, the
@@ -363,7 +371,7 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
         _utilityPanelSplitterHelper = new SplitterHelper(
             RootGrid,
             GridResizeMode.Columns,
-            0,
+            UtilityPanelColumnIndex,
             minSizeFunc: () => CreateComposer().UtilityPanelMinimumWidth,
             maxSizeFunc: () => CreateComposer().AvailableUtilityPanelWidth);
 
@@ -381,7 +389,7 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
         _sideAreaSplitterHelper = new SplitterHelper(
             RootGrid,
             GridResizeMode.Columns,
-            4,
+            SideAreaColumnIndex,
             minSizeFunc: () => CreateComposer().SideAreaMinimumWidth,
             invertDelta: true,
             maxSizeFunc: () => CreateComposer().AvailableSideAreaWidth);

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml.cs
@@ -8,15 +8,13 @@ namespace Celbridge.WorkspaceUI.Views;
 
 /// <summary>
 /// Lays out the workspace surfaces: the Utility Rail and Utility Panel it hosts, the three document-area
-/// grids, and the splitters that size them. This control owns surface geometry only. The presentation is
-/// pushed in as a snapshot, and the sections inside the area grids are managed by the documents panel. Every
-/// floor and every maximum it applies is composed by WorkspaceSurfaceComposer.
+/// grids, and the splitters that size them. This control owns surface geometry only, with the presentation
+/// pushed in as a snapshot.
 /// </summary>
 public sealed partial class WorkspaceSurfaceContainer : UserControl
 {
-    // Positions in the workspace grid: the tracks each surface sits in, which are both what the Bottom area's
-    // alignment moves things between and what the splitters resize. A surface beside the document areas runs
-    // the full height of the grid, and shortens to the Main area row alone once the Bottom area runs
+    // Positions in the workspace grid: the tracks each surface sits in. A surface beside the document areas
+    // runs the full height of the grid, and shortens to the Main area row alone once the Bottom area runs
     // underneath it.
     private const int UtilityPanelColumnIndex = 1;
     private const int MainAreaColumnIndex = 3;
@@ -85,9 +83,8 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
         SideAreaColumn.Width = new GridLength(WorkspaceConstants.SideAreaWidth);
         BottomAreaRow.Height = new GridLength(WorkspaceConstants.BottomAreaHeight);
 
-        // The Utility Panel is part of the workspace layout rather than a sibling of it, so this
-        // container creates and hosts it. Its rail is hosted in a column of its own, which is what keeps the
-        // rail on screen while the panel is collapsed.
+        // This container creates and hosts the Utility Panel. Its rail is hosted in a column of its own,
+        // which keeps the rail on screen while the panel is collapsed.
         var utilityPanel = ServiceLocator.AcquireService<IUtilityPanel>();
         _utilityPanel = (UtilityPanel)utilityPanel;
         UtilityPanelHost.Children.Add(_utilityPanel);
@@ -346,8 +343,6 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
         Grid.SetColumn(BottomAreaSplitter, bottomColumn);
         Grid.SetColumnSpan(BottomAreaSplitter, bottomColumnSpan);
 
-        // The rail is not spanned however the Bottom area is aligned, so it keeps its full-height row span and
-        // its bottom group stays pinned to the bottom of the window.
         int utilityPanelRowSpan = spansUtilityPanel ? AboveBottomAreaRowSpan : FullHeightRowSpan;
         Grid.SetRowSpan(UtilityPanelHost, utilityPanelRowSpan);
         Grid.SetRowSpan(UtilityPanelSplitter, utilityPanelRowSpan);

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml.cs
@@ -8,7 +8,7 @@ namespace Celbridge.WorkspaceUI.Views;
 
 /// <summary>
 /// Lays out the workspace surfaces: the Utility Rail and Utility Panel it hosts, the three document-area
-/// grids, and the splitters that size them. This control owns surface geometry only; the presentation is
+/// grids, and the splitters that size them. This control owns surface geometry only. The presentation is
 /// pushed in as a snapshot, and the sections inside the area grids are managed by the documents panel. Every
 /// floor and every maximum it applies is composed by WorkspaceSurfaceComposer.
 /// </summary>
@@ -361,7 +361,7 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
         _utilityPanel.SetBottomEdgePresented(spansUtilityPanel);
     }
 
-    // Bottom and Side are measured from the far edge, so their deltas are inverted; the Utility Panel is
+    // Bottom and Side are measured from the far edge, so their deltas are inverted. The Utility Panel is
     // measured from the near edge.
     private void InitializeSurfaceSplitters()
     {


### PR DESCRIPTION
This pull request focuses on refining the conventions and implementation for reviewing and fixing code comments added or rewritten in a branch, specifically enforcing the Celbridge comment standards. The changes update both the documentation and supporting scripts to clarify scope, improve automation, and ensure that only relevant new or modified comments are reviewed. Additionally, there are targeted updates to naming, documentation, and UI behavior to improve clarity and consistency across the codebase.

**Comment Review Process and Automation Improvements:**

* Updated `.claude/skills/fix-branch-comments/SKILL.md` to clarify that only comments added or rewritten by the branch are reviewed, not all comments in touched files. The process is now more automated, using a new script to extract relevant comment lines, and includes clearer step-by-step instructions for running and reporting the review. The conventions section has been refined for clarity and precision.
* Added `.claude/skills/fix-branch-comments/extract-comments.sh`, a shell script that programmatically emits every comment line added or rewritten by the branch, supporting the new review workflow.

**Naming and Documentation Consistency:**

* Renamed `UtilityPanelRailWidth` to `UtilityRailWidth` in `WorkspaceConstants` and updated related documentation and references for clarity and consistency. [[1]](diffhunk://#diff-f261fe95d7a3a5642c5814942f0fe5ec51a68cdd4921c1d550366c17e55a72d9L35-R39) [[2]](diffhunk://#diff-0f838b381ef101f502c99592fcf21061f7fb90451bf028bdb41325c68f480d71L142-R142)
* Updated summaries and parameter descriptions in `IUtilityPanel` to clarify method behaviors, improve contract documentation, and remove obsolete or redundant members. [[1]](diffhunk://#diff-1f4bc4c0311b1f888d657f2dac2e7a816657e3692ef713a3ce2f21b8f9855f0bL55-R58) [[2]](diffhunk://#diff-1f4bc4c0311b1f888d657f2dac2e7a816657e3692ef713a3ce2f21b8f9855f0bL80-L91)

**UI and Accessibility Adjustments:**

* Adjusted the attention flash animation timing in `AttentionFlash.cs` to provide a slightly longer and smoother visual cue. [[1]](diffhunk://#diff-4e42c1107240d81c152b5d9b80a7b88e324c8bf67531b00171b43c08507eb149L6-R9) [[2]](diffhunk://#diff-4e42c1107240d81c152b5d9b80a7b88e324c8bf67531b00171b43c08507eb149L40-R44)
* Updated `SpotlightLandmarks.cs` so that certain utility button landmarks are no longer associated with the `UtilityPanel` surface, improving accessibility and navigation logic. [[1]](diffhunk://#diff-dfd4bce7a5583461af2f60f1374df374f497ac2e28ae4f710fb05554a5bd0fd3L23-R25) [[2]](diffhunk://#diff-dfd4bce7a5583461af2f60f1374df374f497ac2e28ae4f710fb05554a5bd0fd3L57-R57)