### PR TITLE
Add shared TOML string encoder utility

### DIFF
--- a/Source/Core/Celbridge.Projects/Helpers/ProjectConfigSerializer.cs
+++ b/Source/Core/Celbridge.Projects/Helpers/ProjectConfigSerializer.cs
@@ -28,19 +28,19 @@ public static class ProjectConfigSerializer
         var celbridge = config.Celbridge;
         if (!string.IsNullOrEmpty(celbridge.CelbridgeVersion))
         {
-            WriteKeyValue(builder, "celbridge-version", RenderString(celbridge.CelbridgeVersion));
+            WriteKeyValue(builder, "celbridge-version", TomlStringEncoder.EncodeBasicString(celbridge.CelbridgeVersion));
         }
         if (!string.IsNullOrEmpty(celbridge.ProjectVersion))
         {
-            WriteKeyValue(builder, "project-version", RenderString(celbridge.ProjectVersion));
+            WriteKeyValue(builder, "project-version", TomlStringEncoder.EncodeBasicString(celbridge.ProjectVersion));
         }
         if (!string.IsNullOrEmpty(celbridge.Description))
         {
-            WriteKeyValue(builder, "description", RenderString(celbridge.Description));
+            WriteKeyValue(builder, "description", TomlStringEncoder.EncodeBasicString(celbridge.Description));
         }
         if (!string.IsNullOrEmpty(celbridge.DataFolder))
         {
-            WriteKeyValue(builder, "data-folder", RenderString(celbridge.DataFolder));
+            WriteKeyValue(builder, "data-folder", TomlStringEncoder.EncodeBasicString(celbridge.DataFolder));
         }
         if (celbridge.EditorAssociations.Count > 0)
         {
@@ -62,7 +62,7 @@ public static class ProjectConfigSerializer
         builder.Append("# The resource set: the files the ignore-file allows, plus 'add', minus 'remove'.\n");
         builder.Append("# 'lock' freezes resources so they can't be edited, moved, or deleted.\n");
         builder.Append("[celbridge.resources]\n");
-        WriteKeyValue(builder, "ignore-file", RenderString(resources.IgnoreFile));
+        WriteKeyValue(builder, "ignore-file", TomlStringEncoder.EncodeBasicString(resources.IgnoreFile));
         WriteKeyValue(builder, "add", RenderStringArray(resources.Add));
         WriteKeyValue(builder, "remove", RenderStringArray(resources.Remove));
         WriteKeyValue(builder, "lock", RenderStringArray(resources.Lock));
@@ -82,8 +82,8 @@ public static class ProjectConfigSerializer
             builder.Append('\n');
             builder.Append("[[contribution]]\n");
 
-            WriteKeyValue(builder, ContributionPropertyKeys.Package, RenderString(contribution.PackageName));
-            WriteKeyValue(builder, ContributionPropertyKeys.Contribution, RenderString(contribution.ContributionId));
+            WriteKeyValue(builder, ContributionPropertyKeys.Package, TomlStringEncoder.EncodeBasicString(contribution.PackageName));
+            WriteKeyValue(builder, ContributionPropertyKeys.Contribution, TomlStringEncoder.EncodeBasicString(contribution.ContributionId));
 
             if (contribution.Disabled)
             {
@@ -120,13 +120,13 @@ public static class ProjectConfigSerializer
                 return doubleValue.ToString(CultureInfo.InvariantCulture);
 
             case string stringValue:
-                return RenderString(stringValue);
+                return TomlStringEncoder.EncodeBasicString(stringValue);
 
             case IReadOnlyList<string> listValue:
                 return RenderStringArray(listValue);
 
             default:
-                return RenderString(value?.ToString() ?? string.Empty);
+                return TomlStringEncoder.EncodeBasicString(value?.ToString() ?? string.Empty);
         }
     }
 
@@ -137,7 +137,7 @@ public static class ProjectConfigSerializer
             return "[]";
         }
 
-        var items = values.Select(RenderString);
+        var items = values.Select(TomlStringEncoder.EncodeBasicString);
         return $"[{string.Join(", ", items)}]";
     }
 
@@ -145,7 +145,7 @@ public static class ProjectConfigSerializer
     {
         var entries = map
             .OrderBy(pair => pair.Key, StringComparer.Ordinal)
-            .Select(pair => $"{RenderString(pair.Key)} = {RenderString(pair.Value)}");
+            .Select(pair => $"{TomlStringEncoder.EncodeBasicString(pair.Key)} = {TomlStringEncoder.EncodeBasicString(pair.Value)}");
         return $"{{ {string.Join(", ", entries)} }}";
     }
 
