### PR TITLE
Refactor WebView settings into sectioned UI

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -579,9 +579,6 @@
   <data name="WebView_ShowUrlBar" xml:space="preserve">
     <value>Show URL Bar</value>
   </data>
-  <data name="WebView_Settings_Title" xml:space="preserve">
-    <value>Web View Settings</value>
-  </data>
   <data name="WebView_Settings_HomeUrlLabel" xml:space="preserve">
     <value>Home URL</value>
   </data>
@@ -606,14 +603,44 @@
   <data name="WebView_Settings_ShowUrlBarHint" xml:space="preserve">
     <value>Right-click the document tab to show the URL bar again.</value>
   </data>
-  <data name="WebView_Settings_BrowsingDataLabel" xml:space="preserve">
+  <data name="WebView_Settings_BrowsingDataHint" xml:space="preserve">
+    <value>This data is shared by every web page in Celbridge, so clearing it signs you out of every site, in every document.</value>
+  </data>
+  <data name="WebView_Settings_OpenApplicationSettings" xml:space="preserve">
+    <value>Open Application Settings</value>
+  </data>
+  <data name="WebView_Settings_ReturnToPage" xml:space="preserve">
+    <value>Return to Page</value>
+  </data>
+  <data name="WebView_Placeholder_AddressHint" xml:space="preserve">
+    <value>Enter a web address above to open a page.</value>
+  </data>
+  <data name="WebView_Placeholder_SettingsHint" xml:space="preserve">
+    <value>Set a Home URL in Web View Settings to open a page.</value>
+  </data>
+  <data name="WebView_Placeholder_LoadFailed" xml:space="preserve">
+    <value>This page could not be loaded.</value>
+  </data>
+  <data name="WebView_Placeholder_LoadFailedHint" xml:space="preserve">
+    <value>Check the address and your network connection, then reload.</value>
+  </data>
+  <data name="WebView_Settings_HomeHeader" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="WebView_Settings_HomeDescription" xml:space="preserve">
+    <value>Set the page this document opens on, or adopt the page on screen.</value>
+  </data>
+  <data name="WebView_Settings_AppearanceHeader" xml:space="preserve">
+    <value>Appearance</value>
+  </data>
+  <data name="WebView_Settings_AppearanceDescription" xml:space="preserve">
+    <value>Choose which chrome the document shows around the page.</value>
+  </data>
+  <data name="WebView_Settings_BrowsingDataHeader" xml:space="preserve">
     <value>Browsing Data</value>
   </data>
-  <data name="WebView_Settings_BrowsingDataHint" xml:space="preserve">
-    <value>Cookies, cached credentials and site data are shared by every web page in Celbridge. Clear them from Privacy in Application Settings.</value>
-  </data>
-  <data name="WebView_Settings_CloseTooltip" xml:space="preserve">
-    <value>Close Settings</value>
+  <data name="WebView_Settings_BrowsingDataDescription" xml:space="preserve">
+    <value>Cookies, cached credentials and site data for every web page in Celbridge.</value>
   </data>
   <data name="WebView_InvalidUrl" xml:space="preserve">
     <value>Enter a valid external URL (https://...).</value>

--- a/Source/Core/Celbridge.Foundation/Dialog/IDialogFactory.cs
+++ b/Source/Core/Celbridge.Foundation/Dialog/IDialogFactory.cs
@@ -26,7 +26,7 @@ public interface IDialogFactory
     /// <summary>
     /// Create a Settings Dialog for the application settings.
     /// </summary>
-    ISettingsDialog CreateSettingsDialog();
+    ISettingsDialog CreateSettingsDialog(string sectionKey);
 
     /// <summary>
     /// Create a New Project Dialog with template selection.

--- a/Source/Core/Celbridge.Foundation/Dialog/IDialogService.cs
+++ b/Source/Core/Celbridge.Foundation/Dialog/IDialogService.cs
@@ -47,9 +47,10 @@ public interface IDialogService
     IProgressDialogToken AcquireProgressDialog(string titleText);
 
     /// <summary>
-    /// Display the Settings Dialog for the application settings.
+    /// Display the Settings Dialog for the application settings, opening it on the given category. Pass an
+    /// empty key to open the category the user last had open.
     /// </summary>
-    Task ShowSettingsDialogAsync();
+    Task ShowSettingsDialogAsync(string sectionKey);
 
     /// <summary>
     /// Display a New Project Dialog with template selection.

--- a/Source/Core/Celbridge.Foundation/Dialog/SettingsDialogSections.cs
+++ b/Source/Core/Celbridge.Foundation/Dialog/SettingsDialogSections.cs
@@ -1,0 +1,14 @@
+namespace Celbridge.Dialog;
+
+/// <summary>
+/// The keys the Application Settings dialog registers its categories under. A key is persisted and used to
+/// open the dialog at a particular category, so it is part of the contract rather than a label.
+/// </summary>
+public static class SettingsDialogSections
+{
+    public const string Appearance = "Appearance";
+
+    public const string Workshop = "Workshop";
+
+    public const string WebView = "WebView";
+}

--- a/Source/Core/Celbridge.Foundation/UserInterface/IShowSettingsCommand.cs
+++ b/Source/Core/Celbridge.Foundation/UserInterface/IShowSettingsCommand.cs
@@ -1,0 +1,15 @@
+using Celbridge.Commands;
+
+namespace Celbridge.UserInterface;
+
+/// <summary>
+/// Show the Application Settings.
+/// </summary>
+public interface IShowSettingsCommand : IExecutableCommand
+{
+    /// <summary>
+    /// The category to open on, from SettingsDialogSections. Empty opens the category the user last had
+    /// open. Opening on a category does not change which one that is.
+    /// </summary>
+    string SectionKey { get; set; }
+}

--- a/Source/Core/Celbridge.UserInterface/Commands/ShowSettingsCommand.cs
+++ b/Source/Core/Celbridge.UserInterface/Commands/ShowSettingsCommand.cs
@@ -1,0 +1,17 @@
+using Celbridge.Commands;
+using Celbridge.Dialog;
+
+namespace Celbridge.UserInterface.Commands;
+
+public class ShowSettingsCommand : CommandBase, IShowSettingsCommand
+{
+    public string SectionKey { get; set; } = string.Empty;
+
+    public override async Task<Result> ExecuteAsync()
+    {
+        var dialogService = ServiceLocator.AcquireService<IDialogService>();
+        await dialogService.ShowSettingsDialogAsync(SectionKey);
+
+        return Result.Ok();
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/ServiceConfiguration.cs
+++ b/Source/Core/Celbridge.UserInterface/ServiceConfiguration.cs
@@ -62,6 +62,7 @@ public static class ServiceConfiguration
         services.AddTransient<ISetThemeCommand, SetThemeCommand>();
         services.AddTransient<ISetLanguageCommand, SetLanguageCommand>();
         services.AddTransient<IAlertCommand, AlertCommand>();
+        services.AddTransient<IShowSettingsCommand, ShowSettingsCommand>();
         services.AddTransient<IConfirmActionCommand, ConfirmActionCommand>();
         services.AddTransient<ISpotlightCommand, SpotlightCommand>();
         services.AddTransient<IShowLogsCommand, ShowLogsCommand>();

--- a/Source/Core/Celbridge.UserInterface/Services/Dialogs/DialogFactory.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/Dialogs/DialogFactory.cs
@@ -52,9 +52,9 @@ public class DialogFactory : IDialogFactory
         return WithFocusGuard(dialog);
     }
 
-    public ISettingsDialog CreateSettingsDialog()
+    public ISettingsDialog CreateSettingsDialog(string sectionKey)
     {
-        var dialog = new SettingsDialog();
+        var dialog = new SettingsDialog(sectionKey);
         return WithFocusGuard(dialog);
     }
 

--- a/Source/Core/Celbridge.UserInterface/Services/Dialogs/DialogService.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/Dialogs/DialogService.cs
@@ -87,7 +87,7 @@ public class DialogService : IDialogService
         return token;
     }
 
-    public async Task ShowSettingsDialogAsync()
+    public async Task ShowSettingsDialogAsync(string sectionKey)
     {
         if (IsDialogOpen)
         {
@@ -95,7 +95,7 @@ public class DialogService : IDialogService
             return;
         }
 
-        var dialog = _dialogFactory.CreateSettingsDialog();
+        var dialog = _dialogFactory.CreateSettingsDialog(sectionKey);
 
         try
         {

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Controls/ApplicationMenuViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Controls/ApplicationMenuViewModel.cs
@@ -1,5 +1,4 @@
 using Celbridge.Commands;
-using Celbridge.Dialog;
 using Celbridge.Projects;
 using Celbridge.Settings;
 using Celbridge.UserInterface.Services;
@@ -15,7 +14,6 @@ public partial class ApplicationMenuViewModel : ObservableObject
 {
     private readonly IMessengerService _messengerService;
     private readonly ICommandService _commandService;
-    private readonly IDialogService _dialogService;
     private readonly ISettingsService _settingsService;
     private readonly IWorkspaceWrapper _workspaceWrapper;
     private readonly IProjectService _projectService;
@@ -28,7 +26,6 @@ public partial class ApplicationMenuViewModel : ObservableObject
     public ApplicationMenuViewModel(
         IMessengerService messengerService,
         ICommandService commandService,
-        IDialogService dialogService,
         ISettingsService settingsService,
         IWorkspaceWrapper workspaceWrapper,
         IProjectService projectService,
@@ -37,7 +34,6 @@ public partial class ApplicationMenuViewModel : ObservableObject
     {
         _messengerService = messengerService;
         _commandService = commandService;
-        _dialogService = dialogService;
         _settingsService = settingsService;
         _workspaceWrapper = workspaceWrapper;
         _projectService = projectService;
@@ -105,7 +101,7 @@ public partial class ApplicationMenuViewModel : ObservableObject
 
     public void ShowSettings()
     {
-        _ = _dialogService.ShowSettingsDialogAsync();
+        _commandService.Execute<IShowSettingsCommand>();
     }
 
     public void ExitApplication()

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Dialogs/SettingsDialogViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Dialogs/SettingsDialogViewModel.cs
@@ -30,21 +30,25 @@ public partial class SettingsDialogViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Supplies the categories to show, in rail order, and selects the one the user last had open. Called
-    /// by the dialog, which is the only place that can build each category's content.
+    /// Supplies the categories to show, in rail order, and selects the requested one, falling back to the
+    /// one the user last had open. Called by the dialog, which is the only place that can build each
+    /// category's content. Persistence stays off over the selection, so opening on a requested category
+    /// does not displace the one the user chose for themselves.
     /// </summary>
-    public void InitializeSections(IReadOnlyList<SettingsSection> sections)
+    public void InitializeSections(IReadOnlyList<SettingsSection> sections, string requestedSectionKey)
     {
         Guard.IsTrue(sections.Count > 0);
 
         _sectionPersistenceEnabled = false;
         Sections = sections;
 
+        var requestedSection = sections.FirstOrDefault(section => section.Key == requestedSectionKey);
+
         // An unrecognized or empty key lands on the first category, which is what a new installation gets.
         var storedKey = _settingsService.Get(SettingCatalog.Application.SettingsDialogSelectedSection);
         var storedSection = sections.FirstOrDefault(section => section.Key == storedKey);
 
-        SelectedSection = storedSection ?? sections[0];
+        SelectedSection = requestedSection ?? storedSection ?? sections[0];
 
         _sectionPersistenceEnabled = true;
     }

--- a/Source/Core/Celbridge.UserInterface/Views/Dialogs/SettingsDialog.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Dialogs/SettingsDialog.xaml.cs
@@ -16,7 +16,7 @@ public sealed partial class SettingsDialog : ContentDialog, ISettingsDialog
 
     public SettingsDialogViewModel ViewModel { get; }
 
-    public SettingsDialog()
+    public SettingsDialog(string sectionKey)
     {
         // The labels are bound one-time, so the localizer has to be in place before the XAML loads.
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
@@ -25,7 +25,7 @@ public sealed partial class SettingsDialog : ContentDialog, ISettingsDialog
         XamlRoot = userInterfaceService.XamlRoot as XamlRoot;
 
         ViewModel = ServiceLocator.AcquireService<SettingsDialogViewModel>();
-        ViewModel.InitializeSections(BuildSections());
+        ViewModel.InitializeSections(BuildSections(), sectionKey);
 
         this.InitializeComponent();
 
@@ -49,19 +49,19 @@ public sealed partial class SettingsDialog : ContentDialog, ISettingsDialog
         var sections = new List<SettingsSection>
         {
             new(
-                "Appearance",
+                SettingsDialogSections.Appearance,
                 "bs-palette",
                 _stringLocalizer.GetString("Settings_Appearance_SectionHeader"),
                 _stringLocalizer.GetString("Settings_Appearance_Description"),
                 new AppearanceSettingsView()),
             new(
-                "Workshop",
+                SettingsDialogSections.Workshop,
                 "bs-shop",
                 _stringLocalizer.GetString("Settings_Workshop_SectionHeader"),
                 _stringLocalizer.GetString("Settings_Workshop_Description"),
                 new WorkshopSettingsView()),
             new(
-                "WebView",
+                SettingsDialogSections.WebView,
                 "bs-globe",
                 _stringLocalizer.GetString("Settings_WebView_SectionHeader"),
                 _stringLocalizer.GetString("Settings_WebView_Description"),

--- a/Source/Modules/Celbridge.WebView/ViewModels/WebViewDocumentViewModel.cs
+++ b/Source/Modules/Celbridge.WebView/ViewModels/WebViewDocumentViewModel.cs
@@ -31,22 +31,44 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsHomeUrlValid))]
     [NotifyPropertyChangedFor(nameof(IsHomeUrlInvalid))]
+    [NotifyPropertyChangedFor(nameof(IsHomeEnabled))]
     [NotifyPropertyChangedFor(nameof(HomeUrlTooltip))]
     [NotifyPropertyChangedFor(nameof(CanSetCurrentPageAsHome))]
     private string _sourceUrl = string.Empty;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsUrlBarVisible))]
+    [NotifyPropertyChangedFor(nameof(IsAddressHintVisible))]
+    [NotifyPropertyChangedFor(nameof(IsSettingsHintVisible))]
     private bool _showUrlBar = true;
 
+    // Cleared when a navigation starts and set by the stop gesture, so the cancelled navigation that
+    // follows is not reported as a page that failed to load.
+    private bool _navigationStoppedByUser;
+
+    // The URL bar acts on a page that is not on screen while the settings are showing, so every control
+    // that would navigate is driven from this as well as from its own state.
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsSettingsPanelVisible))]
-    private bool _isSettingsPanelOpen;
+    [NotifyPropertyChangedFor(nameof(IsSettingsVisible))]
+    [NotifyPropertyChangedFor(nameof(IsBackEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsForwardEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsReloadOrStopEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsHomeEnabled))]
+    [NotifyPropertyChangedFor(nameof(IsAddressReadOnly))]
+    [NotifyPropertyChangedFor(nameof(IsPlaceholderVisible))]
+    [NotifyPropertyChangedFor(nameof(IsEmptyStateVisible))]
+    [NotifyPropertyChangedFor(nameof(IsLoadFailedVisible))]
+    [NotifyPropertyChangedFor(nameof(IsAddressHintVisible))]
+    [NotifyPropertyChangedFor(nameof(IsSettingsHintVisible))]
+    [NotifyPropertyChangedFor(nameof(IsPageOnScreen))]
+    private bool _isSettingsOpen;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsBackEnabled))]
     private bool _canGoBack;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsForwardEnabled))]
     private bool _canGoForward;
 
     [ObservableProperty]
