### PR TITLE
Enhance macOS find functionality and keyboard shortcut handling

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Platform/ActiveDocumentFind.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/ActiveDocumentFind.cs
@@ -1,0 +1,26 @@
+using Celbridge.Documents;
+using Celbridge.Workspace;
+
+namespace Celbridge.UserInterface.Platform;
+
+/// <summary>
+/// Resolves the find affordance the macOS host find paths act on: the Find menu item and the native key
+/// monitor that delivers Command+F. Both drive the same document, so they resolve it the same way.
+/// </summary>
+internal static class ActiveDocumentFind
+{
+    /// <summary>
+    /// The active document's find affordance, or null when no workspace is loaded or the active document
+    /// offers no find of its own.
+    /// </summary>
+    public static IFindableDocument? GetActiveFindableDocument()
+    {
+        var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
+        if (!workspaceWrapper.IsWorkspaceLoaded)
+        {
+            return null;
+        }
+
+        return workspaceWrapper.WorkspaceService.DocumentsService.GetActiveFindableDocument();
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyEventMonitor.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyEventMonitor.cs
@@ -12,10 +12,10 @@ namespace Celbridge.UserInterface.Platform;
 /// where a WKWebView is first responder and neither Uno's managed input nor the web content reliably sees the
 /// event. A local monitor sees each key before it is dispatched to any responder. While a document holds focus
 /// it keeps Tab inside the document instead of letting the managed focus loop advance out to the surrounding
-/// panels, and it routes Command+W and Command+Shift+W to the close-document shortcuts (which WKWebView
-/// otherwise swallows as reserved key equivalents). Tab is routed through the web-view focus registry, which
-/// knows the focused surface: its edit target acts on the key (indent, move a cell), or the key is delivered
-/// to the page itself so it can move between its own form fields. macOS-only.
+/// panels, and it routes Command+W, Command+Shift+W, and Command+F to the close-document and find shortcuts
+/// (which WKWebView otherwise swallows as key equivalents). Tab is routed through the web-view focus
+/// registry, which knows the focused surface: its edit target acts on the key (indent, move a cell), or the
+/// key is delivered to the page itself so it can move between its own form fields. macOS-only.
 /// </summary>
 internal static class MacOSKeyEventMonitor
 {
@@ -142,8 +142,8 @@ internal static class MacOSKeyEventMonitor
             }
 
             // Only act while a document is focused. Tab still navigates the managed panels (Explorer, Search,
-            // and so on) everywhere else, and the close shortcuts must not close a hidden document from another
-            // panel.
+            // and so on) everywhere else, the close shortcuts must not close a hidden document from another
+            // panel, and Command+F falls through to the Find menu item, which drives the same document.
             if (_focusService?.FocusedPanel != WorkspacePanelId.Documents)
             {
                 return nsEvent;
@@ -183,6 +183,20 @@ internal static class MacOSKeyEventMonitor
                 return IntPtr.Zero;
             }
 
+            // Command+F opens the active document's find bar, as the Find menu item does. WKWebView hands the
+            // key equivalent to the web content rather than to the menu, so a page that ignores it (an
+            // external site in a .webview) leaves the shortcut dead. Swallowed only once a find has begun: a
+            // document with no find of its own leaves the key to the page, where the editors run their own.
+            if (IsFindShortcut(nsEvent, modifierFlags))
+            {
+                if (ActiveDocumentFind.GetActiveFindableDocument()?.TryBeginFind() == true)
+                {
+                    return IntPtr.Zero;
+                }
+
+                return nsEvent;
+            }
+
             return nsEvent;
         }
         catch (Exception exception)
@@ -193,9 +207,27 @@ internal static class MacOSKeyEventMonitor
         }
     }
 
-    // True for Command+W and Command+Shift+W. Matched on the character (layout-aware) rather than the hardware
-    // key code, and rejected when Control or Option is also held so it does not fire on unrelated chords.
+    // True for Command+W and Command+Shift+W.
     private static bool IsCloseShortcut(IntPtr nsEvent, ulong modifierFlags)
