### PR TITLE
Rename utility launchers to document shortcuts across codebase

### DIFF
--- a/Source/Core/Celbridge.Foundation/Documents/IShowUtilityCommand.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IShowUtilityCommand.cs
@@ -5,8 +5,8 @@ namespace Celbridge.Documents;
 
 /// <summary>
 /// Reveals a rail item by its fully-qualified id, optionally moving it to a workspace area first. Explorer
-/// and Search select their rail item, a contributed utility is revealed wherever it lives, and a launcher
-/// opens its document.
+/// and Search select their rail item, a contributed utility is revealed wherever it lives, and a document
+/// shortcut opens its document.
 /// </summary>
 public interface IShowUtilityCommand : IExecutableCommand
 {
@@ -17,8 +17,8 @@ public interface IShowUtilityCommand : IExecutableCommand
 
     /// <summary>
     /// The area to move the utility to before revealing it. Null reveals it wherever it currently is.
-    /// Only a contributed utility moves between areas: for a built-in utility or a launcher, naming an
-    /// area it cannot reach fails rather than being ignored.
+    /// Only a contributed utility moves between areas: for a built-in utility or a document shortcut,
+    /// naming an area it cannot reach fails rather than being ignored.
     /// </summary>
     WorkspaceArea? TargetArea { get; set; }
 }

--- a/Source/Core/Celbridge.Foundation/Workspace/IUtilityPanel.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IUtilityPanel.cs
@@ -21,18 +21,18 @@ public static class BuiltInUtilityIds
 }
 
 /// <summary>
-/// Ids for the built-in rail launchers, in the same "{scope}.{name}" form as custom utility ids. A launcher
-/// opens a document and never occupies the panel, so it is not a utility.
+/// Ids for the built-in document shortcuts, in the same "{scope}.{name}" form as custom utility ids. A
+/// shortcut opens a document and never occupies the panel, so it is not a utility.
 /// </summary>
-public static class BuiltInLauncherIds
+public static class BuiltInShortcutIds
 {
     /// <summary>
-    /// The Project Settings launcher's rail id.
+    /// The Project Settings shortcut's rail id.
     /// </summary>
     public static readonly EditorId ProjectSettings = EditorId.Create("celbridge", "project-settings");
 
     /// <summary>
-    /// The Community Workshop launcher's rail id.
+    /// The Community Workshop shortcut's rail id.
     /// </summary>
     public static readonly EditorId Workshop = EditorId.Create("celbridge", "workshop");
 }

--- a/Source/Core/Celbridge.Foundation/Workspace/IUtilityService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IUtilityService.cs
@@ -18,20 +18,20 @@ public interface IUtilityService
 
     /// <summary>
     /// Seeds each declared utility's backing file and records it in the rail register, along with the
-    /// launchers, in declaration order, which is the rail order. Each utility also gets a persistent view,
-    /// owned by this service until the workspace unloads.
+    /// document shortcuts, in declaration order, which is the rail order. Each utility also gets a
+    /// persistent view, owned by this service until the workspace unloads.
     /// </summary>
     Task CreateUtilitiesAsync(IReadOnlyList<ResolvedEditor> resolvedEditors);
 
     /// <summary>
     /// Every workspace item the rail presents, in rail order: the registered built-in utilities, then the
-    /// contribution utilities, then the launchers. Empty until the utilities have been created.
+    /// contribution utilities, then the document shortcuts. Empty until the utilities have been created.
     /// </summary>
     IReadOnlyList<UtilityRailItem> GetRailItems();
 
     /// <summary>
-    /// The area a rail item currently occupies, or null when nothing presents it: a launcher whose document
-    /// is closed, or an id the register does not hold. A utility always occupies an area.
+    /// The area a rail item currently occupies, or null when nothing presents it: a document shortcut whose
+    /// document is closed, or an id the register does not hold. A utility always occupies an area.
     /// </summary>
     WorkspaceArea? GetCurrentArea(EditorId itemId);
 

--- a/Source/Core/Celbridge.Foundation/Workspace/UtilityRailItem.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/UtilityRailItem.cs
@@ -24,7 +24,7 @@ public enum RailItemKind
     /// A button that opens a document. It never occupies the panel, and the document it opens closes like
     /// any other.
     /// </summary>
-    DocumentLauncher
+    DocumentShortcut
 }
 
 /// <summary>
@@ -76,9 +76,9 @@ public sealed record UtilityRailItem
     public required string Tooltip { get; init; }
 
     /// <summary>
-    /// The document area this item targets: where a dockable utility docks to, and where a launcher's
-    /// document opens. Null for a panel utility, which never becomes a document. Where the item sits after
-    /// it opens is the user's to change, like any other tab.
+    /// The document area this item targets: where a dockable utility docks to, and where a document
+    /// shortcut opens its document. Null for a panel utility, which never becomes a document. Where the item
+    /// sits after it opens is the user's to change, like any other tab.
     /// </summary>
     public WorkspaceArea? DockArea { get; init; }
 
@@ -95,7 +95,7 @@ public sealed record UtilityRailItem
     public EditorId EditorId { get; init; } = EditorId.Empty;
 
     /// <summary>
-    /// The view this item shows in the Utility Panel. Null only for a launcher.
+    /// The view this item shows in the Utility Panel. Null only for a document shortcut.
     /// </summary>
     public UtilityRailPanelView? PanelView { get; init; }
 
@@ -184,7 +184,7 @@ public sealed record UtilityRailItem
     /// <summary>
     /// A button that opens a document in the given area.
     /// </summary>
