### PR TITLE
Use toggle button for WebView settings panel

### DIFF
--- a/Source/Modules/Celbridge.WebView/ViewModels/WebViewDocumentViewModel.cs
+++ b/Source/Modules/Celbridge.WebView/ViewModels/WebViewDocumentViewModel.cs
@@ -345,11 +345,6 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
         });
     }
 
-    public void ToggleSettingsPanel()
-    {
-        IsSettingsPanelOpen = !IsSettingsPanelOpen;
-    }
-
     /// <summary>
     /// Closes the settings panel. The panel needs a way out of its own, because a document that hides the
     /// URL bar hides the toggle that opened it.

--- a/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml
@@ -120,12 +120,15 @@
                                          Click="OpenInBrowserButton_Click">
                         <controls:Icon Symbol="Reveal" FontSize="{StaticResource IconSizeMedium}" />
                     </controls:IconButton>
-                    <controls:IconButton x:Name="SettingsButton"
-                                         VerticalAlignment="Center"
-                                         ToolTipService.ToolTip="{x:Bind SettingsTooltipString}"
-                                         Click="SettingsButton_Click">
+                    <!-- A toggle rather than a plain button: the panel stays open until it is closed and
+                         its state is saved with the document, so it takes the accent fill the way any other
+                         selected control does. -->
+                    <controls:IconToggleButton x:Name="SettingsButton"
+                                               VerticalAlignment="Center"
+                                               ToolTipService.ToolTip="{x:Bind SettingsTooltipString}"
+                                               IsChecked="{x:Bind ViewModel.IsSettingsPanelOpen, Mode=TwoWay}">
                         <controls:Icon Symbol="Sliders" FontSize="{StaticResource IconSizeMedium}" />
-                    </controls:IconButton>
+                    </controls:IconToggleButton>
                 </StackPanel>
             </Grid>
         </Border>
@@ -170,29 +173,32 @@
                 </Grid.RowDefinitions>
 
                 <!-- A panel header is chrome over the panel's content, matching PanelHeader and the settings
-                     panels in the web editors. Fixed rather than scrolling: the close button is the panel's
-                     only way out once the URL bar carrying the settings toggle is hidden. -->
+                     panels in the web editors. Fixed rather than scrolling: the chevron is the panel's only
+                     way out once the URL bar carrying the settings toggle is hidden. It sits on the inner
+                     edge facing the page and points out towards the application edge, which is where the
+                     Side area puts its own collapse chevron. -->
                 <Grid Grid.Row="0"
                       Height="40"
                       Background="{ThemeResource ChromeBackgroundBrush}">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
-                    <TextBlock Grid.Column="0"
-                               Text="{x:Bind SettingsTitleString}"
-                               Style="{StaticResource PanelTitleTextStyle}"
-                               Margin="12,0,0,0"
-                               VerticalAlignment="Center" />
-
-                    <controls:IconButton Grid.Column="1"
-                                         Margin="0,0,8,0"
+                    <controls:IconButton Grid.Column="0"
+                                         Margin="8,0,0,0"
                                          VerticalAlignment="Center"
                                          ToolTipService.ToolTip="{x:Bind CloseSettingsTooltipString}"
                                          Click="CloseSettingsButton_Click">
-                        <controls:Icon Symbol="Close" FontSize="{StaticResource IconSizeMedium}" />
+                        <controls:Icon Symbol="ChevronRight" FontSize="{StaticResource IconSizeMedium}" />
                     </controls:IconButton>
+
+                    <TextBlock Grid.Column="1"
+                               Text="{x:Bind SettingsTitleString}"
+                               Style="{StaticResource PanelTitleTextStyle}"
+                               Margin="6,0,12,0"
+                               VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis" />
                 </Grid>
 
                 <ScrollViewer Grid.Row="1" Padding="12,0,12,12">

--- a/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
@@ -628,11 +628,6 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
         }
     }
 
-    private void SettingsButton_Click(object sender, RoutedEventArgs e)
-    {
-        ViewModel.ToggleSettingsPanel();
-    }
-
     private void CloseSettingsButton_Click(object sender, RoutedEventArgs e)
     {
         ViewModel.CloseSettingsPanel();


### PR DESCRIPTION
Replaced the settings icon button with an IconToggleButton bound two-way to `IsSettingsPanelOpen`, so the control reflects and persists panel state without a manual click handler. Removed the now-unused `ToggleSettingsPanel` method and `SettingsButton_Click` handler, and updated the settings panel header chrome to use an edge-facing collapse chevron with adjusted layout and title trimming.