@@ -153,57 +153,7 @@ public static class ProjectConfigSerializer
     {
         var entries = map
             .OrderBy(pair => pair.Key, StringComparer.Ordinal)
-            .Select(pair => $"{RenderString(pair.Key)} = {(pair.Value ? "true" : "false")}");
+            .Select(pair => $"{TomlStringEncoder.EncodeBasicString(pair.Key)} = {(pair.Value ? "true" : "false")}");
         return $"{{ {string.Join(", ", entries)} }}";
-    }
-
-    // Renders a TOML basic string with the standard escapes.
-    private static string RenderString(string value)
-    {
-        var builder = new StringBuilder(value.Length + 2);
-        builder.Append('"');
-        foreach (var character in value)
-        {
-            switch (character)
-            {
-                case '"':
-                    builder.Append("\\\"");
-                    break;
-                case '\\':
-                    builder.Append("\\\\");
-                    break;
-                case '\b':
-                    builder.Append("\\b");
-                    break;
-                case '\t':
-                    builder.Append("\\t");
-                    break;
-                case '\n':
-                    builder.Append("\\n");
-                    break;
-                case '\f':
-                    builder.Append("\\f");
-                    break;
-                case '\r':
-                    builder.Append("\\r");
-                    break;
-                default:
-                    // TOML basic strings forbid unescaped control characters. The common ones are
-                    // handled above. Escape the rest (and DEL) as \uXXXX so the file re-parses.
-                    if (character < ' '
-                        || character == '\u007f')
-                    {
-                        builder.Append("\\u").Append(((int)character).ToString("X4", CultureInfo.InvariantCulture));
-                    }
-                    else
-                    {
-                        builder.Append(character);
-                    }
-                    break;
-            }
-        }
-        builder.Append('"');
-
-        return builder.ToString();
     }
 }