@@ -55,7 +77,26 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
     [NotifyPropertyChangedFor(nameof(CanOpenInBrowser))]
     [NotifyPropertyChangedFor(nameof(CanSetCurrentPageAsHome))]
     [NotifyPropertyChangedFor(nameof(CanCreateDocumentFromCurrentPage))]
+    [NotifyPropertyChangedFor(nameof(HasPage))]
+    [NotifyPropertyChangedFor(nameof(AddressText))]
+    [NotifyPropertyChangedFor(nameof(IsPlaceholderVisible))]
+    [NotifyPropertyChangedFor(nameof(IsEmptyStateVisible))]
+    [NotifyPropertyChangedFor(nameof(IsLoadFailedVisible))]
+    [NotifyPropertyChangedFor(nameof(IsAddressHintVisible))]
+    [NotifyPropertyChangedFor(nameof(IsSettingsHintVisible))]
+    [NotifyPropertyChangedFor(nameof(IsPageOnScreen))]
     private string _currentUrl = string.Empty;
+
+    // Reported by the WebView when a navigation does not complete, which leaves the page being left
+    // still rendered.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsPlaceholderVisible))]
+    [NotifyPropertyChangedFor(nameof(IsEmptyStateVisible))]
+    [NotifyPropertyChangedFor(nameof(IsLoadFailedVisible))]
+    [NotifyPropertyChangedFor(nameof(IsAddressHintVisible))]
+    [NotifyPropertyChangedFor(nameof(IsSettingsHintVisible))]
+    [NotifyPropertyChangedFor(nameof(IsPageOnScreen))]
+    private bool _hasNavigationFailed;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsReloadOrStopEnabled))]
@@ -89,7 +130,18 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
         {
             _role = value;
             OnPropertyChanged(nameof(IsUrlBarVisible));
-            OnPropertyChanged(nameof(IsSettingsPanelVisible));
+            OnPropertyChanged(nameof(IsSettingsVisible));
+            OnPropertyChanged(nameof(IsBackEnabled));
+            OnPropertyChanged(nameof(IsForwardEnabled));
+            OnPropertyChanged(nameof(IsReloadOrStopEnabled));
+            OnPropertyChanged(nameof(IsHomeEnabled));
+            OnPropertyChanged(nameof(IsAddressReadOnly));
+            OnPropertyChanged(nameof(IsPlaceholderVisible));
+            OnPropertyChanged(nameof(IsEmptyStateVisible));
+            OnPropertyChanged(nameof(IsLoadFailedVisible));
+            OnPropertyChanged(nameof(IsAddressHintVisible));
+            OnPropertyChanged(nameof(IsSettingsHintVisible));
+            OnPropertyChanged(nameof(IsPageOnScreen));
         }
     }
 
@@ -100,10 +152,56 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
     public bool IsUrlBarVisible => Role == WebViewDocumentRole.ExternalUrl && ShowUrlBar;
 
     /// <summary>
-    /// True when the settings side panel should occupy its column. Like the URL bar,
-    /// the panel is external-URL chrome and never appears for the HTML viewer.
+    /// True when the settings should take the document area in place of the page. Like the URL bar, the
+    /// settings are external-URL chrome and never appear for the HTML viewer.
     /// </summary>
