### PR TITLE
Add FlashSurfaceMessage flow for revealing workspace surfaces

### DIFF
--- a/Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.cs
@@ -27,6 +27,11 @@ public record WorkspaceStateDirtyMessage();
 public record SurfaceVisibilityChangedMessage(WorkspaceSurface SurfaceVisibility);
 
 /// <summary>
+/// Sent to request a brief attention flash around the perimeter of a surface the user has just revealed.
+/// </summary>
+public record FlashSurfaceMessage(WorkspaceSurface Surface);
+
+/// <summary>
 /// Message sent when the Bottom document area's alignment changes.
 /// </summary>
 public record BottomAreaAlignmentChangedMessage(BottomAreaAlignment Alignment);

--- a/Source/Core/Celbridge.UserInterface/Helpers/AttentionFlash.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/AttentionFlash.cs
@@ -11,10 +11,26 @@ namespace Celbridge.UserInterface.Helpers;
 public static class AttentionFlash
 {
     /// <summary>
-    /// Starts a flash on the given overlay and returns the running storyboard. Pulses the overlay's opacity in
-    /// to a partial accent wash (kept below full so any content above it stays readable), holds, then fades out.
+    /// The peak opacity of a flash washing over an element, kept below full so the content underneath stays
+    /// readable.
     /// </summary>
-    public static Storyboard Play(UIElement overlay)
+    public const double FillPeakOpacity = 0.55;
+
+    /// <summary>
+    /// The peak opacity of a flash tracing an outline, which covers no content and so pulses close to full.
+    /// </summary>
+    public const double OutlinePeakOpacity = 0.9;
+
+    /// <summary>
+    /// The thickness a perimeter flash draws its outline at, heavier than the chrome edge it pulses over.
+    /// </summary>
+    public const double OutlineThickness = 2;
+
+    /// <summary>
+    /// Starts a flash on the given overlay and returns the running storyboard. Pulses the overlay's opacity in
+    /// to the given peak, holds, then fades out.
+    /// </summary>
+    public static Storyboard Play(UIElement overlay, double peakOpacity = FillPeakOpacity)
     {
         // One key-framed animation, not several: WinUI forbids two animations in a storyboard from targeting the
         // same property on the same element, so the fade-in, hold, and fade-out are key frames on a single
@@ -32,12 +48,12 @@ public static class AttentionFlash
         animation.KeyFrames.Add(new LinearDoubleKeyFrame
         {
             KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(120)),
-            Value = 0.55
+            Value = peakOpacity
         });
         animation.KeyFrames.Add(new LinearDoubleKeyFrame
         {
             KeyTime = KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(640)),
-            Value = 0.55
+            Value = peakOpacity
         });
         animation.KeyFrames.Add(new LinearDoubleKeyFrame
         {
@@ -50,5 +66,28 @@ public static class AttentionFlash
         storyboard.Begin();
 
         return storyboard;
+    }
+
+    /// <summary>
+    /// Scales a chrome outline to the perimeter flash thickness, leaving bare every edge the chrome itself
+    /// leaves bare.
+    /// </summary>
+    public static Thickness ResolveOutline(Thickness edges)
+    {
+        return new Thickness(
+            ResolveOutlineEdge(edges.Left),
+            ResolveOutlineEdge(edges.Top),
+            ResolveOutlineEdge(edges.Right),
+            ResolveOutlineEdge(edges.Bottom));
+    }
+
+    private static double ResolveOutlineEdge(double edge)
+    {
+        if (edge > 0)
+        {
+            return OutlineThickness;
+        }
+
+        return 0;
     }
 }

--- a/Source/Core/Celbridge.UserInterface/Services/LayoutManager.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/LayoutManager.cs
@@ -116,6 +116,10 @@ public class LayoutManager : IWindowModeService, ILayoutService
         // Focus/Presentation mode and return to the Default layout.
         bool isLeavingLayoutMode = _layoutMode != LayoutMode.Default;
 
+        // Read against what is on screen, so a surface hidden by a layout mode counts as revealed when the
+        // user asks for it back.
+        bool wasVisible = SurfaceVisibility.HasFlag(surface);
+
         // Those modes hide every surface transiently, so the change is composed against the visibility the
         // user prefers.
         var currentVisibility = SurfaceVisibility;
