### PR TITLE
Remove home title from project toolbar

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -1070,9 +1070,6 @@ Open with default application instead?</value>
   <data name="FullScreenToolbar_ExitPresentationHint" xml:space="preserve">
     <value>To exit Presentation mode, choose another layout from the View menu</value>
   </data>
-  <data name="TitleBar_HomeTitle" xml:space="preserve">
-    <value>Celbridge</value>
-  </data>
   <data name="TitleBar_MainMenuTooltip" xml:space="preserve">
     <value>Main menu</value>
   </data>

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ProjectToolbar.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ProjectToolbar.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
     x:Class="Celbridge.UserInterface.Views.ProjectToolbar"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -13,6 +13,7 @@
          button is shown from code-behind on those platforms; macOS surfaces these commands through the system
          menu bar, so the button stays collapsed there. -->
     <controls:IconButton x:Name="MainMenuButton"
+                         Margin="4,0,0,0"
                          AutomationProperties.AutomationId="main-menu-button"
                          VerticalAlignment="Center"
                          Visibility="Collapsed">
@@ -24,14 +25,10 @@
       </Button.Flyout>
     </controls:IconButton>
 
-    <!-- Shown in place of the project switcher while no project is loaded, so the toolbar strip keeps the same
-         geometry in both states. -->
-    <TextBlock x:Name="HomeTitle"
-               Text="{x:Bind HomeTitleString}"
-               Margin="8,0,0,0"
-               VerticalAlignment="Center"/>
-
+    <!-- The switcher rests filled rather than only tinting under the pointer, so without a gap here its
+         pill meets the main menu button's hover fill with no seam between them. -->
     <local:ProjectSwitcher x:Name="ProjectSwitcher"
+                           Margin="8,0,0,0"
                            VerticalAlignment="Center"/>
 
     <controls:ProjectHealthButton x:Name="ProjectHealthButton"

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ProjectToolbar.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ProjectToolbar.xaml.cs
@@ -1,25 +1,18 @@
 using Celbridge.Platform;
 using Celbridge.UserInterface.Services;
-using Celbridge.Workspace;
 
 namespace Celbridge.UserInterface.Views;
 
 public sealed partial class ProjectToolbar : UserControl
 {
-    private readonly IMessengerService _messengerService;
     private readonly IStringLocalizer _stringLocalizer;
-    private readonly IWorkspaceWrapper _workspaceWrapper;
     private MainMenu? _mainMenu;
-
-    private string HomeTitleString => _stringLocalizer.GetString("TitleBar_HomeTitle");
 
     public ProjectToolbar()
     {
         this.InitializeComponent();
 
-        _messengerService = ServiceLocator.AcquireService<IMessengerService>();
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
-        _workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
 
         // The menu opens over the document area, where a hosted web view would take the click too.
         var overlayInputSuppressor = ServiceLocator.AcquireService<IOverlayInputSuppressor>();
@@ -42,10 +35,6 @@ public sealed partial class ProjectToolbar : UserControl
         }
 
         ApplyTooltips();
-        UpdateHomeTitleVisibility();
-
-        _messengerService.Register<WorkspaceLoadedMessage>(this, OnWorkspaceLoaded);
-        _messengerService.Register<WorkspaceUnloadedMessage>(this, OnWorkspaceUnloaded);
     }
 
     private void OnProjectToolbar_Unloaded(object sender, RoutedEventArgs e)
@@ -54,8 +43,6 @@ public sealed partial class ProjectToolbar : UserControl
 
         Loaded -= OnProjectToolbar_Loaded;
         Unloaded -= OnProjectToolbar_Unloaded;
-
-        _messengerService.UnregisterAll(this);
     }
 
     /// <summary>
@@ -79,23 +66,5 @@ public sealed partial class ProjectToolbar : UserControl
         ToolTipService.SetToolTip(MainMenuButton, mainMenuTooltip);
         ToolTipService.SetPlacement(MainMenuButton, PlacementMode.Bottom);
         AutomationProperties.SetName(MainMenuButton, mainMenuTooltip);
-    }
-
-    private void OnWorkspaceLoaded(object recipient, WorkspaceLoadedMessage message)
-    {
-        UpdateHomeTitleVisibility();
-    }
-
-    private void OnWorkspaceUnloaded(object recipient, WorkspaceUnloadedMessage message)
-    {
-        UpdateHomeTitleVisibility();
-    }
-
-    private void UpdateHomeTitleVisibility()
-    {
-        // The switcher occupies this slot while a project is loaded, and collapses itself when none is.
-        HomeTitle.Visibility = _workspaceWrapper.IsWorkspaceLoaded
-            ? Visibility.Collapsed
-            : Visibility.Visible;
     }
 }


### PR DESCRIPTION
Drops the temporary "Celbridge" home title state from `ProjectToolbar` and relies on the `ProjectSwitcher` slot instead, including spacing updates so the main menu and switcher pills render with a clean seam. This also removes now-unused workspace message subscriptions and the `TitleBar_HomeTitle` localization string.