-    public bool IsSettingsPanelVisible => Role == WebViewDocumentRole.ExternalUrl && IsSettingsPanelOpen;
+    public bool IsSettingsVisible => Role == WebViewDocumentRole.ExternalUrl && IsSettingsOpen;
+
+    /// <summary>
+    /// True when the document is showing a page, as opposed to nothing or a page that failed to load.
+    /// </summary>
+    public bool HasPage => IsPageUrl(CurrentUrl);
+
+    /// <summary>
+    /// The address as the URL bar should show it. Blank for a document with no page, so clearing the
+    /// address and committing it leaves the bar empty rather than naming the blank page behind it.
+    /// </summary>
+    public string AddressText => HasPage ? CurrentUrl : string.Empty;
+
+    /// <summary>
+    /// True when the placeholder takes the document area in place of a page: the document has none to
+    /// show, or the one it was sent to did not load.
+    /// </summary>
+    public bool IsPlaceholderVisible => Role == WebViewDocumentRole.ExternalUrl
+        && !IsSettingsVisible
+        && (HasNavigationFailed || !HasPage);
+
+    /// <summary>
+    /// True when the placeholder should say how to open a page, the document having none.
+    /// </summary>
+    public bool IsEmptyStateVisible => IsPlaceholderVisible && !HasNavigationFailed;
+
+    /// <summary>
+    /// True when the placeholder should report that the address it was sent to did not load.
+    /// </summary>
+    public bool IsLoadFailedVisible => IsPlaceholderVisible && HasNavigationFailed;
+
+    /// <summary>
+    /// True when the placeholder should point at the URL bar, which is where a document showing it opens
+    /// a page.
+    /// </summary>
+    public bool IsAddressHintVisible => IsEmptyStateVisible && ShowUrlBar;
+
+    /// <summary>
+    /// True when the placeholder should point at the settings instead, the document having no URL bar to
+    /// type an address into.
+    /// </summary>
+    public bool IsSettingsHintVisible => IsEmptyStateVisible && !ShowUrlBar;
+
+    /// <summary>
+    /// True when the page is what fills the document area, rather than the settings or the placeholder.
+    /// </summary>
+    public bool IsPageOnScreen => !IsSettingsVisible && !IsPlaceholderVisible;
 
     /// <summary>
     /// True when the configured Home URL is a navigable external URL.
@@ -146,7 +244,28 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
 
     public bool CanReload => IsPageUrl(CurrentUrl);
 
-    public bool IsReloadOrStopEnabled => IsNavigating || CanReload;
+    /// <summary>
+    /// True when the page can be navigated back to the previous entry in its history.
+    /// </summary>
+    public bool IsBackEnabled => CanGoBack && !IsSettingsVisible;
+
+    /// <summary>
+    /// True when the page can be navigated forward to the next entry in its history.
+    /// </summary>
+    public bool IsForwardEnabled => CanGoForward && !IsSettingsVisible;
+
+    /// <summary>
+    /// True when the page can be navigated to the configured Home URL.
+    /// </summary>
+    public bool IsHomeEnabled => IsHomeUrlValid && !IsSettingsVisible;
+
+    /// <summary>
+    /// True when the address is shown for reading rather than for editing, which is what the settings
+    /// leave it as: the address can still be selected and copied, but not navigated away from.
+    /// </summary>
+    public bool IsAddressReadOnly => IsSettingsVisible;
+
+    public bool IsReloadOrStopEnabled => (IsNavigating || CanReload) && !IsSettingsVisible;
 
     /// <summary>
     /// True when the reload/stop button shows the reload icon; while a navigation
@@ -346,12 +465,47 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
     }
 
     /// <summary>
-    /// Closes the settings panel. The panel needs a way out of its own, because a document that hides the
-    /// URL bar hides the toggle that opened it.
+    /// Records that a navigation has begun, clearing the failure the previous one may have reported.
     /// </summary>
-    public void CloseSettingsPanel()
+    public void NotifyNavigationStarted()
     {
-        IsSettingsPanelOpen = false;
+        _navigationStoppedByUser = false;
+        HasNavigationFailed = false;
+        IsNavigating = true;
+    }
+
+    /// <summary>
+    /// Records that the user stopped the navigation in flight, so the cancellation reported for it is not
+    /// taken for a page that failed to load.
+    /// </summary>
+    public void NotifyNavigationStopped()
+    {
+        _navigationStoppedByUser = true;
+    }
+
+    /// <summary>
+    /// Records how a navigation ended. A stopped navigation keeps whatever it had rendered so far.
+    /// </summary>
+    public void NotifyNavigationCompleted(bool isSuccess)
+    {
+        IsNavigating = false;
+
+        if (isSuccess
+            || _navigationStoppedByUser)
+        {
+            return;
+        }
+
+        HasNavigationFailed = true;
+    }
+
+    /// <summary>
+    /// Returns the document to the page. The settings need a way out of their own, because a document that
+    /// hides the URL bar hides the toggle that opened them.
+    /// </summary>
+    public void CloseSettings()
+    {
+        IsSettingsOpen = false;
     }
 
     /// <summary>

--- a/Source/Modules/Celbridge.WebView/Views/WebViewAppearanceSectionView.xaml
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewAppearanceSectionView.xaml
@@ -1,0 +1,25 @@
+<UserControl
+    x:Class="Celbridge.WebView.Views.WebViewAppearanceSectionView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+
+    <StackPanel Spacing="12">
+
+        <StackPanel Spacing="2">
+            <TextBlock Text="{x:Bind ShowUrlBarLabelString}"
+                       Style="{StaticResource FieldLabelTextStyle}" />
+            <ToggleSwitch MinWidth="0"
+                          OnContent=""
+                          OffContent=""
+                          IsOn="{x:Bind ViewModel.ShowUrlBar, Mode=TwoWay}" />
+
+            <!-- Shown before the bar is hidden, not after, so the way back is known in advance rather than
+                 discovered once the toggle is out of reach. -->
+            <TextBlock Text="{x:Bind ShowUrlBarHintString}"
+                       Style="{StaticResource SupportingTextStyle}"
+                       TextWrapping="Wrap" />
+        </StackPanel>
+
+    </StackPanel>
+</UserControl>

--- a/Source/Modules/Celbridge.WebView/Views/WebViewAppearanceSectionView.xaml.cs
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewAppearanceSectionView.xaml.cs
@@ -1,0 +1,37 @@
+using Celbridge.UserInterface;
+using Celbridge.WebView.ViewModels;
+using Microsoft.Extensions.Localization;
+
+namespace Celbridge.WebView.Views;
+
+/// <summary>
+/// The Appearance section of the Web View settings: which chrome the document shows around the page.
+/// </summary>
+public sealed partial class WebViewAppearanceSectionView : UserControl
+{
+    private readonly IStringLocalizer _stringLocalizer;
+
+    private WebViewDocumentViewModel? _viewModel;
+
+    // Supplied by the surface that owns this section. Assigning it refreshes the bindings so the section
+    // populates once the surface hands over its instance.
+    public WebViewDocumentViewModel? ViewModel
+    {
+        get => _viewModel;
+        set
+        {
+            _viewModel = value;
+            Bindings?.Update();
+        }
+    }
+
+    public string ShowUrlBarLabelString => _stringLocalizer.GetString("WebView_Settings_ShowUrlBarLabel");
+    public string ShowUrlBarHintString => _stringLocalizer.GetString("WebView_Settings_ShowUrlBarHint");
+
+    public WebViewAppearanceSectionView()
+    {
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
+
+        InitializeComponent();
+    }
+}

--- a/Source/Modules/Celbridge.WebView/Views/WebViewBrowsingDataSectionView.xaml
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewBrowsingDataSectionView.xaml
@@ -1,0 +1,21 @@
+<UserControl
+    x:Class="Celbridge.WebView.Views.WebViewBrowsingDataSectionView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+
+    <!-- A pointer rather than a clear action: every web view in the application shares one profile, so
+         clearing is application-wide and belongs in Application Settings where it cannot read as
+         per-document. -->
+    <StackPanel Spacing="12">
+
+        <TextBlock Text="{x:Bind BrowsingDataHintString}"
+                   Style="{StaticResource SupportingTextStyle}"
+                   TextWrapping="Wrap" />
+
+        <Button HorizontalAlignment="Left"
+                Content="{x:Bind OpenApplicationSettingsString}"
+                Click="OpenApplicationSettingsButton_Click" />
+
+    </StackPanel>
+</UserControl>

--- a/Source/Modules/Celbridge.WebView/Views/WebViewBrowsingDataSectionView.xaml.cs
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewBrowsingDataSectionView.xaml.cs
@@ -1,0 +1,35 @@
+using Celbridge.Commands;
+using Celbridge.Dialog;
+using Celbridge.UserInterface;
+using Microsoft.Extensions.Localization;
+
+namespace Celbridge.WebView.Views;
+
+/// <summary>
+/// The Browsing Data section of the Web View settings: what the shared web profile holds, and the way to
+/// the Application Settings that clear it.
+/// </summary>
+public sealed partial class WebViewBrowsingDataSectionView : UserControl
+{
+    private readonly IStringLocalizer _stringLocalizer;
+    private readonly ICommandService _commandService;
+
+    public string BrowsingDataHintString => _stringLocalizer.GetString("WebView_Settings_BrowsingDataHint");
+    public string OpenApplicationSettingsString => _stringLocalizer.GetString("WebView_Settings_OpenApplicationSettings");
+
+    public WebViewBrowsingDataSectionView()
+    {
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
+        _commandService = ServiceLocator.AcquireService<ICommandService>();
+
+        InitializeComponent();
+    }
+
+    private void OpenApplicationSettingsButton_Click(object sender, RoutedEventArgs e)
+    {
+        _commandService.Execute<IShowSettingsCommand>(command =>
+        {
+            command.SectionKey = SettingsDialogSections.WebView;
+        });
+    }
+}