@@ -140,6 +144,13 @@ public class LayoutManager : IWindowModeService, ILayoutService
         if (isLeavingLayoutMode)
         {
             SetLayoutModeInternal(LayoutMode.Default);
+        }
+
+        // Sent last, once the whole layout has settled, and only for the surface the user asked for.
+        if (isVisible
+            && !wasVisible)
+        {
+            _messengerService.Send(new FlashSurfaceMessage(surface));
         }
     }
 

--- a/Source/Core/Celbridge.Utilities/Helpers/DocumentLayoutHelper.cs
+++ b/Source/Core/Celbridge.Utilities/Helpers/DocumentLayoutHelper.cs
@@ -165,6 +165,24 @@ public static class DocumentLayoutHelper
     }
 
     /// <summary>
+    /// The document area occupying the surface, or null for a surface that holds no area.
+    /// </summary>
+    public static DocumentArea? GetArea(this WorkspaceSurface surface)
+    {
+        switch (surface)
+        {
+            case WorkspaceSurface.BottomArea:
+                return DocumentArea.Bottom;
+
+            case WorkspaceSurface.SideArea:
+                return DocumentArea.Side;
+
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
     /// Parses a section name, returning false when the name does not match a section. Used for stored
     /// addresses and for agent tool arguments, both of which carry the name rather than a number.
     /// </summary>

--- a/Source/Tests/UserInterface/LayoutManagerTests.cs
+++ b/Source/Tests/UserInterface/LayoutManagerTests.cs
@@ -385,6 +385,65 @@ public class LayoutManagerTests
     }
 
     [Test]
+    public void RevealingASurface_SendsFlashSurfaceMessage()
+    {
+        _layoutManager.SetSurfaceVisibility(WorkspaceSurface.UtilityPanel, false);
+
+        FlashSurfaceMessage? receivedMessage = null;
+        var recipient = new object();
+        _messengerService.Register<FlashSurfaceMessage>(recipient, (r, m) => receivedMessage = m);
+
+        _layoutManager.SetSurfaceVisibility(WorkspaceSurface.UtilityPanel, true);
+
+        receivedMessage.Should().NotBeNull();
+        receivedMessage!.Surface.Should().Be(WorkspaceSurface.UtilityPanel);
+    }
+
+    [Test]
+    public void HidingASurface_SendsNoFlashSurfaceMessage()
+    {
+        bool messageReceived = false;
+        var recipient = new object();
+        _messengerService.Register<FlashSurfaceMessage>(recipient, (r, m) => messageReceived = true);
+
+        _layoutManager.SetSurfaceVisibility(WorkspaceSurface.UtilityPanel, false);
+
+        messageReceived.Should().BeFalse();
+    }
+
+    [Test]
+    public void RevealingASurfaceFromFocus_FlashesOnlyTheRequestedSurface()
+    {
+        // Focus hides every surface, so asking for one back brings its neighbours with it.
+        _layoutManager.RequestLayoutTransition(LayoutTransition.Focus);
+
+        var flashedSurfaces = new List<WorkspaceSurface>();
+        var recipient = new object();
+        _messengerService.Register<FlashSurfaceMessage>(recipient, (r, m) => flashedSurfaces.Add(m.Surface));
+
+        _layoutManager.SetSurfaceVisibility(WorkspaceSurface.BottomArea, true);
+
+        _layoutManager.SurfaceVisibility.Should().Be(WorkspaceSurface.All);
+        flashedSurfaces.Should().Equal(WorkspaceSurface.BottomArea);
+    }
+
+    [Test]
+    public void LayoutModeTransition_SendsNoFlashSurfaceMessage()
+    {
+        _layoutManager.RequestLayoutTransition(LayoutTransition.Focus);
+
+        bool messageReceived = false;
+        var recipient = new object();
+        _messengerService.Register<FlashSurfaceMessage>(recipient, (r, m) => messageReceived = true);
+
+        // Returning to Default brings back every surface.
+        _layoutManager.RequestLayoutTransition(LayoutTransition.Default);
+
+        _layoutManager.SurfaceVisibility.Should().Be(WorkspaceSurface.All);
+        messageReceived.Should().BeFalse();
+    }
+
+    [Test]
     public void SetSurfaceVisibility_InDefaultMode_UpdatesPreferredSurfaceVisibility()
     {
         _layoutManager.SetSurfaceVisibility(WorkspaceSurface.UtilityPanel, false);

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentAreaLayout.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentAreaLayout.cs
@@ -623,6 +623,25 @@ public sealed class DocumentAreaLayout
         }
     }
 