--- a/Source/Core/Celbridge.Utilities/TomlStringEncoder.cs
+++ b/Source/Core/Celbridge.Utilities/TomlStringEncoder.cs
@@ -1,0 +1,157 @@
+using System.Globalization;
+using System.Text;
+
+namespace Celbridge.Utilities;
+
+/// <summary>
+/// Encodes values as TOML string literals. The TOML writers in this codebase serialize by hand so they keep
+/// control over key order and layout, and this is the escaping every one of them shares.
+/// </summary>
+public static class TomlStringEncoder
+{
+    /// <summary>
+    /// Encodes a value as a quoted TOML basic string. Characters with a named escape take it, so the escape
+    /// reads as itself in a diff; any other control character is emitted as \uXXXX, which the form requires.
+    /// </summary>
+    public static string EncodeBasicString(string value)
+    {
+        var builder = new StringBuilder(value.Length + 2);
+
+        builder.Append('"');
+
+        foreach (var character in value)
+        {
+            switch (character)
+            {
+                case '"':
+                    builder.Append("\\\"");
+                    break;
+
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+
+                case '\b':
+                    builder.Append("\\b");
+                    break;
+
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+
+                case '\f':
+                    builder.Append("\\f");
+                    break;
+
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+
+                default:
+                    AppendVerbatimOrEscaped(builder, character);
+                    break;
+            }
+        }
+
+        builder.Append('"');
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Encodes a value as a multi-line TOML basic string, which carries newlines and tabs verbatim so the
+    /// value reads as itself on disk. A run of three quotes, or a quote ending the value, is escaped so it
+    /// cannot merge with the closing delimiter.
+    /// </summary>
+    public static string EncodeMultilineBasicString(string value)
+    {
+        var builder = new StringBuilder(value.Length + 8);
+
+        // The newline straight after the opening delimiter is dropped by the parser, so starting the
+        // content on its own line does not change the value.
+        builder.Append("\"\"\"\n");
+
+        var quoteRun = 0;
+
+        foreach (var character in value)
+        {
+            if (character == '\\')
+            {
+                builder.Append("\\\\");
+                quoteRun = 0;
+                continue;
+            }
+
+            if (character == '"')
+            {
+                quoteRun++;
+
+                if (quoteRun == 3)
+                {
+                    builder.Append("\\\"");
+                    quoteRun = 0;
+                }
+                else
+                {
+                    builder.Append('"');
+                }
+
+                continue;
+            }
+
+            quoteRun = 0;
+
+            switch (character)
+            {
+                // The characters this form exists to carry, held as themselves.
+                case '\n':
+                case '\r':
+                case '\t':
+                    builder.Append(character);
+                    break;
+
+                case '\b':
+                    builder.Append("\\b");
+                    break;
+
+                case '\f':
+                    builder.Append("\\f");
+                    break;
+
+                default:
+                    AppendVerbatimOrEscaped(builder, character);
+                    break;
+            }
+        }
+
+        if (quoteRun > 0)
+        {
+            // The value ends in one or two quotes, which would merge with the closing delimiter. Escaping
+            // the last of them breaks the run without changing what the value reads back as.
+            builder.Remove(builder.Length - 1, 1);
+            builder.Append("\\\"");
+        }
+
+        builder.Append("\"\"\"");
+
+        return builder.ToString();
+    }
+
+    // A control character has no verbatim form in either kind of string, so it falls back to \uXXXX.
+    private static void AppendVerbatimOrEscaped(StringBuilder builder, char character)
+    {
+        if (character >= ' '
+            && character != '\u007f')
+        {
+            builder.Append(character);
+            return;
+        }
+
+        builder.Append("\\u");
+        builder.Append(((int)character).ToString("X4", CultureInfo.InvariantCulture));
+    }
+}

--- a/Source/Core/Celbridge.WebHost/Services/WebViewFileContent.cs
+++ b/Source/Core/Celbridge.WebHost/Services/WebViewFileContent.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text;
 using Celbridge.Utilities;
 using Tomlyn;
@@ -215,7 +214,7 @@ public sealed record WebViewFileContent(
     {
         builder.Append(key);
         builder.Append(" = ");
-        builder.Append(EncodeTomlString(value));
+        builder.Append(TomlStringEncoder.EncodeBasicString(value));
         builder.Append('\n');
     }
 
@@ -225,34 +224,5 @@ public sealed record WebViewFileContent(
         builder.Append(" = ");
         builder.Append(value ? "true" : "false");
         builder.Append('\n');
-    }
-
-    // Encodes a value as a TOML basic string, escaping the few characters a URL
-    // can legally carry that a basic string cannot hold verbatim.
-    private static string EncodeTomlString(string value)
-    {
-        var builder = new StringBuilder(value.Length + 2);
-        builder.Append('"');
-        foreach (var character in value)
-        {
-            if (character == '\\' ||
-                character == '"')
-            {
-                builder.Append('\\');
-                builder.Append(character);
-            }
-            else if (character < 0x20 ||
-                     character == 0x7F)
-            {
-                builder.AppendFormat(CultureInfo.InvariantCulture, "\\u{0:X4}", (int)character);
-            }
-            else
-            {
-                builder.Append(character);
-            }
-        }
-        builder.Append('"');
-
-        return builder.ToString();
     }
 }

--- a/Source/Tests/Utilities/TomlStringEncoderTests.cs
+++ b/Source/Tests/Utilities/TomlStringEncoderTests.cs
@@ -1,0 +1,117 @@
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace Celbridge.Tests.Utilities;
+
+[TestFixture]
+public class TomlStringEncoderTests
+{
+    [Test]
+    public void EncodeBasicString_PlainValue_IsQuotedUnchanged()
+    {
+        TomlStringEncoder.EncodeBasicString("https://example.com")
+            .Should().Be("\"https://example.com\"");
+    }
+
+    [Test]
+    public void EncodeBasicString_EscapesQuotesAndBackslashes()
+    {
+        TomlStringEncoder.EncodeBasicString("a\"b\\c")
+            .Should().Be("\"a\\\"b\\\\c\"");
+    }
+
+    // A named escape rather than \uXXXX, which is the point of writing these files by hand: the escape
+    // reads as itself in a diff.
+    [TestCase("\t", "\"\\t\"")]
+    [TestCase("\n", "\"\\n\"")]
+    [TestCase("\r", "\"\\r\"")]
+    [TestCase("\b", "\"\\b\"")]
+    [TestCase("\f", "\"\\f\"")]
+    public void EncodeBasicString_UsesTheNamedEscapeWhenThereIsOne(string value, string expected)
+    {
+        TomlStringEncoder.EncodeBasicString(value).Should().Be(expected);
+    }
+
+    [TestCase("\u0001", "\"\\u0001\"")]
+    [TestCase("\u001f", "\"\\u001F\"")]
+    [TestCase("\u007f", "\"\\u007F\"")]
+    public void EncodeBasicString_EscapesTheRemainingControlCharactersAsUnicode(string value, string expected)
+    {
+        TomlStringEncoder.EncodeBasicString(value).Should().Be(expected);
+    }
+
+    [TestCase("plain")]
+    [TestCase("")]
+    [TestCase("has \"quotes\" and a \\ backslash")]
+    [TestCase("tab\there")]
+    [TestCase("newline\nhere")]
+    [TestCase("carriage\rreturn")]
+    [TestCase("control\u0001character")]
+    [TestCase("delete\u007fcharacter")]
+    [TestCase("trailing backslash \\")]
+    public void EncodeBasicString_RoundTripsThroughTheParser(string value)
+    {
+        ReadValue(TomlStringEncoder.EncodeBasicString(value)).Should().Be(value);
+    }
+
+    [Test]
+    public void EncodeMultilineBasicString_HoldsNewlinesAndTabsVerbatim()
+    {
+        var encoded = TomlStringEncoder.EncodeMultilineBasicString("first\nsecond\tindented");
+
+        encoded.Should().Be("\"\"\"\nfirst\nsecond\tindented\"\"\"");
+    }
+
+    [Test]
+    public void EncodeMultilineBasicString_BreaksUpARunOfThreeQuotes()
+    {
+        // Three consecutive quotes inside the content would close the string early.
+        var encoded = TomlStringEncoder.EncodeMultilineBasicString("a\"\"\"b");
+
+        encoded.Should().Be("\"\"\"\na\"\"\\\"b\"\"\"");
+    }
+
+    [Test]
+    public void EncodeMultilineBasicString_BreaksAQuoteEndingTheValue()
+    {
+        // A trailing quote would otherwise merge with the closing delimiter into a run of four.
+        var encoded = TomlStringEncoder.EncodeMultilineBasicString("a\"");
+
+        encoded.Should().Be("\"\"\"\na\\\"\"\"\"");
+    }
+
+    [TestCase("plain")]
+    [TestCase("multi\nline\nvalue")]
+    [TestCase("tab\tseparated")]
+    [TestCase("a\"\"\"b")]
+    [TestCase("four\"\"\"\"quotes")]
+    [TestCase("ends with one quote\"")]
+    [TestCase("ends with two quotes\"\"")]
+    [TestCase("back\\slash")]
+    [TestCase("control\u0001character")]
+    [TestCase("delete\u007fcharacter")]
+    [TestCase("backspace\bcharacter")]
+    public void EncodeMultilineBasicString_RoundTripsThroughTheParser(string value)
+    {
+        ReadValue(TomlStringEncoder.EncodeMultilineBasicString(value)).Should().Be(value);
+    }
+
+    // Files written before the escaping was consolidated carry \uXXXX where a named escape is emitted now.
+    // The reader is the same parser either way, so both forms still load.
+    [TestCase("\"a\\u0009b\"")]
+    [TestCase("\"a\\tb\"")]
+    public void TheParser_ReadsBothTheOldAndTheNewEscapeForm(string literal)
+    {
+        ReadValue(literal).Should().Be("a\tb");
+    }
+
+    // Parses an encoded literal with the parser every one of these writers is read back by, so what is
+    // asserted is that the value survives rather than that the bytes take a particular shape.
+    private static string ReadValue(string encodedLiteral)
+    {
+        var table = TomlSerializer.Deserialize<TomlTable>($"value = {encodedLiteral}\n");
+        table.Should().NotBeNull();
+
+        return (string)table!["value"]!;
+    }
+}

--- a/Source/Workspace/Celbridge.Resources/Helpers/SidecarTomlEncoder.cs
+++ b/Source/Workspace/Celbridge.Resources/Helpers/SidecarTomlEncoder.cs
@@ -44,7 +44,7 @@ public static class SidecarTomlEncoder
 
         if (CanUseBasicString(raw))
         {
-            return "\"" + raw + "\"";
+            return TomlStringEncoder.EncodeBasicString(raw);
         }
 
         if (CanUseLiteralTriple(raw))
@@ -55,8 +55,7 @@ public static class SidecarTomlEncoder
             return "'''\n" + raw + "'''";
         }
 