--- a/Source/Modules/Celbridge.WebView/Views/WebViewDocumentSettingsView.xaml
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewDocumentSettingsView.xaml
@@ -1,0 +1,22 @@
+<UserControl
+    x:Class="Celbridge.WebView.Views.WebViewDocumentSettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Celbridge.UserInterface.Views.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="Transparent">
+
+    <controls:SettingsSectionSwitcher x:Name="SectionSwitcher"
+                                      Margin="12">
+
+        <!-- Leaving the settings belongs to the whole surface rather than to any one section, and the URL
+             bar carrying the toggle back can be hidden, so the way out sits under the rail. -->
+        <controls:SettingsSectionSwitcher.RailFooter>
+            <Button x:Name="ReturnToPageButton"
+                    HorizontalAlignment="Stretch"
+                    Content="{x:Bind ReturnToPageString}"
+                    Click="ReturnToPageButton_Click" />
+        </controls:SettingsSectionSwitcher.RailFooter>
+
+    </controls:SettingsSectionSwitcher>
+</UserControl>

--- a/Source/Modules/Celbridge.WebView/Views/WebViewDocumentSettingsView.xaml.cs
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewDocumentSettingsView.xaml.cs
@@ -1,0 +1,145 @@
+using Celbridge.UserInterface;
+using Celbridge.UserInterface.Views.Controls;
+using Celbridge.WebView.ViewModels;
+using Microsoft.Extensions.Localization;
+
+namespace Celbridge.WebView.Views;
+
+/// <summary>
+/// The settings surface of a .webview document: a rail of sections covering the document area in place of
+/// the page. The same layout the Project Settings editor and the Application Settings dialog present, so a
+/// new section is added here the way it is added there.
+/// </summary>
+public sealed partial class WebViewDocumentSettingsView : UserControl
+{
+    /// <summary>
+    /// The key of the section holding the Home URL, which is where a document with nothing to show has to
+    /// open.
+    /// </summary>
+    public const string HomeSectionKey = "Home";
+
+    private readonly IStringLocalizer _stringLocalizer;
+
+    private WebViewDocumentViewModel? _viewModel;
+
+    // The section to fall back on when the rail reports no selection.
+    private SettingsSection? _lastSelectedSection;
+
+    public string ReturnToPageString => _stringLocalizer.GetString("WebView_Settings_ReturnToPage");
+
+    /// <summary>
+    /// Raised when the user leaves the settings from the rail footer.
+    /// </summary>
+    public event EventHandler? ReturnToPageRequested;
+
+    /// <summary>
+    /// The key of the section showing, so the document can reopen on the one the user last had open.
+    /// Empty until the sections are built.
+    /// </summary>
+    public string SelectedSectionKey => SectionSwitcher.SelectedSection?.Key ?? string.Empty;
+
+    public WebViewDocumentSettingsView()
+    {
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
+
+        InitializeComponent();
+
+        SectionSwitcher.RegisterPropertyChangedCallback(
+            SettingsSectionSwitcher.SelectedSectionProperty,
+            (_, _) => ApplySelection());
+    }
+
+    /// <summary>
+    /// Builds the sections over the document's view model, selecting the one the given key names. Called
+    /// the first time the settings are shown, so a document that never opens them builds no section views.
+    /// </summary>
+    public void Initialize(WebViewDocumentViewModel viewModel, string selectedSectionKey)
+    {
+        if (_viewModel is not null)
+        {
+            return;
+        }
+
+        _viewModel = viewModel;
+
+        var sections = BuildSections(viewModel);
+        SectionSwitcher.Sections = sections;
+
+        // An unrecognized or empty key lands on the first section, which is what a new document gets.
+        var storedSection = sections.FirstOrDefault(section => section.Key == selectedSectionKey);
+        SectionSwitcher.SelectedSection = storedSection ?? sections[0];
+    }
+
+    // The sections in rail order. The keys are persisted, so changing one drops the section a returning
+    // user had open.
+    private List<SettingsSection> BuildSections(WebViewDocumentViewModel viewModel)
+    {
+        var homeView = new WebViewHomeSectionView
+        {
+            ViewModel = viewModel
+        };
+
+        var appearanceView = new WebViewAppearanceSectionView
+        {
+            ViewModel = viewModel
+        };
+
+        var browsingDataView = new WebViewBrowsingDataSectionView();
+
+        var sections = new List<SettingsSection>
+        {
+            new(
+                HomeSectionKey,
+                "bs-house",
+                _stringLocalizer.GetString("WebView_Settings_HomeHeader"),
+                _stringLocalizer.GetString("WebView_Settings_HomeDescription"),
+                homeView),
+            new(
+                "Appearance",
+                "bs-palette",
+                _stringLocalizer.GetString("WebView_Settings_AppearanceHeader"),
+                _stringLocalizer.GetString("WebView_Settings_AppearanceDescription"),
+                appearanceView),
+            new(
+                "BrowsingData",
+                "bs-clock-history",
+                _stringLocalizer.GetString("WebView_Settings_BrowsingDataHeader"),
+                _stringLocalizer.GetString("WebView_Settings_BrowsingDataDescription"),
+                browsingDataView),
+        };
+
+        return sections;
+    }
+
+    // The switcher writes the clicked section but leaves the checked state of the rail rows to its owner,
+    // so exactly one row carries it.
+    private void ApplySelection()
+    {
+        var selectedSection = SectionSwitcher.SelectedSection;
+        if (selectedSection is null)
+        {
+            // Nothing in the rail clears the selection, but the property is public: hold the invariant that
+            // a section is always showing rather than leaving it to callers.
+            SectionSwitcher.SelectedSection = _lastSelectedSection;
+            return;
+        }
+
+        var sections = SectionSwitcher.Sections;
+        if (sections is null)
+        {
+            return;
+        }
+
+        foreach (var section in sections)
+        {
+            section.IsSelected = ReferenceEquals(section, selectedSection);
+        }
+
+        _lastSelectedSection = selectedSection;
+    }
+
+    private void ReturnToPageButton_Click(object sender, RoutedEventArgs e)
+    {
+        ReturnToPageRequested?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml
@@ -14,21 +14,12 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <!-- The settings side panel occupies column 2 and its splitter the gutter in column 1. Both
-                 collapse to zero width while the panel is closed. -->
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition x:Name="SettingsPanelColumn" Width="0" />
-        </Grid.ColumnDefinitions>
 
         <!-- Docked in its own row above the WebView, not overlaid on it: on the macOS Skia head the native
-             WKWebView sits above managed content and would otherwise intercept clicks meant for the bar.
-             Spans every column so the address box does not shrink when the settings panel opens. -->
+             WKWebView sits above managed content and takes any mouse input meant for a control drawn over
+             it, on top of delivering the same input to that control. -->
         <Border x:Name="UrlBar"
                 Grid.Row="0"
-                Grid.Column="0"
-                Grid.ColumnSpan="3"
                 Padding="8,4"
                 Background="{ThemeResource ChromeBackgroundBrush}"
                 BorderBrush="{ThemeResource DividerBrush}"
@@ -47,14 +38,14 @@
                             VerticalAlignment="Center">
                     <controls:IconButton x:Name="BackButton"
                                          VerticalAlignment="Center"
-                                         IsEnabled="{x:Bind ViewModel.CanGoBack, Mode=OneWay}"
+                                         IsEnabled="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay}"
                                          ToolTipService.ToolTip="{x:Bind BackTooltipString}"
                                          Click="BackButton_Click">
                         <controls:Icon Symbol="Back" FontSize="{StaticResource IconSizeMedium}" />
                     </controls:IconButton>
                     <controls:IconButton x:Name="ForwardButton"
                                          VerticalAlignment="Center"
-                                         IsEnabled="{x:Bind ViewModel.CanGoForward, Mode=OneWay}"
+                                         IsEnabled="{x:Bind ViewModel.IsForwardEnabled, Mode=OneWay}"
                                          ToolTipService.ToolTip="{x:Bind ForwardTooltipString}"
                                          Click="ForwardButton_Click">
                         <controls:Icon Symbol="Forward" FontSize="{StaticResource IconSizeMedium}" />
@@ -74,20 +65,23 @@
                     </controls:IconButton>
                     <controls:IconButton x:Name="HomeButton"
                                          VerticalAlignment="Center"
-                                         IsEnabled="{x:Bind ViewModel.IsHomeUrlValid, Mode=OneWay}"
+                                         IsEnabled="{x:Bind ViewModel.IsHomeEnabled, Mode=OneWay}"
                                          ToolTipService.ToolTip="{x:Bind HomeTooltipString}"
                                          Click="HomeButton_Click">
                         <controls:Icon Symbol="Home" FontSize="{StaticResource IconSizeMedium}" />
                     </controls:IconButton>
                 </StackPanel>
 
+                <!-- Read-only rather than disabled while the settings are showing, so the address can
+                     still be selected and copied. -->
                 <TextBox x:Name="AddressTextBox"
                          Grid.Column="1"
                          MinHeight="32"
                          VerticalAlignment="Center"
                          IsSpellCheckEnabled="False"
+                         IsReadOnly="{x:Bind ViewModel.IsAddressReadOnly, Mode=OneWay}"
                          PlaceholderText="{x:Bind AddressPlaceholderString}"
-                         Text="{x:Bind ViewModel.CurrentUrl, Mode=OneWay}"
+                         Text="{x:Bind ViewModel.AddressText, Mode=OneWay}"
                          KeyDown="AddressTextBox_KeyDown" />
 
                 <StackPanel Grid.Column="2"
@@ -120,160 +114,92 @@
                                          Click="OpenInBrowserButton_Click">
                         <controls:Icon Symbol="Reveal" FontSize="{StaticResource IconSizeMedium}" />
                     </controls:IconButton>
-                    <!-- A toggle rather than a plain button: the panel stays open until it is closed and
-                         its state is saved with the document, so it takes the accent fill the way any other
-                         selected control does. -->
+                    <!-- A toggle rather than a plain button: the settings stay open until they are closed
+                         and their state is saved with the document, so it takes the accent fill the way any
+                         other selected control does. -->
                     <controls:IconToggleButton x:Name="SettingsButton"
                                                VerticalAlignment="Center"
                                                ToolTipService.ToolTip="{x:Bind SettingsTooltipString}"
-                                               IsChecked="{x:Bind ViewModel.IsSettingsPanelOpen, Mode=TwoWay}">
+                                               IsChecked="{x:Bind ViewModel.IsSettingsOpen, Mode=TwoWay}">
                         <controls:Icon Symbol="Sliders" FontSize="{StaticResource IconSizeMedium}" />
                     </controls:IconToggleButton>
                 </StackPanel>
             </Grid>
         </Border>
 
-        <!-- The find bar sits inside the content column rather than spanning the full width: it drives
-             the WebView through IWebViewFindTarget and applies to nothing else. -->
+        <!-- Sits in its own row above the page, for the same reason the URL bar does. -->
         <local:WebViewFindBar x:Name="FindBar"
-                              Grid.Row="1"
-                              Grid.Column="0" />
+                              Grid.Row="1" />
 
         <Grid x:Name="AppWebViewContainer"
               Grid.Row="2"
-              Grid.Column="0"
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch" />
 
-        <!-- The splitter fills its own gutter column so its grab area never overlaps the WebView, where a
-             drag would be unreliable on macOS. It spans both content rows so the panel edge is grabbable
-             along its whole length. -->
-        <!-- Divides two panes inside one document rather than two workspace panels, so there is no gutter
-             behind it and it fills its own band. Chrome rather than the gutter tone, which is what marks
-             the divide as internal to one document. A band drawing an edge on each side needs a pixel more
-             than the shared GutterSize to read at the same width. -->
-        <controls:Splitter x:Name="SettingsPanelSplitter"
-                           Grid.Row="1"
-                           Grid.RowSpan="2"
-                           Grid.Column="1"
-                           Orientation="Vertical"
-                           GrabAreaBrush="{ThemeResource ChromeBackgroundBrush}"
-                           GrabAreaSize="8"
-                           Visibility="Collapsed" />
-
-        <Border Grid.Row="1"
-                Grid.RowSpan="2"
-                Grid.Column="2"
+        <!-- Shown before the document has an address, in place of the blank page a new document would
+             otherwise present. The WebView is hidden while this shows, so the blank page does not read as
+             a broken one. -->
+        <Border x:Name="ContentPlaceholder"
+                Grid.Row="2"
                 Background="{ThemeResource ContentBackgroundBrush}"
-                Visibility="{x:Bind ViewModel.IsSettingsPanelVisible, Mode=OneWay}">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
+                Visibility="Collapsed">
+            <StackPanel HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        MaxWidth="360"
+                        Spacing="12">
+                <!-- Sized for an empty state rather than from the icon scale, which sizes glyphs sitting
+                     in controls. -->
+                <controls:Icon IconName="bs-globe"
+                               FontSize="48"
+                               HorizontalAlignment="Center"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Visibility="{x:Bind ViewModel.IsEmptyStateVisible, Mode=OneWay}" />
 
-                <!-- A panel header is chrome over the panel's content, matching PanelHeader and the settings
-                     panels in the web editors. Fixed rather than scrolling: the chevron is the panel's only
-                     way out once the URL bar carrying the settings toggle is hidden. It sits on the inner
-                     edge facing the page and points out towards the application edge, which is where the
-                     Side area puts its own collapse chevron. -->
-                <Grid Grid.Row="0"
-                      Height="40"
-                      Background="{ThemeResource ChromeBackgroundBrush}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
+                <TextBlock Text="{x:Bind PlaceholderAddressHintString}"
+                           HorizontalAlignment="Center"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           Style="{StaticResource SupportingTextStyle}"
+                           Visibility="{x:Bind ViewModel.IsAddressHintVisible, Mode=OneWay}" />
 
-                    <controls:IconButton Grid.Column="0"
-                                         Margin="8,0,0,0"
-                                         VerticalAlignment="Center"
-                                         ToolTipService.ToolTip="{x:Bind CloseSettingsTooltipString}"
-                                         Click="CloseSettingsButton_Click">
-                        <controls:Icon Symbol="ChevronRight" FontSize="{StaticResource IconSizeMedium}" />
-                    </controls:IconButton>
+                <TextBlock Text="{x:Bind PlaceholderSettingsHintString}"
+                           HorizontalAlignment="Center"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           Style="{StaticResource SupportingTextStyle}"
+                           Visibility="{x:Bind ViewModel.IsSettingsHintVisible, Mode=OneWay}" />
 
-                    <TextBlock Grid.Column="1"
-                               Text="{x:Bind SettingsTitleString}"
-                               Style="{StaticResource PanelTitleTextStyle}"
-                               Margin="6,0,12,0"
-                               VerticalAlignment="Center"
-                               TextTrimming="CharacterEllipsis" />
-                </Grid>
+                <!-- The address bar names the page that failed, so this reports the failure and what to do
+                     about it rather than repeating the address. -->
+                <controls:Icon IconName="bs-exclamation-triangle"
+                               FontSize="48"
+                               HorizontalAlignment="Center"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Visibility="{x:Bind ViewModel.IsLoadFailedVisible, Mode=OneWay}" />
 
-                <ScrollViewer Grid.Row="1" Padding="12,0,12,12">
-                    <!-- Groups are separated by space rather than boxed: the panel already reads as one
-                         surface, and with this few controls the field labels carry the structure. -->
-                    <StackPanel Spacing="20">
-                        <StackPanel Spacing="4">
-                            <!-- The Home URL takes the full panel width rather than a form row: a URL is too
-                                 long to read in the half-width control column of a side panel. -->
-                            <TextBlock Text="{x:Bind HomeUrlLabelString}"
-                                       Style="{StaticResource FieldLabelTextStyle}" />
-                            <TextBox IsSpellCheckEnabled="False"
-                                     PlaceholderText="{x:Bind AddressPlaceholderString}"
-                                     ToolTipService.ToolTip="{x:Bind ViewModel.HomeUrlTooltip, Mode=OneWay}"
-                                     Text="{x:Bind ViewModel.SourceUrl, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
-                            <TextBlock Text="{x:Bind InvalidUrlString}"
-                                       Style="{StaticResource SupportingTextStyle}"
-                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                       TextWrapping="Wrap"
-                                       Visibility="{x:Bind ViewModel.IsHomeUrlInvalid, Mode=OneWay}" />
+                <TextBlock Text="{x:Bind PlaceholderLoadFailedString}"
+                           HorizontalAlignment="Center"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           Style="{StaticResource FieldLabelTextStyle}"
+                           Visibility="{x:Bind ViewModel.IsLoadFailedVisible, Mode=OneWay}" />
 
-                            <Button HorizontalAlignment="Stretch"
-                                    Margin="0,4,0,0"
-                                    Content="{x:Bind SetCurrentPageAsHomeString}"
-                                    IsEnabled="{x:Bind ViewModel.CanSetCurrentPageAsHome, Mode=OneWay}"
-                                    Click="SetCurrentPageAsHomeButton_Click" />
-                            <Button HorizontalAlignment="Stretch"
-                                    Content="{x:Bind NewDocumentString}"
-                                    ToolTipService.ToolTip="{x:Bind NewDocumentTooltipString}"
-                                    IsEnabled="{x:Bind ViewModel.CanCreateDocumentFromCurrentPage, Mode=OneWay}"
-                                    Click="NewDocumentButton_Click" />
-                        </StackPanel>
-
-                        <StackPanel Spacing="4">
-                            <!-- The label takes the free width and the switch sits at the panel edge, rather
-                                 than the fixed label column a full-width settings page uses. -->
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-
-                                <TextBlock Grid.Column="0"
-                                           Text="{x:Bind ShowUrlBarLabelString}"
-                                           Style="{StaticResource FieldLabelTextStyle}"
-                                           VerticalAlignment="Center"
-                                           TextTrimming="CharacterEllipsis" />
-
-                                <ToggleSwitch Grid.Column="1"
-                                              MinWidth="0"
-                                              OnContent=""
-                                              OffContent=""
-                                              IsOn="{x:Bind ViewModel.ShowUrlBar, Mode=TwoWay}" />
-                            </Grid>
-
-                            <!-- Shown before the bar is hidden, not after, so the way back is known in
-                                 advance rather than discovered once the toggle is out of reach. -->
-                            <TextBlock Text="{x:Bind ShowUrlBarHintString}"
-                                       Style="{StaticResource SupportingTextStyle}"
-                                       TextWrapping="Wrap" />
-                        </StackPanel>
-
-                        <StackPanel Spacing="4">
-                            <!-- A pointer rather than a clear action: every WebView in the application
-                                 shares one profile, so clearing is application-wide and belongs in
-                                 Application Settings where it cannot read as per-document. -->
-                            <TextBlock Text="{x:Bind BrowsingDataLabelString}"
-                                       Style="{StaticResource FieldLabelTextStyle}" />
-                            <TextBlock Text="{x:Bind BrowsingDataHintString}"
-                                       Style="{StaticResource SupportingTextStyle}"
-                                       TextWrapping="Wrap" />
-                        </StackPanel>
-                    </StackPanel>
-                </ScrollViewer>
-            </Grid>
+                <TextBlock Text="{x:Bind PlaceholderLoadFailedHintString}"
+                           HorizontalAlignment="Center"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           Style="{StaticResource SupportingTextStyle}"
+                           Visibility="{x:Bind ViewModel.IsLoadFailedVisible, Mode=OneWay}" />
+            </StackPanel>
         </Border>
+
+        <!-- Takes the content row in place of the page rather than sitting beside it, so opening the
+             settings never resizes the WebView and reflows what the page is showing. The WebView is hidden
+             while this shows, which is also what keeps a hosted web view from taking mouse input meant for
+             the settings on the macOS Skia head. -->
+        <local:WebViewDocumentSettingsView x:Name="SettingsSurface"
+                                           Grid.Row="2"
+                                           Visibility="Collapsed" />
+
     </Grid>
 </documents:DocumentView>

--- a/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
@@ -9,7 +9,6 @@ using Celbridge.Logging;
 using Celbridge.Platform;
 using Celbridge.Projects;
 using Celbridge.UserInterface;
-using Celbridge.UserInterface.Helpers;
 using Celbridge.WebHost;
 using Celbridge.WebHost.Services;
 using Celbridge.WebView.Services;
@@ -22,29 +21,22 @@ using Windows.System;
 namespace Celbridge.WebView.Views;
 
 /// <summary>
-/// The per-user view state of a .webview document: whether the settings side panel is open and how wide
-/// it is. Persisted through the document editor state, not the .webview file.
+/// The per-user view state of a .webview document: whether the settings are open and which section they
+/// are showing. Persisted through the document editor state, not the .webview file.
 /// </summary>
-internal sealed record WebViewEditorState(bool SettingsPanelOpen, double SettingsPanelWidth);
+internal sealed record WebViewEditorState(bool SettingsOpen, string SettingsSectionKey);
 
 /// <summary>
 /// Hosts an arbitrary user URL from a .webview document, or a project-served
 /// HTML page from a .html / .htm document. The two roles share a single WebView2
 /// lifecycle and differ only in URL source, navigation policy, and chrome: the
 /// external-URL role presents a browser-style URL bar above the page and a
-/// resizable settings side panel beside it.
+/// resizable settings panel over it.
 /// </summary>
 public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFindableDocument, IWebViewFindTarget, IDocumentChromeOwner
 {
     // How long the settled download indicator stays visible before fading out.
     private static readonly TimeSpan DownloadIndicatorDismissDelay = TimeSpan.FromSeconds(10);
-
-    // Sized so the panel's action buttons carry their full labels, with headroom for longer translations.
-    // A URL is too long to fit at any width a side panel can take, so the address is left to scroll.
-    private const double DefaultSettingsPanelWidth = 340;
-    private const double MinSettingsPanelWidth = 260;
-    // The narrowest the page is allowed to become while the settings panel is dragged wider.
-    private const double MinWebViewWidth = 240;
 
     private static readonly JsonSerializerOptions EditorStateSerializerOptions = new()
     {
@@ -70,8 +62,11 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
 
     private DispatcherTimer? _downloadIndicatorDismissTimer;
 
-    private readonly SplitterHelper _settingsPanelSplitterHelper;
-    private double _settingsPanelWidth = DefaultSettingsPanelWidth;
+    // The section the settings reopen on, carried until the surface is built on first use.
+    private string _settingsSectionKey = string.Empty;
+
+    // Where the page was last told to go, held until the committed address catches up with it.
+    private string _pendingNavigationUrl = string.Empty;
 
     // Set on successful registration with the bridge. Only populated for the
     // HtmlViewer role. .webview (external URL) documents do not register and the
@@ -98,17 +93,10 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
     private string AddressPlaceholderString => _stringLocalizer.GetString("WebView_UrlBar_AddressPlaceholder");
     private string OpenInBrowserTooltipString => _stringLocalizer.GetString("WebView_UrlBar_OpenInBrowserTooltip");
     private string SettingsTooltipString => _stringLocalizer.GetString("WebView_UrlBar_SettingsTooltip");
-    private string SettingsTitleString => _stringLocalizer.GetString("WebView_Settings_Title");
-    private string CloseSettingsTooltipString => _stringLocalizer.GetString("WebView_Settings_CloseTooltip");
-    private string HomeUrlLabelString => _stringLocalizer.GetString("WebView_Settings_HomeUrlLabel");
-    private string InvalidUrlString => _stringLocalizer.GetString("WebView_InvalidUrl");
-    private string SetCurrentPageAsHomeString => _stringLocalizer.GetString("WebView_Settings_SetCurrentPageAsHome");
-    private string NewDocumentString => _stringLocalizer.GetString("WebView_Settings_NewDocument");
-    private string NewDocumentTooltipString => _stringLocalizer.GetString("WebView_Settings_NewDocumentTooltip");
-    private string ShowUrlBarLabelString => _stringLocalizer.GetString("WebView_Settings_ShowUrlBarLabel");
-    private string ShowUrlBarHintString => _stringLocalizer.GetString("WebView_Settings_ShowUrlBarHint");
-    private string BrowsingDataLabelString => _stringLocalizer.GetString("WebView_Settings_BrowsingDataLabel");
-    private string BrowsingDataHintString => _stringLocalizer.GetString("WebView_Settings_BrowsingDataHint");
+    private string PlaceholderAddressHintString => _stringLocalizer.GetString("WebView_Placeholder_AddressHint");
+    private string PlaceholderSettingsHintString => _stringLocalizer.GetString("WebView_Placeholder_SettingsHint");
+    private string PlaceholderLoadFailedString => _stringLocalizer.GetString("WebView_Placeholder_LoadFailed");
+    private string PlaceholderLoadFailedHintString => _stringLocalizer.GetString("WebView_Placeholder_LoadFailedHint");
 
     public WebViewDocumentView(
         IServiceProvider serviceProvider,
@@ -136,19 +124,7 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
         FindBar.Attach(this);
         FindBar.Closed += OnFindBarClosed;
 
-        // The panel is docked to the right edge, so a drag towards the page has to widen it.
-        _settingsPanelSplitterHelper = new SplitterHelper(
-            LayoutRoot,
-            GridResizeMode.Columns,
-            index: 2,
-            minSizeFunc: () => MinSettingsPanelWidth,
-            invertDelta: true,
-            maxSizeFunc: () => LayoutRoot.ActualWidth - MinWebViewWidth);
-
-        SettingsPanelSplitter.DragStarted += SettingsPanelSplitter_DragStarted;
-        SettingsPanelSplitter.DragDelta += SettingsPanelSplitter_DragDelta;
-        SettingsPanelSplitter.DragCompleted += SettingsPanelSplitter_DragCompleted;
-        SettingsPanelSplitter.DoubleClicked += SettingsPanelSplitter_DoubleClicked;
+        SettingsSurface.ReturnToPageRequested += SettingsSurface_ReturnToPageRequested;
 
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
         UpdateReloadOrStopTooltip();
@@ -173,6 +149,13 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
         Navigate(navigateUrl);
     }
 
+    // Drops the page and returns the document to the placeholder it started on. A real navigation rather
+    // than just clearing the address, so the page being left stops running instead of playing on unseen.
+    private void ClearPage()
+    {
+        Navigate("about:blank");
+    }
+
     private void Navigate(string url)
     {
         if (_webView is null)
@@ -191,7 +174,12 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
         // the Skia heads raise no navigation event for it at all, not even once the tab is later shown, so
         // its address bar would otherwise stay empty for the life of the document. Any redirect is picked
         // up by the navigation events as usual.
+        // A document restored into a background tab navigates with no events at all, so the failure a
+        // previous navigation reported is cleared here rather than in NavigationStarting alone.
+        ViewModel.HasNavigationFailed = false;
+
         ViewModel.CurrentUrl = uri.AbsoluteUri;
+        _pendingNavigationUrl = uri.AbsoluteUri;
 
         _webView.Source = uri;
     }
@@ -512,7 +500,7 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
             }
         }
 
-        ViewModel.IsNavigating = false;
+        ViewModel.NotifyNavigationCompleted(e.IsSuccess);
         UpdateNavigationState();
     }
 
@@ -526,10 +514,11 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
             _toolBridge?.NotifyContentLoading(FileResource);
         }
 