+    /// <summary>
+    /// Briefly pulses an accent outline around the area's perimeter, outlining both sections of a split
+    /// area. A no-op while the area is not presented.
+    /// </summary>
+    public void FlashAreaPerimeter(DocumentArea area)
+    {
+        if (!_layoutState.IsAreaPresented(area))
+        {
+            return;
+        }
+
+        _sectionLookup(area.GetPrimarySection()).FlashPerimeter();
+
+        if (_layoutState.IsAreaSplit(area))
+        {
+            _sectionLookup(area.GetSecondarySection()).FlashPerimeter();
+        }
+    }
+
     private void Splitter_DragStarted(object? sender, EventArgs e)
     {
         if (sender is not Splitter splitter || splitter.Tag is not DocumentArea area)

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml
@@ -62,5 +62,11 @@
                                    HorizontalAlignment="Left"
                                    VerticalAlignment="Top"
                                    Visibility="Collapsed"/>
+
+    <!-- Attention flash outline, tracing the same edges and corners as the section's own chrome. -->
+    <Border x:Name="PerimeterOverlay"
+            BorderBrush="{ThemeResource AccentBrush}"
+            Opacity="0"
+            IsHitTestVisible="False"/>
   </Grid>
 </UserControl>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
@@ -26,6 +26,7 @@ public sealed partial class DocumentSectionView : UserControl
     private bool _isShuttingDown = false;
     private bool _scrollButtonsHidden;
     private bool _scrollIndicatorAttached;
+    private Storyboard? _perimeterStoryboard;
 
     // The tab list template's two overflow arrows, named by their containers because that is what carries
     // the width each arrow costs the strip.
@@ -208,6 +209,19 @@ public sealed partial class DocumentSectionView : UserControl
         // The placeholder fills the section, so it has to repeat the rounding or it squares the corners off
         // again while the section is empty.
         EmptyPlaceholder.CornerRadius = corners;
+
+        // The flash outline traces the same shape as the chrome, at its own heavier thickness.
+        PerimeterOverlay.BorderThickness = AttentionFlash.ResolveOutline(edges);
+        PerimeterOverlay.CornerRadius = corners;
+    }
+
+    /// <summary>
+    /// Briefly pulses an accent outline around the section's perimeter.
+    /// </summary>
+    public void FlashPerimeter()
+    {
+        _perimeterStoryboard?.Stop();
+        _perimeterStoryboard = AttentionFlash.Play(PerimeterOverlay, AttentionFlash.OutlinePeakOpacity);
     }
 
     /// <summary>

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -382,6 +382,9 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         // Listen for requests to flash a document tab (e.g. when a utility is surfaced or a document reopened)
         _messengerService.Register<FlashDocumentMessage>(this, OnFlashDocumentRequested);
 
+        // Listen for requests to flash the perimeter of a surface the user has just revealed.
+        _messengerService.Register<FlashSurfaceMessage>(this, OnFlashSurfaceRequested);
+
         // Register how this panel takes keyboard focus, so the focus service can hand it back after an
         // interaction moves it away transiently. Without it a modal dialog raised over a document leaves the
         // keyboard nowhere when it closes.
@@ -917,6 +920,35 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         // state we were trying to get into anyway, so we consider this a success.
 
         return Result.Ok();
+    }
+
+    private void OnFlashSurfaceRequested(object recipient, FlashSurfaceMessage message)
+    {
+        if (_isShuttingDown)
+        {
+            return;
+        }
+
+        // Deferred until the layout has settled, so the outline is at the size it will pulse at.
+        var surface = message.Surface;
+        _ = DispatcherQueue.TryEnqueue(
+            Microsoft.UI.Dispatching.DispatcherQueuePriority.Low,
+            () => FlashSurface(surface));
+    }
+
+    private void FlashSurface(WorkspaceSurface surface)
+    {
+        if (surface == WorkspaceSurface.UtilityPanel)
+        {
+            SurfaceContainer.FlashUtilityPanelPerimeter();
+            return;
+        }
+
+        var area = surface.GetArea();
+        if (area is DocumentArea revealedArea)
+        {
+            SectionContainer.Areas.FlashAreaPerimeter(revealedArea);
+        }
     }
 
     private void OnFlashDocumentRequested(object recipient, FlashDocumentMessage message)

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml
@@ -25,5 +25,14 @@
                         VerticalContentAlignment="Stretch"
                         Visibility="Collapsed"
                         ui:FocusTracking.PreservePanelFocus="True" />