+    {
+        return IsCommandShortcut(nsEvent, modifierFlags, "w");
+    }
+
+    // True for Command+F. Command+Shift+F is not a find shortcut, so Shift is rejected.
+    private static bool IsFindShortcut(IntPtr nsEvent, ulong modifierFlags)
+    {
+        if ((modifierFlags & ModifierFlagShift) != 0)
+        {
+            return false;
+        }
+
+        return IsCommandShortcut(nsEvent, modifierFlags, "f");
+    }
+
+    // True when the event is Command plus the given character. Matched on the character (layout-aware) rather
+    // than the hardware key code, and rejected when Control or Option is also held so it does not fire on
+    // unrelated chords.
+    private static bool IsCommandShortcut(IntPtr nsEvent, ulong modifierFlags, string character)
     {
         bool command = (modifierFlags & ModifierFlagCommand) != 0;
         bool control = (modifierFlags & ModifierFlagControl) != 0;
@@ -210,7 +242,7 @@ internal static class MacOSKeyEventMonitor
 
         var characters = ReadNSString(SendMessage(nsEvent, GetSelector("charactersIgnoringModifiers")));
 
-        return string.Equals(characters, "w", StringComparison.OrdinalIgnoreCase);
+        return string.Equals(characters, character, StringComparison.OrdinalIgnoreCase);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyEventMonitor.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyEventMonitor.cs
@@ -166,10 +166,13 @@ internal static class MacOSKeyEventMonitor
                 return nsEvent;
             }
 
+            // The letter the chord names, which is what the shortcuts below are matched against.
+            var shortcutCharacter = ResolveShortcutCharacter(nsEvent, keyCode);
+
             // Command+W closes the active document, Command+Shift+W closes its section. WKWebView reserves
             // Command+W and never delivers it to the web content, so this native monitor is the only reliable
             // delivery path on the Skia head.