-        ViewModel.IsNavigating = true;
+        ViewModel.NotifyNavigationStarted();
         if (!string.IsNullOrEmpty(args.Uri))
         {
             ViewModel.CurrentUrl = args.Uri;
+            _pendingNavigationUrl = args.Uri;
         }
     }
 
@@ -542,7 +531,27 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
 
         ViewModel.CanGoBack = _webView.CanGoBack;
         ViewModel.CanGoForward = _webView.CanGoForward;
-        ViewModel.CurrentUrl = _webView.Source?.AbsoluteUri ?? string.Empty;
+
+        // Source names the last committed navigation, so while one is in flight it still reports the page
+        // being left. With nothing pending it is the only signal for a same-document navigation, which
+        // raises no navigation event.
+        var committedUrl = _webView.CoreWebView2?.Source;
+        if (string.IsNullOrEmpty(committedUrl))
+        {
+            return;
+        }
+
+        if (_pendingNavigationUrl.Length > 0
+            && committedUrl != _pendingNavigationUrl)
+        {
+            return;
+        }
+
+        _pendingNavigationUrl = string.Empty;
+
+        // CoreWebView2.Source rather than WebView2.Source, which reports the address percent-encoded where
+        // this reports it as the page shows it.
+        ViewModel.CurrentUrl = committedUrl;
     }
 
     private void BackButton_Click(object sender, RoutedEventArgs e)