+
+        <!-- Attention flash outline, tracing the same edges and corners as the panel's own chrome. Its
+             z-index clears the one the active surface is raised to, so the outline draws over that
+             surface's opaque rows. -->
+        <Border x:Name="PerimeterOverlay"
+                Canvas.ZIndex="2"
+                BorderBrush="{ThemeResource AccentBrush}"
+                Opacity="0"
+                IsHitTestVisible="False" />
     </Grid>
 </UserControl>

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
@@ -7,9 +7,11 @@ using Celbridge.Projects;
 using Celbridge.Search;
 using Celbridge.Settings;
 using Celbridge.UserInterface;
+using Celbridge.UserInterface.Helpers;
 using Celbridge.WorkspaceUI.ViewModels;
 using Celbridge.WorkspaceUI.Views.Controls;
 using Microsoft.Extensions.Localization;
+using Microsoft.UI.Xaml.Media.Animation;
 
 namespace Celbridge.WorkspaceUI.Views;
 
@@ -59,6 +61,8 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     // items: they never select a surface, so they carry no selection, focus, or docked state.
     private readonly List<CommunityRailButton> _communityButtons = new();
 
+    private Storyboard? _perimeterStoryboard;
+
     // Selection is persisted only after RestoreSelectedUtility runs, so the constructor's default selection and
     // the restore itself do not overwrite the saved selection before it is read.
     private bool _selectionPersistenceEnabled;
@@ -90,6 +94,19 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         double edge = WorkspaceConstants.SectionEdgeThickness;
         ContentArea.BorderThickness = new Thickness(edge, edge, edge, isPresented ? edge : 0);
         ContentArea.CornerRadius = new CornerRadius(panelCornerRadius, panelCornerRadius, bottomRadius, bottomRadius);
+
+        // The flash outline traces the same shape as the chrome, at its own heavier thickness.
+        PerimeterOverlay.BorderThickness = AttentionFlash.ResolveOutline(ContentArea.BorderThickness);
+        PerimeterOverlay.CornerRadius = ContentArea.CornerRadius;
+    }
+
+    /// <summary>
+    /// Briefly pulses an accent outline around the panel's perimeter.
+    /// </summary>
+    internal void FlashPerimeter()
+    {
+        _perimeterStoryboard?.Stop();
+        _perimeterStoryboard = AttentionFlash.Play(PerimeterOverlay, AttentionFlash.OutlinePeakOpacity);
     }
 
     public UtilityPanel()
@@ -435,6 +452,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         // onto it, leaving its rail button unfocused.
         bool wasAlreadyVisible = content.Visibility == Visibility.Visible;
 
+        // Below the perimeter flash overlay, which takes the z-index above this one.
         Canvas.SetZIndex(content, 1);
         content.Visibility = Visibility.Visible;
 

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/WorkspaceSurfaceContainer.xaml.cs
@@ -73,6 +73,14 @@ public sealed partial class WorkspaceSurfaceContainer : UserControl
     /// </summary>
     public IUtilityPanel UtilityPanel => _utilityPanel;
 
+    /// <summary>
+    /// Briefly pulses an accent outline around the Utility Panel's perimeter.
+    /// </summary>
+    public void FlashUtilityPanelPerimeter()
+    {
+        _utilityPanel.FlashPerimeter();
+    }
+
     public WorkspaceSurfaceContainer()
     {
         InitializeComponent();


### PR DESCRIPTION
Adds a new `FlashSurfaceMessage` flow so revealing a hidden surface triggers a brief perimeter attention flash. `LayoutManager` now emits the message only when a user-requested surface transitions from hidden to visible (including reveal-from-focus cases), while suppressing flashes for hides and layout-mode-only transitions. UI updates add outline flash overlays for document sections and the utility panel, with shared `AttentionFlash` constants/helpers for opacity and outline thickness, and tests now cover the new messaging behavior.