-    public static UtilityRailItem CreateDocumentLauncher(
+    public static UtilityRailItem CreateDocumentShortcut(
         EditorId itemId,
         string landmarkId,
         string iconName,
@@ -196,7 +196,7 @@ public sealed record UtilityRailItem
     {
         return new UtilityRailItem
         {
-            Kind = RailItemKind.DocumentLauncher,
+            Kind = RailItemKind.DocumentShortcut,
             ItemId = itemId,
             LandmarkId = landmarkId,
             IconName = iconName,

--- a/Source/Core/Celbridge.Tools/Guides/Tools/app_list_utilities.md
+++ b/Source/Core/Celbridge.Tools/Guides/Tools/app_list_utilities.md
@@ -1,6 +1,6 @@
 # app_list_utilities
 
-Lists every utility the app can show: the built-in Utility Panel items (Explorer, Search), the built-in launchers (Project Settings, Community Workshop), and any custom utilities the project contributes. Use it to discover what utilities exist and their ids before calling `app_show_utility`, and to see how each is currently presented and which one the user is looking at.
+Lists every utility the app can show: the built-in Utility Panel items (Explorer, Search), the built-in document shortcuts (Project Settings, Community Workshop), and any custom utilities the project contributes. Use it to discover what utilities exist and their ids before calling `app_show_utility`, and to see how each is currently presented and which one the user is looking at.
 
 The list is the utility rail as the user sees it: one entry per rail button. Some of those buttons open a document rather than showing something in the panel, and they are listed all the same, because a user pointing at a button expects you to find it.
 
@@ -19,7 +19,7 @@ A JSON object with one field:
 - `utilities` (array) — every available utility. Each entry has:
   - `utilityId` (string) — the id to pass to `app_show_utility` (e.g. `celbridge.explorer`, or the editor id of a contributed utility).
   - `displayName` (string) — the human-readable, localized name.
-  - `currentArea` (string) — the workspace area the utility occupies right now: `"utility"` when the Utility Panel shows it, or a document area token (`"main"`, `"bottom"`, `"side"`) when it is a document tab. Empty when nothing presents it, which is a launcher whose document is closed. A custom utility moves between areas at runtime; Explorer and Search are always `"utility"`.
+  - `currentArea` (string) — the workspace area the utility occupies right now: `"utility"` when the Utility Panel shows it, or a document area token (`"main"`, `"bottom"`, `"side"`) when it is a document tab. Empty when nothing presents it, which is a document shortcut whose document is closed. A custom utility moves between areas at runtime; Explorer and Search are always `"utility"`.
   - `dockArea` (string) — the area token this utility opens in as a document, which is where `app_show_utility` sends it when asked for `"document"`. This is what the utility declares, not where it is now: read `currentArea` for that. Empty for a utility that stays in the Utility Panel and cannot become a document, which is what Explorer and Search are.
   - `isVisible` (bool) — whether the user can currently see the utility. That means it is the selected rail item (in the `utility` area) or the active document (in a document area), **and** that its area is not collapsed. A utility can be the selected rail item while the Utility Panel is collapsed, and that reports `false`, because nothing is on screen. Trust this rather than inferring visibility from `currentArea`.
   - `resource` (string) — the file the utility presents, or empty when it has none. Explorer and Search have no file behind them, so they report an empty string.

--- a/Source/Core/Celbridge.Tools/Guides/Tools/app_show_utility.md
+++ b/Source/Core/Celbridge.Tools/Guides/Tools/app_show_utility.md
@@ -9,7 +9,7 @@ Call `app_list_utilities` first to discover the valid ids, each utility's `curre
 - `utilityId` — the id of the utility to show. Two forms, one scheme:
   - Built-in: `celbridge.explorer`, `celbridge.search`, `celbridge.project-settings` and `celbridge.workshop`.
   - Custom utilities: the editor id of the contributed utility (the same id `app_list_utilities` reports).
-- `area` (required) — a workspace area to move the utility to before revealing it: `"utility"` (the Utility Panel rail), or `"main"`, `"bottom"` or `"side"` (a document tab in that area). `"document"` is accepted as an alias for the utility's own document area, so you can ask for a tab without naming an area. Pass an empty string to reveal the utility wherever it currently is without moving it. Only a custom utility moves between areas: for a built-in or a launcher, naming the area it is already in reveals it, and naming any other one is an error.
+- `area` (required) — a workspace area to move the utility to before revealing it: `"utility"` (the Utility Panel rail), or `"main"`, `"bottom"` or `"side"` (a document tab in that area). `"document"` is accepted as an alias for the utility's own document area, so you can ask for a tab without naming an area. Pass an empty string to reveal the utility wherever it currently is without moving it. Only a custom utility moves between areas: for a built-in or a document shortcut, naming the area it is already in reveals it, and naming any other one is an error.
 
 ## Behaviour
 
@@ -20,6 +20,6 @@ Call `app_list_utilities` first to discover the valid ids, each utility's `curre
 
 - An unknown id returns an error. Use `app_list_utilities` to get the exact ids rather than guessing.
 - An unrecognised `area` returns an error naming the accepted tokens. A utility that stays in the Utility Panel refuses a document area, and `"document"` returns an error for it, because it has nowhere to be sent. Read `dockArea` from `app_list_utilities` to tell those apart.
-- Explorer, Search and the launchers do not move. Asking for an area they are not already in returns an error rather than quietly revealing them where they were, so pass an empty string when you only want to bring one up.
+- Explorer, Search and the document shortcuts do not move. Asking for an area they are not already in returns an error rather than quietly revealing them where they were, so pass an empty string when you only want to bring one up.
 - Revealing a utility that is already in the requested area is a no-op (it stays put, with a brief highlight when it is a document).
 - This tool reveals or relocates a utility; it never closes or destroys one. A custom utility is never destroyed — closing its document tab docks it back into the Utility Panel rather than closing it. Project Settings and the Workshop are ordinary documents, so closing one of those closes it, and showing it again reopens it.

--- a/Source/Core/Celbridge.Tools/Tools/App/AppTools.ListUtilities.cs
+++ b/Source/Core/Celbridge.Tools/Tools/App/AppTools.ListUtilities.cs
@@ -44,8 +44,8 @@ public partial class AppTools
         var entries = new List<UtilityListEntry>(snapshot.Utilities.Count);
         foreach (var utility in snapshot.Utilities)
         {
-            // A launcher whose document is closed occupies no area, so it reports an empty string rather
-            // than a token that would read as somewhere it currently is.
+            // A document shortcut whose document is closed occupies no area, so it reports an empty string
+            // rather than a token that would read as somewhere it currently is.
             var currentArea = utility.CurrentArea is null
                 ? string.Empty
                 : utility.CurrentArea.Value.ToToken();

--- a/Source/Core/Celbridge.Tools/Tools/App/AppTools.ShowUtility.cs
+++ b/Source/Core/Celbridge.Tools/Tools/App/AppTools.ShowUtility.cs
@@ -8,7 +8,7 @@ public partial class AppTools
 {
     /// <summary>Show a utility by id: reveal it where it is, or move it to a workspace area first.</summary>
     /// <param name="utilityId">The utility to show: a built-in id ("celbridge.explorer", "celbridge.search", "celbridge.project-settings", "celbridge.workshop") or a custom id in "{packageName}.{contributionId}" form.</param>
-    /// <param name="area">Workspace area to move the utility to before revealing it: "utility" (the Utility Panel rail), or "main", "bottom" or "side" (a document tab in that area). "document" is accepted as an alias for the area the utility declares as its dock area. Pass an empty string to reveal the utility wherever it currently is without moving it. Only a custom utility moves between areas: naming an area that a built-in or a launcher is not already in fails rather than being ignored.</param>
+    /// <param name="area">Workspace area to move the utility to before revealing it: "utility" (the Utility Panel rail), or "main", "bottom" or "side" (a document tab in that area). "document" is accepted as an alias for the area the utility declares as its dock area. Pass an empty string to reveal the utility wherever it currently is without moving it. Only a custom utility moves between areas: naming an area that a built-in or a document shortcut is not already in fails rather than being ignored.</param>
     [McpServerTool(Name = "app_show_utility")]
     [ToolAlias("app.show_utility")]
     [RelatedGuides("workspace_panels")]

--- a/Source/Tests/Documents/GetUtilitiesStateCommandTests.cs
+++ b/Source/Tests/Documents/GetUtilitiesStateCommandTests.cs
@@ -36,7 +36,7 @@ public class GetUtilitiesStateCommandTests
         // Nothing is collapsed unless a test says so, so isVisible follows what is presenting the item.
         _layoutService = Substitute.For<ILayoutService>();
         _layoutService.IsAreaVisible(Arg.Any<WorkspaceArea>()).Returns(true);
-        _utilityService.GetCurrentArea(BuiltInLauncherIds.Workshop).Returns(WorkspaceArea.Main);
+        _utilityService.GetCurrentArea(BuiltInShortcutIds.Workshop).Returns(WorkspaceArea.Main);
 
         _documentsService = Substitute.For<IDocumentsService>();
         _documentsService.ActiveDocument.Returns(ResourceKey.Empty);
@@ -51,7 +51,7 @@ public class GetUtilitiesStateCommandTests
         _workspaceWrapper.WorkspaceService.Returns(workspaceService);
     }
 
-    // A register in rail order: a panel utility with no file behind it, a dockable utility, then a launcher.
+    // A register in rail order: a panel utility with no file behind it, a dockable utility, then a shortcut.
     private static List<UtilityRailItem> BuildRegister()
     {
         return new List<UtilityRailItem>
@@ -67,8 +67,8 @@ public class GetUtilitiesStateCommandTests
                 new UtilityRailPanelView(new object(), () => { }, FocusPanelId.CustomUtility),
                 WorkspaceArea.Bottom),
 
-            UtilityRailItem.CreateDocumentLauncher(
-                BuiltInLauncherIds.Workshop, "workshop-utility-button", "people",
+            UtilityRailItem.CreateDocumentShortcut(
+                BuiltInShortcutIds.Workshop, "workshop-utility-button", "people",
                 "Community Workshop", "Community Workshop",
                 WorkshopResource,
                 BuiltInEditors.WebViewEditorId,
@@ -97,8 +97,8 @@ public class GetUtilitiesStateCommandTests
         utilities[1].UtilityId.Should().Be(NotepadId);
         utilities[1].Resource.Should().Be(NotepadResource);
 
-        // A launcher is listed like anything else on the rail, whatever its scope.
-        utilities[2].UtilityId.Should().Be(BuiltInLauncherIds.Workshop);
+        // A document shortcut is listed like anything else on the rail, whatever its scope.
+        utilities[2].UtilityId.Should().Be(BuiltInShortcutIds.Workshop);
         utilities[2].DisplayName.Should().Be("Community Workshop");
         utilities[2].CurrentArea.Should().Be(WorkspaceArea.Main);
         utilities[2].Resource.Should().Be(WorkshopResource);
@@ -115,12 +115,12 @@ public class GetUtilitiesStateCommandTests
 
         var utilities = command.ResultValue.Utilities;
 
-        // A dockable utility reports where it docks to, a launcher where its document opens, and a panel
+        // A dockable utility reports where it docks to, a shortcut where its document opens, and a panel
         // utility reports none because it never becomes a document.
         utilities.Single(utility => utility.UtilityId == NotepadId).DockArea
             .Should().Be(WorkspaceArea.Bottom);
 
-        utilities.Single(utility => utility.UtilityId == BuiltInLauncherIds.Workshop).DockArea
+        utilities.Single(utility => utility.UtilityId == BuiltInShortcutIds.Workshop).DockArea
             .Should().Be(WorkspaceArea.Main);
 
         utilities.Single(utility => utility.UtilityId == BuiltInUtilityIds.Explorer).DockArea
@@ -158,7 +158,7 @@ public class GetUtilitiesStateCommandTests
         notepad.IsVisible.Should().BeTrue();
 
         // The Workshop is in a document area too, but no section is showing its document.
-        var workshop = command.ResultValue.Utilities.Single(utility => utility.UtilityId == BuiltInLauncherIds.Workshop);
+        var workshop = command.ResultValue.Utilities.Single(utility => utility.UtilityId == BuiltInShortcutIds.Workshop);
         workshop.IsVisible.Should().BeFalse();
     }
 

--- a/Source/Tests/Documents/ShowUtilityCommandTests.cs
+++ b/Source/Tests/Documents/ShowUtilityCommandTests.cs
@@ -124,37 +124,37 @@ public class ShowUtilityCommandTests
     }
 
     [Test]
-    public async Task Execute_Launcher_RevealsItsDocument()
+    public async Task Execute_DocumentShortcut_RevealsItsDocument()
     {
-        // A launcher opens a document rather than occupying the panel, so it is not a live utility either.
-        // An agent asked for a button the user can see has to be able to reveal it.
-        _utilityPanel.HasRailItem(BuiltInLauncherIds.Workshop).Returns(true);
+        // A document shortcut opens a document rather than occupying the panel, so it is not a live utility
+        // either. An agent asked for a button the user can see has to be able to reveal it.
+        _utilityPanel.HasRailItem(BuiltInShortcutIds.Workshop).Returns(true);
 
         var command = new ShowUtilityCommand(_workspaceWrapper)
         {
-            UtilityId = BuiltInLauncherIds.Workshop
+            UtilityId = BuiltInShortcutIds.Workshop
         };
 
         var result = await command.ExecuteAsync();
 
         result.IsSuccess.Should().BeTrue();
-        _utilityPanel.Received(1).ShowUtility(BuiltInLauncherIds.Workshop);
+        _utilityPanel.Received(1).ShowUtility(BuiltInShortcutIds.Workshop);
 
-        // Only a live utility can be moved between areas, so a launcher never reaches the dock path.
+        // Only a live utility can be moved between areas, so a shortcut never reaches the dock path.
         await _utilityService.DidNotReceive().DockUtilityAsync(Arg.Any<EditorId>(), Arg.Any<WorkspaceArea>());
     }
 
     [Test]
-    public async Task Execute_LauncherWithAnAreaItCannotReach_FailsRatherThanIgnoringIt()
+    public async Task Execute_ShortcutWithAnAreaItCannotReach_FailsRatherThanIgnoringIt()
     {
-        // A launcher's document opens in the area it declares. Reporting success while quietly dropping the
-        // requested area would leave a caller believing the move happened.
-        _utilityPanel.HasRailItem(BuiltInLauncherIds.Workshop).Returns(true);
-        _utilityService.GetRailItems().Returns(new List<UtilityRailItem> { CreateWorkshopLauncher() });
+        // A document shortcut's document opens in the area it declares. Reporting success while quietly
+        // dropping the requested area would leave a caller believing the move happened.
+        _utilityPanel.HasRailItem(BuiltInShortcutIds.Workshop).Returns(true);
+        _utilityService.GetRailItems().Returns(new List<UtilityRailItem> { CreateWorkshopShortcut() });
 
         var command = new ShowUtilityCommand(_workspaceWrapper)
         {
-            UtilityId = BuiltInLauncherIds.Workshop,
+            UtilityId = BuiltInShortcutIds.Workshop,
             TargetArea = WorkspaceArea.Side
         };
 
@@ -165,22 +165,22 @@ public class ShowUtilityCommandTests
     }
 
     [Test]
-    public async Task Execute_LauncherWithTheAreaItOpensIn_RevealsIt()
+    public async Task Execute_ShortcutWithTheAreaItOpensIn_RevealsIt()
     {
         // Naming where the item already opens is a reveal, not a move, so it succeeds.
-        _utilityPanel.HasRailItem(BuiltInLauncherIds.Workshop).Returns(true);
-        _utilityService.GetRailItems().Returns(new List<UtilityRailItem> { CreateWorkshopLauncher() });
+        _utilityPanel.HasRailItem(BuiltInShortcutIds.Workshop).Returns(true);
+        _utilityService.GetRailItems().Returns(new List<UtilityRailItem> { CreateWorkshopShortcut() });
 
         var command = new ShowUtilityCommand(_workspaceWrapper)
         {
-            UtilityId = BuiltInLauncherIds.Workshop,
+            UtilityId = BuiltInShortcutIds.Workshop,
             TargetArea = WorkspaceArea.Main
         };
 
         var result = await command.ExecuteAsync();
 
         result.IsSuccess.Should().BeTrue();
-        _utilityPanel.Received(1).ShowUtility(BuiltInLauncherIds.Workshop);
+        _utilityPanel.Received(1).ShowUtility(BuiltInShortcutIds.Workshop);
     }
 
     [Test]
@@ -193,10 +193,10 @@ public class ShowUtilityCommandTests
         result.IsFailure.Should().BeTrue();
     }
 
-    private static UtilityRailItem CreateWorkshopLauncher()
+    private static UtilityRailItem CreateWorkshopShortcut()
     {
-        return UtilityRailItem.CreateDocumentLauncher(
-            BuiltInLauncherIds.Workshop,
+        return UtilityRailItem.CreateDocumentShortcut(
+            BuiltInShortcutIds.Workshop,
             "workshop-utility-button",
             "people",
             "Community Workshop",

--- a/Source/Tests/Documents/UtilityRailItemTests.cs
+++ b/Source/Tests/Documents/UtilityRailItemTests.cs
@@ -73,10 +73,10 @@ public class UtilityRailItemTests
     }
 
     [Test]
-    public void DocumentLauncher_CarriesNoPanelView()
+    public void DocumentShortcut_CarriesNoPanelView()
     {
-        var railItem = UtilityRailItem.CreateDocumentLauncher(
-            BuiltInLauncherIds.Workshop,
+        var railItem = UtilityRailItem.CreateDocumentShortcut(
+            BuiltInShortcutIds.Workshop,
             "workshop-utility-button",
             "people",
             "Community Workshop",
@@ -85,10 +85,10 @@ public class UtilityRailItemTests
             EditorId.Create("celbridge", "webview"),
             WorkspaceArea.Main);
 
-        railItem.Kind.Should().Be(RailItemKind.DocumentLauncher);
+        railItem.Kind.Should().Be(RailItemKind.DocumentShortcut);
         railItem.DockArea.Should().Be(WorkspaceArea.Main);
 
-        // A launcher never occupies the panel, so it parks no live view there.
+        // A document shortcut never occupies the panel, so it parks no live view there.
         railItem.PanelView.Should().BeNull();
     }
 }

--- a/Source/Tests/Documents/UtilityServiceRegisterTests.cs
+++ b/Source/Tests/Documents/UtilityServiceRegisterTests.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Localization;
 namespace Celbridge.Tests.Documents;
 
 /// <summary>
-/// Covers the rail register UtilityService assembles: the order it holds, the launchers it builds, and the
+/// Covers the rail register UtilityService assembles: the order it holds, the shortcuts it builds, and the
 /// area it reports for an item that has never moved. Creating a contribution utility instantiates a WebView,
 /// so these exercise a workspace that declares none.
 /// </summary>
@@ -78,7 +78,7 @@ public class UtilityServiceRegisterTests
         var resourceService = Substitute.For<IResourceService>();
         resourceService.FileSystem.Returns(_resourceFileSystem);
 
-        // GetCurrentArea asks the documents service where a launcher's tab actually is. Nothing is open by
+        // GetCurrentArea asks the documents service where a shortcut's tab actually is. Nothing is open by
         // default, so each test that cares opens one.
         _documentsService = Substitute.For<IDocumentsService>();
 
@@ -119,7 +119,7 @@ public class UtilityServiceRegisterTests
     }
 
     [Test]
-    public async Task GetRailItems_HoldsTheRegisteredBuiltInsAheadOfTheLaunchers()
+    public async Task GetRailItems_HoldsTheRegisteredBuiltInsAheadOfTheShortcuts()
     {
         var service = CreateService();
 
@@ -137,12 +137,12 @@ public class UtilityServiceRegisterTests
         itemIds.Should().Equal(
             BuiltInUtilityIds.Explorer,
             BuiltInUtilityIds.Search,
-            BuiltInLauncherIds.ProjectSettings,
-            BuiltInLauncherIds.Workshop);
+            BuiltInShortcutIds.ProjectSettings,
+            BuiltInShortcutIds.Workshop);
     }
 
     [Test]
-    public async Task CreateUtilitiesAsync_BuildsTheLaunchersWithTheirResources()
+    public async Task CreateUtilitiesAsync_BuildsTheShortcutsWithTheirResources()
     {
         var service = CreateService();
 
@@ -150,21 +150,21 @@ public class UtilityServiceRegisterTests
 
         var railItems = service.GetRailItems();
 
-        var projectSettings = railItems.Single(railItem => railItem.ItemId == BuiltInLauncherIds.ProjectSettings);
+        var projectSettings = railItems.Single(railItem => railItem.ItemId == BuiltInShortcutIds.ProjectSettings);
         projectSettings.FileResource.Should().Be(ProjectFileResource);
         projectSettings.DisplayName.Should().Be("localized:UtilityPanel_ProjectSettingsTooltip");
 
-        var workshop = railItems.Single(railItem => railItem.ItemId == BuiltInLauncherIds.Workshop);
+        var workshop = railItems.Single(railItem => railItem.ItemId == BuiltInShortcutIds.Workshop);
         workshop.FileResource.Should().Be(WorkshopResource);
         workshop.DisplayName.Should().Be("localized:UtilityPanel_WorkshopTooltip");
 
-        // A launcher opens a document and never occupies the panel, which is what makes it a launcher.
+        // A document shortcut opens a document and never occupies the panel, which is what makes it one.
         workshop.PanelView.Should().BeNull();
         workshop.DockArea.Should().Be(WorkspaceArea.Main);
     }
 
     [Test]
-    public async Task CreateUtilitiesAsync_NoProjectLoaded_OmitsTheProjectSettingsLauncher()
+    public async Task CreateUtilitiesAsync_NoProjectLoaded_OmitsTheProjectSettingsShortcut()
     {
         var projectService = Substitute.For<IProjectService>();
         projectService.CurrentProject.Returns((IProject?)null);
@@ -175,11 +175,11 @@ public class UtilityServiceRegisterTests
         await service.CreateUtilitiesAsync(Array.Empty<ResolvedEditor>());
 
         var itemIds = service.GetRailItems().Select(railItem => railItem.ItemId);
-        itemIds.Should().NotContain(BuiltInLauncherIds.ProjectSettings);
+        itemIds.Should().NotContain(BuiltInShortcutIds.ProjectSettings);
     }
 
     [Test]
-    public async Task GetCurrentArea_ReportsThePanelForAUtilityAndNothingForAClosedLauncher()
+    public async Task GetCurrentArea_ReportsThePanelForAUtilityAndNothingForAClosedShortcut()
     {
         var service = CreateService();
 
@@ -195,14 +195,14 @@ public class UtilityServiceRegisterTests
 
         // No document is open for the Workshop, so it occupies nothing. Its declared area says where it
         // would open, which is a different question.
-        service.GetCurrentArea(BuiltInLauncherIds.Workshop).Should().BeNull();
+        service.GetCurrentArea(BuiltInShortcutIds.Workshop).Should().BeNull();
 
         // An id the register does not hold occupies nothing either, rather than claiming the panel.
         service.GetCurrentArea(EditorId.Create("acme", "absent")).Should().BeNull();
     }
 
     [Test]
-    public async Task GetCurrentArea_ReportsWhereALauncherDocumentActuallyIs()
+    public async Task GetCurrentArea_ReportsWhereAShortcutDocumentActuallyIs()
     {
         var service = CreateService();
 
@@ -215,6 +215,6 @@ public class UtilityServiceRegisterTests
 
         await service.CreateUtilitiesAsync(Array.Empty<ResolvedEditor>());
 
-        service.GetCurrentArea(BuiltInLauncherIds.Workshop).Should().Be(WorkspaceArea.Bottom);
+        service.GetCurrentArea(BuiltInShortcutIds.Workshop).Should().Be(WorkspaceArea.Bottom);
     }
 }

--- a/Source/Workspace/Celbridge.Documents/Commands/ShowUtilityCommand.cs
+++ b/Source/Workspace/Celbridge.Documents/Commands/ShowUtilityCommand.cs
@@ -66,7 +66,7 @@ public class ShowUtilityCommand : CommandBase, IShowUtilityCommand
         }
 
         // Reveal the utility wherever it now lives: ShowUtility shows it in the panel when it is there,
-        // activates its document tab when it is docked as a document, and opens a launcher's document.
+        // activates its document tab when it is docked as a document, and opens a document shortcut's file.
         utilityPanel.ShowUtility(UtilityId);
 
         return Result.Ok();
@@ -84,14 +84,15 @@ public class ShowUtilityCommand : CommandBase, IShowUtilityCommand
             return Result.Ok();
         }
 
-        // A launcher declares where its document opens, and a panel utility only ever occupies the panel.
+        // A document shortcut declares where its document opens, and a panel utility only ever occupies
+        // the panel.
         var openArea = railItem.DockArea ?? WorkspaceArea.Utility;
         if (requestedArea == openArea)
         {
             return Result.Ok();
         }
 
-        // The user can move a launcher's tab after it opens, so where it is now counts too.
+        // The user can move a shortcut's tab after it opens, so where it is now counts too.
         var currentArea = utilityService.GetCurrentArea(UtilityId);
         if (requestedArea == currentArea)
         {

--- a/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
@@ -23,8 +23,8 @@ public class UtilityService : IUtilityService, IDisposable
 
     private readonly List<CustomUtilityView> _utilities = new();
 
-    // Spotlight landmark ids for the launcher rail buttons. The Utility Panel sets each one as the button's
-    // AutomationId, which is what a landmark has to match.
+    // Spotlight landmark ids for the document shortcut rail buttons. The Utility Panel sets each one as
+    // the button's AutomationId, which is what a landmark has to match.
     private const string ProjectSettingsLandmarkId = "project-settings-utility-button";
     private const string WorkshopLandmarkId = "workshop-utility-button";
 
@@ -32,7 +32,7 @@ public class UtilityService : IUtilityService, IDisposable
     // their descriptors wrap live views. The rest are built here.
     private readonly List<UtilityRailItem> _builtInUtilityItems = new();
     private readonly List<UtilityRailItem> _contributedItems = new();
-    private readonly List<UtilityRailItem> _builtInLauncherItems = new();
+    private readonly List<UtilityRailItem> _builtInShortcutItems = new();
 
     // The three groups above as one ordered list, and the same items by id. Rebuilt whenever a group
     // changes, so a reader never pays to assemble them.
@@ -82,7 +82,7 @@ public class UtilityService : IUtilityService, IDisposable
         _railItems.Clear();
         _railItems.AddRange(_builtInUtilityItems);
         _railItems.AddRange(_contributedItems);
-        _railItems.AddRange(_builtInLauncherItems);
+        _railItems.AddRange(_builtInShortcutItems);
 
         _railItemsById.Clear();
         foreach (var railItem in _railItems)
@@ -113,8 +113,8 @@ public class UtilityService : IUtilityService, IDisposable
                 // panel is where it is.
                 return WorkspaceArea.Utility;
 
-            case RailItemKind.DocumentLauncher:
-                // A launcher's document sits wherever the user last moved its tab. Closed, it occupies no
+            case RailItemKind.DocumentShortcut:
+                // A shortcut's document sits wherever the user last moved its tab. Closed, it occupies no
                 // area at all, and DockArea is what says where it would open.
                 return FindOpenDocumentArea(railItem.FileResource);
 
@@ -191,8 +191,8 @@ public class UtilityService : IUtilityService, IDisposable
             _contributedItems.Add(railItem);
         }
 
-        _builtInLauncherItems.Clear();
-        _builtInLauncherItems.AddRange(BuildBuiltInLauncherItems());
+        _builtInShortcutItems.Clear();
+        _builtInShortcutItems.AddRange(BuildBuiltInShortcutItems());
 
         RebuildRailRegister();
     }