@@ -577,10 +586,14 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
                 // Unlike the other navigation commands, Stop has no equivalent on the WebView2 control, and
                 // the CoreWebView2 member behind it is unimplemented on the Skia heads, so it goes through
                 // the adapter.
+                ViewModel.NotifyNavigationStopped();
                 await _webViewAdapter.StopAsync(coreWebView2);
             }
             else
             {
+                // Reload acts on the page, not on the address box, so an uncommitted edit there is
+                // dropped rather than left standing over a page it does not name.
+                SyncAddressText();
                 await _webViewAdapter.ReloadAsync(coreWebView2, clearCache: true);
             }
         }
@@ -594,8 +607,18 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
     {
         if (ViewModel.TryNormalizeUserUrl(ViewModel.SourceUrl, out var homeUrl))
         {
+            // Navigating to the address already showing raises no change for the binding to follow, so an
+            // uncommitted edit in the box would survive the navigation.
+            SyncAddressText();
             Navigate(homeUrl);
         }
+    }
+
+    // Puts the address the page is actually showing back in the box, discarding an edit the user typed
+    // but never committed.
+    private void SyncAddressText()
+    {
+        AddressTextBox.Text = ViewModel.AddressText;
     }
 
     private void OpenInBrowserButton_Click(object sender, RoutedEventArgs e)