-            if (IsCloseShortcut(nsEvent, modifierFlags))
+            if (IsCloseShortcut(shortcutCharacter, modifierFlags))
             {
                 if (shift)
                 {
@@ -187,7 +190,7 @@ internal static class MacOSKeyEventMonitor
             // key equivalent to the web content rather than to the menu, so a page that ignores it (an
             // external site in a .webview) leaves the shortcut dead. Swallowed only once a find has begun: a
             // document with no find of its own leaves the key to the page, where the editors run their own.
-            if (IsFindShortcut(nsEvent, modifierFlags))
+            if (IsFindShortcut(shortcutCharacter, modifierFlags))
             {
                 if (ActiveDocumentFind.GetActiveFindableDocument()?.TryBeginFind() == true)
                 {
@@ -208,41 +211,55 @@ internal static class MacOSKeyEventMonitor
     }
 
     // True for Command+W and Command+Shift+W.
-    private static bool IsCloseShortcut(IntPtr nsEvent, ulong modifierFlags)
+    private static bool IsCloseShortcut(char? shortcutCharacter, ulong modifierFlags)
     {
-        return IsCommandShortcut(nsEvent, modifierFlags, "w");
+        return shortcutCharacter == 'w'
+            && IsPlainCommandChord(modifierFlags);
     }
 
     // True for Command+F. Command+Shift+F is not a find shortcut, so Shift is rejected.
-    private static bool IsFindShortcut(IntPtr nsEvent, ulong modifierFlags)
+    private static bool IsFindShortcut(char? shortcutCharacter, ulong modifierFlags)
     {
         if ((modifierFlags & ModifierFlagShift) != 0)
         {
             return false;
         }
 
-        return IsCommandShortcut(nsEvent, modifierFlags, "f");
+        return shortcutCharacter == 'f'
+            && IsPlainCommandChord(modifierFlags);
     }
 
-    // True when the event is Command plus the given character. Matched on the character (layout-aware) rather
-    // than the hardware key code, and rejected when Control or Option is also held so it does not fire on
-    // unrelated chords.
-    private static bool IsCommandShortcut(IntPtr nsEvent, ulong modifierFlags, string character)
+    // True for a Command chord holding neither Control nor Option, so a shortcut cannot fire on an unrelated
+    // chord built over the same letter.
+    private static bool IsPlainCommandChord(ulong modifierFlags)
     {
         bool command = (modifierFlags & ModifierFlagCommand) != 0;
         bool control = (modifierFlags & ModifierFlagControl) != 0;
         bool option = (modifierFlags & ModifierFlagOption) != 0;
 
-        if (!command
-            || control
-            || option)
+        return command
+            && !control
+            && !option;
+    }
+
+    // The lower-case letter a chord names, or null when it names none. The event's own character answers for
+    // a Latin layout whatever its arrangement, because it reports the key as labelled: the W key gives "w" on
+    // AZERTY as on QWERTY, and a layout that swaps to QWERTY under Command (Dvorak-QWERTY) reports the
+    // swapped letter. A non-Latin layout reports its own alphabet instead, so the key code is translated
+    // through the ASCII-capable layout, which is how AppKit matches menu key equivalents.
+    private static char? ResolveShortcutCharacter(IntPtr nsEvent, ulong keyCode)
+    {
+        var characters = ReadNSString(SendMessage(nsEvent, GetSelector("charactersIgnoringModifiers")));
+        if (characters.Length == 1)
         {
-            return false;
+            var character = char.ToLowerInvariant(characters[0]);
+            if (character is >= 'a' and <= 'z')
+            {
+                return character;
+            }
         }
 
-        var characters = ReadNSString(SendMessage(nsEvent, GetSelector("charactersIgnoringModifiers")));
-
-        return string.Equals(characters, character, StringComparison.OrdinalIgnoreCase);
+        return MacOSKeyboardLayout.ResolveAsciiLetter(keyCode);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyboardLayout.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyboardLayout.cs
@@ -1,0 +1,140 @@
+using System.Runtime.InteropServices;
+
+namespace Celbridge.UserInterface.Platform;
+
+/// <summary>
+/// Resolves the ASCII letter a hardware key carries on the ASCII-capable keyboard layout, so a Command
+/// shortcut still matches while a non-Latin layout is active and the key reports its own alphabet's letter
+/// instead (Cyrillic, Greek, Hebrew). AppKit matches menu key equivalents through the same layout, so this
+/// keeps the shortcuts the native key monitor delivers in step with the menu items beside them. macOS-only.
+/// </summary>
+internal static class MacOSKeyboardLayout
+{
+    private const string HIToolbox = "/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox";
+    private const string CoreFoundation = "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation";
+    private const string LibSystem = "/usr/lib/libSystem.dylib";
+
+    // kUCKeyActionDisplay asks what the key carries on its keycap, which needs no key-down state of its own.
+    private const ushort KeyActionDisplay = 3;
+
+    // kUCKeyTranslateNoDeadKeysMask stops a dead key (an accent) from swallowing the translation.
+    private const uint TranslateNoDeadKeysMask = 1;
+
+    private static readonly IntPtr RtldDefault = new(-2);
+
+    [DllImport(HIToolbox)]
+    private static extern IntPtr TISCopyCurrentASCIICapableKeyboardLayoutInputSource();
+
+    [DllImport(HIToolbox)]
+    private static extern IntPtr TISGetInputSourceProperty(IntPtr inputSource, IntPtr propertyKey);
+
+    [DllImport(HIToolbox)]
+    private static extern byte LMGetKbdType();
+
+    [DllImport(HIToolbox)]
+    private static extern int UCKeyTranslate(
+        IntPtr keyLayoutPointer,
+        ushort virtualKeyCode,
+        ushort keyAction,
+        uint modifierKeyState,
+        uint keyboardType,
+        uint keyTranslateOptions,
+        ref uint deadKeyState,
+        nuint maxStringLength,
+        out nuint actualStringLength,
+        [Out] char[] unicodeString);
+
+    [DllImport(CoreFoundation)]
+    private static extern IntPtr CFDataGetBytePtr(IntPtr data);
+
+    [DllImport(CoreFoundation)]
+    private static extern void CFRelease(IntPtr reference);
+
+    [DllImport(LibSystem)]
+    private static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+    /// <summary>
+    /// The lower-case ASCII letter the given hardware key code carries on the ASCII-capable keyboard layout,
+    /// or null when it carries none or the layout cannot be read.
+    /// </summary>
+    public static char? ResolveAsciiLetter(ulong keyCode)
+    {
+        var inputSource = TISCopyCurrentASCIICapableKeyboardLayoutInputSource();
+        if (inputSource == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        // Resolved on each call rather than cached: the layout answers the input source the user has
+        // selected, and this runs at keypress rate on the few chords that reach it.
+        try
+        {
+            var layoutData = GetUnicodeKeyLayoutData(inputSource);
+            if (layoutData == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            return TranslateToAsciiLetter(layoutData, (ushort)keyCode);
+        }
+        finally
+        {
+            CFRelease(inputSource);
+        }
+    }
+
+    // The layout bytes UCKeyTranslate reads. The input source owns them, so they stay valid only while it is
+    // alive.
+    private static IntPtr GetUnicodeKeyLayoutData(IntPtr inputSource)
+    {
+        // The property key is an exported CFStringRef, so its symbol holds a pointer to the string. Copying
+        // the input source has already loaded HIToolbox, so the default search finds it.
+        var propertyKeySymbol = dlsym(RtldDefault, "kTISPropertyUnicodeKeyLayoutData");
+        if (propertyKeySymbol == IntPtr.Zero)
+        {
+            return IntPtr.Zero;
+        }
+
+        var propertyKey = Marshal.ReadIntPtr(propertyKeySymbol);
+
+        var layoutDataReference = TISGetInputSourceProperty(inputSource, propertyKey);
+        if (layoutDataReference == IntPtr.Zero)
+        {
+            return IntPtr.Zero;
+        }
+
+        return CFDataGetBytePtr(layoutDataReference);
+    }
+
+    private static char? TranslateToAsciiLetter(IntPtr layoutData, ushort keyCode)
+    {
+        uint deadKeyState = 0;
+        var characters = new char[4];
+
+        var status = UCKeyTranslate(
+            layoutData,
+            keyCode,
+            KeyActionDisplay,
+            modifierKeyState: 0,
+            LMGetKbdType(),
+            TranslateNoDeadKeysMask,
+            ref deadKeyState,
+            (nuint)characters.Length,
+            out var characterCount,
+            characters);
+
+        if (status != 0
+            || characterCount == 0)
+        {
+            return null;
+        }
+
+        var character = char.ToLowerInvariant(characters[0]);
+        if (character is < 'a' or > 'z')
+        {
+            return null;
+        }
+
+        return character;
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSMainMenu.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSMainMenu.cs
@@ -1,6 +1,5 @@
 using Celbridge.Commands;
 using Celbridge.Dialog;
-using Celbridge.Documents;
 using Celbridge.Explorer;
 using Celbridge.Settings;
 using Celbridge.UserInterface.ViewModels.Controls;
@@ -236,17 +235,6 @@ internal static class MacOSMainMenu
         return items;
     }
 
-    private static IFindableDocument? GetActiveFindableDocument()
-    {
-        var workspaceWrapper = ServiceLocator.AcquireService<IWorkspaceWrapper>();
-        if (!workspaceWrapper.IsWorkspaceLoaded)
-        {
-            return null;
-        }
-
-        return workspaceWrapper.WorkspaceService.DocumentsService.GetActiveFindableDocument();
-    }
-
     private static MacMenuItemState QueryState(long tag)
     {
         // The standard Edit verbs and Full Screen are responder-chain Selector items (see Install), so
@@ -315,7 +303,7 @@ internal static class MacOSMainMenu
 
     private static MacMenuItemState FindCommandState()
     {
-        var canFind = GetActiveFindableDocument()?.CanFind ?? false;
+        var canFind = ActiveDocumentFind.GetActiveFindableDocument()?.CanFind ?? false;
 
         return canFind ? MacMenuItemState.Enabled : MacMenuItemState.Disabled;
     }
@@ -433,7 +421,7 @@ internal static class MacOSMainMenu
                 break;
 
             case TagFind:
-                GetActiveFindableDocument()?.TryBeginFind();
+                ActiveDocumentFind.GetActiveFindableDocument()?.TryBeginFind();
                 break;
 
             case TagLayoutDefault:

--- a/Source/Core/Celbridge.UserInterface/Views/MainPage.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/MainPage.xaml.cs
@@ -77,8 +77,8 @@ public partial class MainPage : Page
 
         // Deliver document keys the focused WKWebView would otherwise swallow: Tab to the focused web
         // surface (editor indent, or the page's own form-field navigation) instead of letting the managed
-        // focus loop move focus out of it, and Command+W / Command+Shift+W to the close-document shortcuts.
-        // macOS-only. A no-op elsewhere.
+        // focus loop move focus out of it, Command+W / Command+Shift+W to the close-document shortcuts, and
+        // Command+F to the active document's find bar. macOS-only. A no-op elsewhere.
         var focusServiceForKeyMonitor = ServiceLocator.AcquireService<IFocusService>();
         var webViewFocusRegistry = ServiceLocator.AcquireService<IWebViewFocusRegistry>();
         MacOSKeyEventMonitor.Start(focusServiceForKeyMonitor, webViewFocusRegistry, _messengerService, _logger);

--- a/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
+++ b/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
@@ -278,9 +278,8 @@ function initializeSpreadsheet() {
     }
 }
 
-// Moves the active cell one column on Tab (or back on Shift+Tab). The host swallows the native Tab so focus
-// stays in the document, then forwards it here, matching the cell navigation the packaged Windows head gets
-// from the WebView natively.
+// Applies Tab (or Shift+Tab) to the workbook. The host swallows the native key so focus stays in the
+// document, then forwards it here.
 function handleTabKey(shift) {
     if (!designer) {
         return;
@@ -298,21 +297,16 @@ function handleTabKey(shift) {
         return;
     }
 
-    const row = sheet.getActiveRowIndex();
-    const column = sheet.getActiveColumnIndex();
-    if (row < 0
-        || column < 0) {
-        return;
-    }
+    // SpreadJS binds Tab to these commands itself, so running them gives the key the behaviour it has on the
+    // packaged Windows head, where it reaches the WebView: an open cell editor is committed before the
+    // selection moves, the move stays inside a selected range, and it wraps to the next row at the end of one.
+    const commandManager = spread.commandManager();
+    const command = shift ? 'moveToPreviousCell' : 'moveToNextCell';
 
-    const columnCount = sheet.getColumnCount();
-    const targetColumn = Math.max(0, Math.min(shift ? column - 1 : column + 1, columnCount - 1));
-    if (targetColumn === column) {
-        return;
-    }
-
-    sheet.setActiveCell(row, targetColumn);
-    sheet.showColumn(targetColumn, GC.Spread.Sheets.HorizontalPosition.nearest);
+    commandManager.execute({
+        cmd: command,
+        sheetName: sheet.name()
+    });
 }
 
 async function initializeEditor() {


### PR DESCRIPTION
This pull request improves keyboard shortcut handling and menu integration for document operations (close and find) on macOS, especially when using non-Latin keyboard layouts. It introduces a new utility for reliably resolving shortcut keys, ensures consistent behavior between native shortcuts and menu items, and refactors related code for clarity and maintainability.

**Keyboard Shortcut Handling Enhancements:**

* Added a new `ActiveDocumentFind` utility class to centralize logic for resolving the active document's find affordance, improving code reuse and maintainability.
* Refactored the macOS key event monitor (`MacOSKeyEventMonitor`) to handle Command+F (find) shortcuts in addition to Command+W/Command+Shift+W (close document/section), ensuring these shortcuts work reliably even when WKWebView swallows native key equivalents. [[1]](diffhunk://#diff-b96e07b5798d84e0c571523631e5de9a6419949141e0ebe78abf8101dd46ba69L15-R18) [[2]](diffhunk://#diff-b96e07b5798d84e0c571523631e5de9a6419949141e0ebe78abf8101dd46ba69L145-R146) [[3]](diffhunk://#diff-b96e07b5798d84e0c571523631e5de9a6419949141e0ebe78abf8101dd46ba69R169-R175) [[4]](diffhunk://#diff-b96e07b5798d84e0c571523631e5de9a6419949141e0ebe78abf8101dd46ba69R189-R202)
* Introduced a new `MacOSKeyboardLayout` helper to resolve ASCII letter shortcuts on non-Latin layouts, ensuring menu and shortcut handling are consistent regardless of the active keyboard layout. [[1]](diffhunk://#diff-ecddaabf79669b138b84411dc09dbf64d1f8a3226a2535e789202159693478e0R1-R140) [[2]](diffhunk://#diff-b96e07b5798d84e0c571523631e5de9a6419949141e0ebe78abf8101dd46ba69L196-R262)

**Menu and Command Integration:**

* Updated `MacOSMainMenu` to use the new `ActiveDocumentFind` utility for enabling/disabling and invoking the Find command, removing redundant code and ensuring consistent logic between menu items and keyboard shortcuts. [[1]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6L3) [[2]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6L239-L249) [[3]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6L318-R306) [[4]](diffhunk://#diff-789852c8d6216cad6efd17a185d77e7c2bfa75766811a8dc923c460a73e77bc6L436-R424)

**Documentation and Behavior Clarification:**

* Improved comments and documentation throughout the codebase to clarify shortcut handling logic, especially regarding the interaction between native shortcuts, menu items, and document focus. [[1]](diffhunk://#diff-3416f32fe5b22aedd8804ecd5600a04fc2fbe4d4a65c3391323c3f4d37264493L80-R81) [[2]](diffhunk://#diff-899e16e4cafce86349f5e9141ce0c80b0c6db5ddf1e0256c4c2ed7d78b886ac8L281-R282)

**Spreadsheet Key Handling:**

* Refined Tab key handling in the spreadsheet module to use SpreadJS commands directly, ensuring consistent behavior with the Windows version and better handling of cell navigation and editing. [[1]](diffhunk://#diff-899e16e4cafce86349f5e9141ce0c80b0c6db5ddf1e0256c4c2ed7d78b886ac8L281-R282) [[2]](diffhunk://#diff-899e16e4cafce86349f5e9141ce0c80b0c6db5ddf1e0256c4c2ed7d78b886ac8L301-R309)