@@ -216,16 +216,16 @@ public class UtilityService : IUtilityService, IDisposable
         return panelView;
     }
 
-    // The built-in launchers: rail items that open a document and never occupy the panel, so they carry no
-    // panel view. A contribution declaring no utility area builds the same shape from its manifest.
-    private List<UtilityRailItem> BuildBuiltInLauncherItems()
+    // The built-in document shortcuts: rail items that open a document and never occupy the panel, so they
+    // carry no panel view. A contribution declaring no utility area builds the same shape from its manifest.
+    private List<UtilityRailItem> BuildBuiltInShortcutItems()
     {
         var projectService = _serviceProvider.GetRequiredService<IProjectService>();
         var workshopService = _serviceProvider.GetRequiredService<IWorkshopService>();
         var stringLocalizer = _serviceProvider.GetRequiredService<IStringLocalizer>();
         var iconService = _serviceProvider.GetRequiredService<IIconService>();
 
-        var launcherItems = new List<UtilityRailItem>();
+        var shortcutItems = new List<UtilityRailItem>();
 
         // The project file sits at the project root, so its resource key is just the file name. The editor is
         // named so the choice does not depend on extension resolution.
@@ -237,8 +237,8 @@ public class UtilityService : IUtilityService, IDisposable
             {
                 string projectSettingsName = stringLocalizer.GetString("UtilityPanel_ProjectSettingsTooltip");
 
-                var projectSettingsItem = UtilityRailItem.CreateDocumentLauncher(
-                    BuiltInLauncherIds.ProjectSettings,
+                var projectSettingsItem = UtilityRailItem.CreateDocumentShortcut(
+                    BuiltInShortcutIds.ProjectSettings,
                     ProjectSettingsLandmarkId,
                     iconService.GetIconName(IconSymbol.Sliders),
                     projectSettingsName,
@@ -247,14 +247,14 @@ public class UtilityService : IUtilityService, IDisposable
                     BuiltInEditors.ProjectSettingsEditorId,
                     WorkspaceArea.Main);
 
-                launcherItems.Add(projectSettingsItem);
+                shortcutItems.Add(projectSettingsItem);
             }
         }
 
         string workshopName = stringLocalizer.GetString("UtilityPanel_WorkshopTooltip");
 
-        var workshopItem = UtilityRailItem.CreateDocumentLauncher(
-            BuiltInLauncherIds.Workshop,
+        var workshopItem = UtilityRailItem.CreateDocumentShortcut(
+            BuiltInShortcutIds.Workshop,
             WorkshopLandmarkId,
             iconService.GetIconName(IconSymbol.People),
             workshopName,
@@ -263,9 +263,9 @@ public class UtilityService : IUtilityService, IDisposable
             BuiltInEditors.WebViewEditorId,
             WorkspaceArea.Main);
 
-        launcherItems.Add(workshopItem);
+        shortcutItems.Add(workshopItem);
 
-        return launcherItems;
+        return shortcutItems;
     }
 
     public async Task<Result> RestoreDockedUtilityAsync(ResourceKey resource, DocumentAddress address)

--- a/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Views/UtilityPanel.xaml.cs
@@ -46,9 +46,9 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     // click activates its document tab instead of showing it in the panel.
     private readonly Dictionary<EditorId, ResourceKey> _dockedUtilityResources = new();
 
-    // The launchers, by rail id. A launcher never occupies the panel, so its descriptor is what its button
-    // click and its reveal both go through.
-    private readonly Dictionary<EditorId, UtilityRailItem> _launcherItems = new();
+    // The document shortcuts, by rail id. A shortcut never occupies the panel, so its descriptor is what
+    // its button click and its reveal both go through.
+    private readonly Dictionary<EditorId, UtilityRailItem> _shortcutItems = new();
 
     // The Spotlight landmark each rail button owns, by rail id. Unregistering reads the id that was
     // registered rather than rebuilding it, so the two cannot drift apart.
@@ -59,11 +59,11 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     private readonly List<UtilityRailItem> _builtInUtilityItems = new();
 
     // The rail's buttons in the three ordered groups the panel presents: the built-in utilities, then the
-    // contribution utilities, then the launchers. The rail draws them as one stack, so the panel rebuilds it
-    // from these whenever the middle group changes.
+    // contribution utilities, then the document shortcuts. The rail draws them as one stack, so the panel
+    // rebuilds it from these whenever the middle group changes.
     private readonly List<UtilityButton> _builtInUtilityButtons = new();
     private readonly List<UtilityButton> _customUtilityButtons = new();
-    private readonly List<UtilityButton> _launcherButtons = new();
+    private readonly List<UtilityButton> _shortcutButtons = new();
 
     private Storyboard? _perimeterStoryboard;
 
@@ -219,9 +219,9 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
                 _focusActions[itemId] = panelView.FocusPanel;
                 break;
 
-            case RailItemKind.DocumentLauncher:
-                _launcherItems[itemId] = item;
-                railButton.Click += (sender, e) => ShowLauncherDocument(item);
+            case RailItemKind.DocumentShortcut:
+                _shortcutItems[itemId] = item;
+                railButton.Click += (sender, e) => ShowShortcutDocument(item);
                 break;
 
             default:
@@ -267,12 +267,12 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         return contentControl;
     }
 