@@ -605,9 +628,23 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
 
     private void AddressTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
     {
+        if (ViewModel.IsSettingsVisible)
+        {
+            // Read-only stops the address being edited, but Enter would still navigate what it already
+            // holds, and Escape would discard a selection the user made to copy from.
+            return;
+        }
+
         if (e.Key == VirtualKey.Enter)
         {
-            if (ViewModel.TryNormalizeUserUrl(AddressTextBox.Text, out var url))
+            var address = AddressTextBox.Text.Trim();
+            if (address.Length == 0)
+            {
+                // Committing an empty address is a request to go nowhere, which leaves the document on
+                // the placeholder rather than on the page it happened to be showing.
+                ClearPage();
+            }
+            else if (ViewModel.TryNormalizeUserUrl(address, out var url))
             {
                 Navigate(url);
 
@@ -621,63 +658,75 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
         else if (e.Key == VirtualKey.Escape)
         {
             // Abandon the edit: restore the address the page is actually showing and return to the content.
-            AddressTextBox.Text = ViewModel.CurrentUrl;
+            SyncAddressText();
             GiveFocusToWebContent();
 
             e.Handled = true;
         }
     }
 
-    private void CloseSettingsButton_Click(object sender, RoutedEventArgs e)
+    // A document with neither an address nor a URL bar to type one into has no way in, so it opens on the
+    // settings whatever state it was saved in. Home is the section holding the URL, and a restored section
+    // would otherwise land the user somewhere that cannot help.
+    private void OpenSettingsIfNoWayToNavigate()
     {
-        ViewModel.CloseSettingsPanel();
-    }
-
-    private void SetCurrentPageAsHomeButton_Click(object sender, RoutedEventArgs e)
-    {
-        ViewModel.SetCurrentPageAsHome();
-    }
-
-    private void NewDocumentButton_Click(object sender, RoutedEventArgs e)
-    {
-        ViewModel.CreateDocumentFromCurrentPage();
-    }
-
-    private void SettingsPanelSplitter_DragStarted(object? sender, EventArgs e)
-    {
-        _settingsPanelSplitterHelper.OnDragStarted();
-    }
-
-    private void SettingsPanelSplitter_DragDelta(object? sender, double delta)
-    {
-        _settingsPanelSplitterHelper.OnDragDelta(delta);
-    }
-
-    private void SettingsPanelSplitter_DragCompleted(object? sender, EventArgs e)
-    {
-        _settingsPanelWidth = SettingsPanelColumn.ActualWidth;
-    }
-
-    private void SettingsPanelSplitter_DoubleClicked(object? sender, EventArgs e)
-    {
-        _settingsPanelWidth = DefaultSettingsPanelWidth;
-        ApplySettingsPanelLayout();
-    }
-
-    // Drives the panel column and its splitter gutter from the view model's open state. The panel border
-    // binds its own visibility, but the column and the splitter are layout, not content.
-    private void ApplySettingsPanelLayout()
-    {
-        if (ViewModel.IsSettingsPanelVisible)
+        if (Options.Role != WebViewDocumentRole.ExternalUrl
+            || !string.IsNullOrWhiteSpace(ViewModel.SourceUrl)
+            || ViewModel.ShowUrlBar)
         {
-            SettingsPanelColumn.Width = new GridLength(_settingsPanelWidth, GridUnitType.Pixel);
-            SettingsPanelSplitter.Visibility = Visibility.Visible;
+            return;
         }
-        else
+
+        _settingsSectionKey = WebViewDocumentSettingsView.HomeSectionKey;
+        ViewModel.IsSettingsOpen = true;
+
+        // The open state may be unchanged, which raises no property change to drive the layout.
+        ApplyContentLayout();
+    }
+
+    // A document showing nothing navigates as soon as it is given an address. One already showing a page
+    // keeps it: changing the Home URL is not a request to leave the page.
+    private void NavigateIfPageIsBlank()
+    {
+        if (Options.Role != WebViewDocumentRole.ExternalUrl
+            || ViewModel.HasPage)
         {
-            SettingsPanelColumn.Width = new GridLength(0);
-            SettingsPanelSplitter.Visibility = Visibility.Collapsed;
+            return;
         }
+
+        TryNavigate();
+    }
+
+    private void SettingsSurface_ReturnToPageRequested(object? sender, EventArgs e)
+    {
+        ViewModel.CloseSettings();
+
+        // The button that asked has just collapsed with the settings, so the keyboard has nowhere to go.
+        GiveFocusToWebContent();
+    }
+
+    // Gives the document area to whichever of the page, the settings and the placeholder belongs there.
+    // The WebView is collapsed rather than covered by either of the other two: a hosted web view is a
+    // native view above the canvas they are drawn on, so while it is shown it takes mouse input meant for
+    // them, and the cursor over it answers to the page.
+    private void ApplyContentLayout()
+    {
+        var showSettings = ViewModel.IsSettingsVisible;
+        if (showSettings)
+        {
+            SettingsSurface.Initialize(ViewModel, _settingsSectionKey);
+
+            // Find applies to the page, which is no longer on screen. Closing the bar hands the keyboard
+            // back to the page, so only do it when the bar is actually showing.
+            if (FindBar.Visibility == Visibility.Visible)
+            {
+                FindBar.Close();
+            }
+        }
+
+        SettingsSurface.Visibility = showSettings ? Visibility.Visible : Visibility.Collapsed;
+        ContentPlaceholder.Visibility = ViewModel.IsPlaceholderVisible ? Visibility.Visible : Visibility.Collapsed;
+        AppWebViewContainer.Visibility = ViewModel.IsPageOnScreen ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void DownloadIndicatorButton_Click(object sender, RoutedEventArgs e)
@@ -698,9 +747,18 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
         {
             UpdateDownloadIndicatorTooltip();
         }
-        else if (e.PropertyName == nameof(WebViewDocumentViewModel.IsSettingsPanelVisible))
+        else if (e.PropertyName == nameof(WebViewDocumentViewModel.IsSettingsVisible))
         {
-            ApplySettingsPanelLayout();
+            ApplyContentLayout();
+        }
+        else if (e.PropertyName == nameof(WebViewDocumentViewModel.CurrentUrl)
+            || e.PropertyName == nameof(WebViewDocumentViewModel.HasNavigationFailed))
+        {
+            ApplyContentLayout();
+        }
+        else if (e.PropertyName == nameof(WebViewDocumentViewModel.SourceUrl))
+        {
+            NavigateIfPageIsBlank();
         }
     }
 
@@ -993,6 +1051,8 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
             return loadResult;
         }
 
+        OpenSettingsIfNoWayToNavigate();
+
         // Runs after the view model so NavigateUrl is resolved by the time initialization navigates.
         var wasInitialized = _initializeWebViewTask is not null;
         await EnsureWebViewInitializedAsync();
@@ -1022,15 +1082,23 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
     {
         await Task.CompletedTask;
 
-        // A view that has not finished initializing would report a default panel state, which the layout
-        // store would then write over good saved state. The HTML viewer has no settings panel at all.
+        // A view that has not finished initializing would report a default settings state, which the
+        // layout store would then write over good saved state. The HTML viewer has no settings at all.
         if (Options.Role != WebViewDocumentRole.ExternalUrl ||
             _webView is null)
         {
             return null;
         }
 
-        var editorState = new WebViewEditorState(ViewModel.IsSettingsPanelOpen, _settingsPanelWidth);
+        var sectionKey = SettingsSurface.SelectedSectionKey;
+        if (string.IsNullOrEmpty(sectionKey))
+        {
+            // The surface builds its sections on first use, so a document that never opened the settings
+            // carries the section it was restored with rather than reporting none.
+            sectionKey = _settingsSectionKey;
+        }
+
+        var editorState = new WebViewEditorState(ViewModel.IsSettingsOpen, sectionKey);
 
         return JsonSerializer.Serialize(editorState, EditorStateSerializerOptions);
     }
@@ -1060,12 +1128,16 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
             return;
         }
 