-        var escaped = EscapeForBasicTriple(raw);
-        return "\"\"\"\n" + escaped + "\"\"\"";
+        return TomlStringEncoder.EncodeMultilineBasicString(raw);
     }
 
     /// <summary>
@@ -378,68 +377,5 @@ public static class SidecarTomlEncoder
             }
         }
         return true;
-    }
-
-    // Escape backslashes, break any run of three or more consecutive double
-    // quotes, and break the tail so trailing quotes don't merge with the
-    // closing delimiter. Control characters other than tab, LF, and CR are
-    // emitted as \uXXXX escapes.
-    private static string EscapeForBasicTriple(string raw)
-    {
-        var builder = new StringBuilder(raw.Length + 8);
-        int run = 0;
-        for (int i = 0; i < raw.Length; i++)
-        {
-            var c = raw[i];
-            if (c == '\\')
-            {
-                builder.Append("\\\\");
-                run = 0;
-                continue;
-            }
-            if (c == '"')
-            {
-                run++;
-                if (run == 3)
-                {
-                    builder.Append("\\\"");
-                    run = 0;
-                }
-                else
-                {
-                    builder.Append('"');
-                }
-                continue;
-            }
-            if (c == '\n'
-                || c == '\r'
-                || c == '\t')
-            {
-                builder.Append(c);
-                run = 0;
-                continue;
-            }
-            if (c < 0x20
-                || c == 0x7F)
-            {
-                builder.AppendFormat(CultureInfo.InvariantCulture, "\\u{0:X4}", (int)c);
-                run = 0;
-                continue;
-            }
-            builder.Append(c);
-            run = 0;
-        }
-
-        if (run > 0)
-        {
-            // The content tail is one or two consecutive quotes and would merge
-            // with the closing delimiter. Replace the last emitted quote with
-            // its escaped form to break the merge.
-            int lastIndex = builder.Length - 1;
-            builder.Remove(lastIndex, 1);
-            builder.Append("\\\"");
-        }
-
-        return builder.ToString();
     }
 }