-    // Opens a launcher's document in the area it declares. Already open, the command activates its tab.
-    private void ShowLauncherDocument(UtilityRailItem item)
+    // Opens a shortcut's document in the area it declares. Already open, the command activates its tab.
+    private void ShowShortcutDocument(UtilityRailItem item)
     {
         FlashRailButton(item.ItemId);
 
-        // A launcher always names the area its document opens in.
+        // A document shortcut always names the area its document opens in.
         var area = item.DockArea!.Value;
 
         // Opening into a section does not reveal its area, so a collapsed one is presented first.
@@ -280,7 +280,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
 
         // The declared area decides where the document lands when it opens. A tab that is already open keeps
         // the section the user put it in, which is what an unnamed section means to the open command.
-        var targetSection = ResolveLauncherSection(item.FileResource, area);
+        var targetSection = ResolveShortcutSection(item.FileResource, area);
 
         _commandService.Execute<IOpenDocumentCommand>(command =>
         {
@@ -291,7 +291,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     }
 
     // Null once the document is open, so the open command leaves the tab where the user put it.
-    private DocumentSection? ResolveLauncherSection(ResourceKey resource, WorkspaceArea area)
+    private DocumentSection? ResolveShortcutSection(ResourceKey resource, WorkspaceArea area)
     {
         var documentsService = _workspaceWrapper.WorkspaceService.DocumentsService;
         if (documentsService.FindOpenDocument(resource) is not null)
@@ -371,7 +371,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
     // Flags the Project Settings rail button when any contribution has dropped configuration.
     private void UpdateProjectSettingsIssuePip()
     {
-        if (!_buttons.TryGetValue(BuiltInLauncherIds.ProjectSettings, out var projectSettingsButton))
+        if (!_buttons.TryGetValue(BuiltInShortcutIds.ProjectSettings, out var projectSettingsButton))
         {
             return;
         }
@@ -395,11 +395,11 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
 
     public void ShowUtility(EditorId utilityId)
     {
-        // A launcher never occupies the panel, so revealing it is opening its document, the same as clicking
-        // it.
-        if (_launcherItems.TryGetValue(utilityId, out var launcherItem))
+        // A document shortcut never occupies the panel, so revealing it is opening its document, the same
+        // as clicking it.
+        if (_shortcutItems.TryGetValue(utilityId, out var shortcutItem))
         {
-            ShowLauncherDocument(launcherItem);
+            ShowShortcutDocument(shortcutItem);
             return;
         }
 
@@ -623,10 +623,10 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
 
             var railButton = AddRailItem(railItem);
 
-            // A launcher joins the group the rail draws after the gap.
-            if (railItem.Kind == RailItemKind.DocumentLauncher)
+            // A document shortcut joins the group the rail draws after the gap.
+            if (railItem.Kind == RailItemKind.DocumentShortcut)
             {
-                _launcherButtons.Add(railButton);
+                _shortcutButtons.Add(railButton);
             }
             else
             {
@@ -640,8 +640,9 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         UpdateProjectSettingsIssuePip();
     }
 
-    // Rebuilds the rail as two visual groups: the built-in utilities with the contribution utilities, then the
-    // launchers. The rail draws the gap at the group boundary, so no button carries layout of its own.
+    // Rebuilds the rail as two visual groups: the built-in utilities with the contribution utilities, then
+    // the document shortcuts. The rail draws the gap at the group boundary, so no button carries layout of
+    // its own.
     private void RefreshRailButtons()
     {
         _rail.ClearButtons();
@@ -651,7 +652,7 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
         utilityGroup.AddRange(_customUtilityButtons);
 
         _rail.AddButtonGroup(utilityGroup);
-        _rail.AddButtonGroup(_launcherButtons);
+        _rail.AddButtonGroup(_shortcutButtons);
     }
 
     public void ClearRailItems()
@@ -692,15 +693,15 @@ public sealed partial class UtilityPanel : UserControl, IUtilityPanel
             ViewModel.RemoveItem(utilityId);
         }
 
-        // The launchers host no live view and no content, so they are simply dropped and rebuilt.
-        foreach (var launcherItem in _launcherItems.Values)
+        // The document shortcuts host no live view and no content, so they are simply dropped and rebuilt.
+        foreach (var shortcutItem in _shortcutItems.Values)
         {
-            _buttons.Remove(launcherItem.ItemId);
-            UnregisterRailLandmark(launcherItem.ItemId);
+            _buttons.Remove(shortcutItem.ItemId);
+            UnregisterRailLandmark(shortcutItem.ItemId);
         }
 
-        _launcherItems.Clear();
-        _launcherButtons.Clear();
+        _shortcutItems.Clear();
+        _shortcutButtons.Clear();
     }
 
     public void SetUtilityArea(EditorId utilityId, WorkspaceArea area, ResourceKey documentResource)


### PR DESCRIPTION
This pull request standardizes terminology throughout the codebase and documentation, replacing the terms "launcher" and "BuiltInLauncherIds" with "document shortcut" and "BuiltInShortcutIds" respectively. This change clarifies the distinction between utilities that open documents (shortcuts) and those that occupy the utility panel, and ensures consistent language across interfaces, comments, documentation, and tests.

**Terminology Standardization and Refactoring:**

* Renamed all references to "launcher" (e.g., `BuiltInLauncherIds`, `DocumentLauncher`) to "document shortcut" (e.g., `BuiltInShortcutIds`, `DocumentShortcut`) in code, comments, and public APIs (`IShowUtilityCommand`, `IUtilityService`, `UtilityRailItem`, `RailItemKind`). [[1]](diffhunk://#diff-1f4bc4c0311b1f888d657f2dac2e7a816657e3692ef713a3ce2f21b8f9855f0bL24-R35) [[2]](diffhunk://#diff-9aaa9dfd33a0160de434d6137140e3543fa3e94fa14f55df236e1cd475e1423eL27-R27) [[3]](diffhunk://#diff-9aaa9dfd33a0160de434d6137140e3543fa3e94fa14f55df236e1cd475e1423eL187-R187) [[4]](diffhunk://#diff-9aaa9dfd33a0160de434d6137140e3543fa3e94fa14f55df236e1cd475e1423eL199-R199) [[5]](diffhunk://#diff-9aaa9dfd33a0160de434d6137140e3543fa3e94fa14f55df236e1cd475e1423eL79-R81) [[6]](diffhunk://#diff-9aaa9dfd33a0160de434d6137140e3543fa3e94fa14f55df236e1cd475e1423eL98-R98) [[7]](diffhunk://#diff-eca1a4d842d1aa261a2a2967e6c0299077a1aa4557496990fe6fb5257ba2fd21L8-R9) [[8]](diffhunk://#diff-eca1a4d842d1aa261a2a2967e6c0299077a1aa4557496990fe6fb5257ba2fd21L20-R21) [[9]](diffhunk://#diff-0754556c715b188323f7d9b17e523f8dec8632e49874379841d2f9a4aef7ed8aL21-R34) [[10]](diffhunk://#diff-d43f753f09b9ea30b34c5637404ce08f288ae52621e4815afcb17bac18b358baL47-R48) [[11]](diffhunk://#diff-64900f3c61838cc698e435a8fa0b7f22983e697ad826dc8fe63a9ab1b1e19e79L11-R11)

**Documentation Updates:**

* Updated all user and developer documentation to use "document shortcut" instead of "launcher", clarifying descriptions and behavior in markdown guides (`app_list_utilities.md`, `app_show_utility.md`). [[1]](diffhunk://#diff-d24b55022621a3c26fc6298ba14327c51ff4d88e607c62ffeb2be43abfeba542L3-R3) [[2]](diffhunk://#diff-d24b55022621a3c26fc6298ba14327c51ff4d88e607c62ffeb2be43abfeba542L22-R22) [[3]](diffhunk://#diff-3e6332f2b7afd2eeeff54fd51ca8540cd1babbf54f77604ed5a3a3bc677831acL12-R12) [[4]](diffhunk://#diff-3e6332f2b7afd2eeeff54fd51ca8540cd1babbf54f77604ed5a3a3bc677831acL23-R23)

**Test Maintenance:**

* Updated tests to use the new terminology and identifiers, ensuring that all test logic and comments refer to "document shortcuts" rather than "launchers". [[1]](diffhunk://#diff-13aa7d2864e68144a4d6dd0c09534793be963398a4ad878adc141b609b84abadL39-R39) [[2]](diffhunk://#diff-13aa7d2864e68144a4d6dd0c09534793be963398a4ad878adc141b609b84abadL54-R54) [[3]](diffhunk://#diff-13aa7d2864e68144a4d6dd0c09534793be963398a4ad878adc141b609b84abadL70-R71) [[4]](diffhunk://#diff-13aa7d2864e68144a4d6dd0c09534793be963398a4ad878adc141b609b84abadL100-R101) [[5]](diffhunk://#diff-13aa7d2864e68144a4d6dd0c09534793be963398a4ad878adc141b609b84abadL118-R123) [[6]](diffhunk://#diff-13aa7d2864e68144a4d6dd0c09534793be963398a4ad878adc141b609b84abadL161-R161)Replaces launcher terminology with document shortcut terminology across Foundation contracts, workspace/UI implementation, MCP tool guides, and tests. This includes renaming IDs, enum values, factory/helper methods, and related comments so the rail item behavior is described consistently as opening documents rather than acting as panel utilities.