-        _settingsPanelWidth = Math.Max(editorState.SettingsPanelWidth, MinSettingsPanelWidth);
-        ViewModel.IsSettingsPanelOpen = editorState.SettingsPanelOpen;
+        _settingsSectionKey = editorState.SettingsSectionKey;
+        ViewModel.IsSettingsOpen = editorState.SettingsOpen;
 
         // The open state may be unchanged from the default, which raises no property change, so apply the
         // layout directly rather than relying on the view model notification.
-        ApplySettingsPanelLayout();
+        ApplyContentLayout();
+
+        // Restoring runs after the content loads, so a saved closed state would otherwise put a document
+        // with no way in back to its blank page.
+        OpenSettingsIfNoWayToNavigate();
     }
 
     // The URL bar is the only chrome this view hides, and it carries every control the view owns.
@@ -1091,6 +1163,14 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
 
     public override void FocusDocument()
     {
+        if (ViewModel.IsSettingsVisible)
+        {
+            // The page is collapsed behind the settings, and native focus on macOS would land on a hidden
+            // web view that no keystroke could ever leave.
+            SettingsSurface.Focus(FocusState.Programmatic);
+            return;
+        }
+
         // A tab click focuses the web content (native first responder on macOS, where no managed GotFocus
         // follows). The registry gives it focus and reports it, releasing the previously focused surface.
         GiveFocusToWebContent();
@@ -1128,9 +1208,12 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
         await host.NotifyGrantFocusAsync();
     }
 
-    // True when the host find bar can drive this document: the WebView is live and its backend has no find UI
-    // of its own (the Windows Chromium heads do, so they report false and keep their built-in bar).
-    public bool CanFind => !_webViewAdapter.ProvidesBuiltInFind && _webView?.CoreWebView2 is not null;
+    // True when the host find bar can drive this document: the page is the thing on screen, the WebView is
+    // live, and its backend has no find UI of its own (the Windows Chromium heads do, so they report false
+    // and keep their built-in bar).
+    public bool CanFind => ViewModel.IsPageOnScreen
+        && !_webViewAdapter.ProvidesBuiltInFind
+        && _webView?.CoreWebView2 is not null;
 
     public bool TryBeginFind()
     {

--- a/Source/Modules/Celbridge.WebView/Views/WebViewHomeSectionView.xaml
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewHomeSectionView.xaml
@@ -1,0 +1,35 @@
+<UserControl
+    x:Class="Celbridge.WebView.Views.WebViewHomeSectionView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+
+    <StackPanel Spacing="12">
+
+        <StackPanel Spacing="2">
+            <TextBlock Text="{x:Bind HomeUrlLabelString}"
+                       Style="{StaticResource FieldLabelTextStyle}" />
+            <TextBox IsSpellCheckEnabled="False"
+                     PlaceholderText="{x:Bind AddressPlaceholderString}"
+                     ToolTipService.ToolTip="{x:Bind ViewModel.HomeUrlTooltip, Mode=OneWay}"
+                     Text="{x:Bind ViewModel.SourceUrl, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+            <TextBlock Text="{x:Bind InvalidUrlString}"
+                       Style="{StaticResource SupportingTextStyle}"
+                       Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                       TextWrapping="Wrap"
+                       Visibility="{x:Bind ViewModel.IsHomeUrlInvalid, Mode=OneWay}" />
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal"
+                    Spacing="8">
+            <Button Content="{x:Bind SetCurrentPageAsHomeString}"
+                    IsEnabled="{x:Bind ViewModel.CanSetCurrentPageAsHome, Mode=OneWay}"
+                    Click="SetCurrentPageAsHomeButton_Click" />
+            <Button Content="{x:Bind NewDocumentString}"
+                    ToolTipService.ToolTip="{x:Bind NewDocumentTooltipString}"
+                    IsEnabled="{x:Bind ViewModel.CanCreateDocumentFromCurrentPage, Mode=OneWay}"
+                    Click="NewDocumentButton_Click" />
+        </StackPanel>
+
+    </StackPanel>
+</UserControl>

--- a/Source/Modules/Celbridge.WebView/Views/WebViewHomeSectionView.xaml.cs
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewHomeSectionView.xaml.cs
@@ -1,0 +1,52 @@
+using Celbridge.UserInterface;
+using Celbridge.WebView.ViewModels;
+using Microsoft.Extensions.Localization;
+
+namespace Celbridge.WebView.Views;
+
+/// <summary>
+/// The Home section of the Web View settings: the URL the document opens on, and the actions that adopt
+/// the page on screen as that URL or as a new document.
+/// </summary>
+public sealed partial class WebViewHomeSectionView : UserControl
+{
+    private readonly IStringLocalizer _stringLocalizer;
+
+    private WebViewDocumentViewModel? _viewModel;
+
+    // Supplied by the surface that owns this section. Assigning it refreshes the bindings so the section
+    // populates once the surface hands over its instance.
+    public WebViewDocumentViewModel? ViewModel
+    {
+        get => _viewModel;
+        set
+        {
+            _viewModel = value;
+            Bindings?.Update();
+        }
+    }
+
+    public string HomeUrlLabelString => _stringLocalizer.GetString("WebView_Settings_HomeUrlLabel");
+    public string AddressPlaceholderString => _stringLocalizer.GetString("WebView_UrlBar_AddressPlaceholder");
+    public string InvalidUrlString => _stringLocalizer.GetString("WebView_InvalidUrl");
+    public string SetCurrentPageAsHomeString => _stringLocalizer.GetString("WebView_Settings_SetCurrentPageAsHome");
+    public string NewDocumentString => _stringLocalizer.GetString("WebView_Settings_NewDocument");
+    public string NewDocumentTooltipString => _stringLocalizer.GetString("WebView_Settings_NewDocumentTooltip");
+
+    public WebViewHomeSectionView()
+    {
+        _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
+
+        InitializeComponent();
+    }
+
+    private void SetCurrentPageAsHomeButton_Click(object sender, RoutedEventArgs e)
+    {
+        ViewModel?.SetCurrentPageAsHome();
+    }
+
+    private void NewDocumentButton_Click(object sender, RoutedEventArgs e)
+    {
+        ViewModel?.CreateDocumentFromCurrentPage();
+    }
+}

--- a/Source/Tests/UserInterface/SettingsDialogViewModelTests.cs
+++ b/Source/Tests/UserInterface/SettingsDialogViewModelTests.cs
@@ -85,7 +85,7 @@ public class SettingsDialogViewModelTests
         };
 
         var viewModel = new SettingsDialogViewModel(_settingsService);
-        viewModel.InitializeSections(reorderedSections);
+        viewModel.InitializeSections(reorderedSections, string.Empty);
 
         viewModel.SelectedSection.Should().Be(WebView);
     }
@@ -130,16 +130,51 @@ public class SettingsDialogViewModelTests
     }
 
     [Test]
+    public void ARequestedCategory_IsSelectedOverTheStoredOne()
+    {
+        // A caller opening the dialog on a category is answering its own question, not returning the user
+        // to where they were.
+        _settingsService.Set(SettingCatalog.Application.SettingsDialogSelectedSection, "Workshop");
+
+        var viewModel = CreateViewModel(requestedSectionKey: "WebView");
+
+        viewModel.SelectedSection.Should().Be(WebView);
+    }
+
+    [Test]
+    public void ARequestedCategory_DoesNotDisplaceTheStoredOne()
+    {
+        // The jump is the caller's choice rather than the user's, so the category they chose for
+        // themselves is still there the next time they open the dialog from the menu.
+        _settingsService.Set(SettingCatalog.Application.SettingsDialogSelectedSection, "Workshop");
+
+        CreateViewModel(requestedSectionKey: "WebView");
+
+        var storedKey = _settingsService.Get(SettingCatalog.Application.SettingsDialogSelectedSection);
+        storedKey.Should().Be("Workshop");
+    }
+
+    [Test]
+    public void AnUnknownRequestedKey_FallsBackToTheStoredCategory()
+    {
+        _settingsService.Set(SettingCatalog.Application.SettingsDialogSelectedSection, "Workshop");
+
+        var viewModel = CreateViewModel(requestedSectionKey: "Retired");
+
+        viewModel.SelectedSection.Should().Be(Workshop);
+    }
+
+    [Test]
     public void InitializeSections_RejectsAnEmptyRail()
     {
         var viewModel = new SettingsDialogViewModel(_settingsService);
 
-        var initialize = () => viewModel.InitializeSections(Array.Empty<SettingsSection>());
+        var initialize = () => viewModel.InitializeSections(Array.Empty<SettingsSection>(), string.Empty);
 
         initialize.Should().Throw<InvalidOperationException>();
     }
 
-    private SettingsDialogViewModel CreateViewModel()
+    private SettingsDialogViewModel CreateViewModel(string requestedSectionKey = "")
     {
         var sections = new List<SettingsSection>
         {
@@ -149,7 +184,7 @@ public class SettingsDialogViewModelTests
         };
 
         var viewModel = new SettingsDialogViewModel(_settingsService);
-        viewModel.InitializeSections(sections);
+        viewModel.InitializeSections(sections, requestedSectionKey);
 
         return viewModel;
     }


### PR DESCRIPTION
Reworks .webview settings from a resizable side panel into a full settings surface with Home, Appearance, and Browsing Data sections, plus a return-to-page action and updated localized copy. It also adds section-key routing for Application Settings via a new show-settings command, persists the selected webview settings section, and updates navigation/view-model behavior to handle empty-page and load-failure placeholders cleanly.