### PR DESCRIPTION
This pull request consolidates and standardizes TOML string escaping throughout the codebase by introducing a shared utility, `TomlStringEncoder`, and updating all TOML writers to use it. This reduces duplicated code, ensures consistent escaping, and improves maintainability. Comprehensive unit tests are also added to verify correct encoding and round-trip parsing.

**TOML string escaping consolidation:**

* Introduced the `TomlStringEncoder` utility class, providing `EncodeBasicString` and `EncodeMultilineBasicString` methods for TOML string escaping, replacing custom or duplicated implementations.
* Updated all TOML writing code in `ProjectConfigSerializer.cs`, `WebViewFileContent.cs`, and `SidecarTomlEncoder.cs` to use `TomlStringEncoder` methods instead of local string-escaping logic. [[1]](diffhunk://#diff-478ab4836a61dbb9ad3df84b420bb9c8a513487b7d81bbf23be1cfe5b6a92a03L31-R43) [[2]](diffhunk://#diff-478ab4836a61dbb9ad3df84b420bb9c8a513487b7d81bbf23be1cfe5b6a92a03L65-R65) [[3]](diffhunk://#diff-478ab4836a61dbb9ad3df84b420bb9c8a513487b7d81bbf23be1cfe5b6a92a03L85-R86) [[4]](diffhunk://#diff-478ab4836a61dbb9ad3df84b420bb9c8a513487b7d81bbf23be1cfe5b6a92a03L123-R129) [[5]](diffhunk://#diff-478ab4836a61dbb9ad3df84b420bb9c8a513487b7d81bbf23be1cfe5b6a92a03L140-L208) [[6]](diffhunk://#diff-6dadae11e6d4c9cab41ce2238bdc5850ac4cdae01f57dffcab6e94ed88775880L218-R217) [[7]](diffhunk://#diff-5e42381bccda5032d32c61d584ca8dc228d0efda92a333ec4c89840e1c4a4140L47-R47) [[8]](diffhunk://#diff-5e42381bccda5032d32c61d584ca8dc228d0efda92a333ec4c89840e1c4a4140L58-R58)
* Removed now-redundant string escaping helper methods from affected files. [[1]](diffhunk://#diff-478ab4836a61dbb9ad3df84b420bb9c8a513487b7d81bbf23be1cfe5b6a92a03L140-L208) [[2]](diffhunk://#diff-6dadae11e6d4c9cab41ce2238bdc5850ac4cdae01f57dffcab6e94ed88775880L229-L257) [[3]](diffhunk://#diff-5e42381bccda5032d32c61d584ca8dc228d0efda92a333ec4c89840e1c4a4140L382-L444)

**Testing improvements:**

* Added `TomlStringEncoderTests` to verify escaping, named/unicode escapes, and round-trip parsing for both basic and multiline TOML strings.

These changes ensure all TOML output is consistent, correct, and easier to maintain.Introduce `TomlStringEncoder` to centralize TOML string escaping for hand-written serializers. It supports both quoted basic strings and multiline basic strings, handling TOML-required escapes for quotes, backslashes, control characters, and edge cases like triple-quote runs and trailing quotes.