### PR TITLE
Add file picker and browse button for document shortcuts

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -902,6 +902,12 @@ Open with default application instead?</value>
   <data name="ProjectSettings_ShortcutMissingResource" xml:space="preserve">
     <value>This project has no file at this path yet.</value>
   </data>
+  <data name="ProjectSettings_ShortcutBrowseTooltip" xml:space="preserve">
+    <value>Choose a file</value>
+  </data>
+  <data name="ProjectSettings_ShortcutPickerTitle" xml:space="preserve">
+    <value>Choose a File to Open</value>
+  </data>
   <data name="ProjectSettings_ShortcutOpenTooltip" xml:space="preserve">
     <value>Open this document</value>
   </data>

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/DocumentShortcutViewModel.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/DocumentShortcutViewModel.cs
@@ -197,6 +197,7 @@ public partial class DocumentShortcutViewModel : ObservableObject
     }
 
     public string OpenTooltip => ProjectSettingsLabels.ShortcutOpenTooltip;
+    public string BrowseTooltip => ProjectSettingsLabels.ShortcutBrowseTooltip;
     public string AreaLabel => ProjectSettingsLabels.ShortcutAreaLabel;
     public string AreaHint => ProjectSettingsLabels.ShortcutAreaHint;
     public string ResourceLabel => ProjectSettingsLabels.ShortcutResourceLabel;

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/DocumentShortcutsSectionViewModel.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/DocumentShortcutsSectionViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using Celbridge.Dialog;
 using Celbridge.Projects;
 using Celbridge.Documents;
 using Celbridge.UserInterface;
@@ -16,6 +17,7 @@ namespace Celbridge.ProjectSettings.ViewModels;
 public class DocumentShortcutsSectionViewModel : ProjectSettingsSectionViewModel
 {
     private readonly IIconService _iconService;
+    private readonly IDialogService _dialogService;
 
     // Set while the section rebuilds itself from the config, so populating the collection does not write
     // what it just read back into the draft.
@@ -27,10 +29,14 @@ public class DocumentShortcutsSectionViewModel : ProjectSettingsSectionViewModel
 
     public string AddShortcutText => ProjectSettingsLabels.AddShortcut;
 
-    public DocumentShortcutsSectionViewModel(ProjectSettingsContext context, IIconService iconService)
+    public DocumentShortcutsSectionViewModel(
+        ProjectSettingsContext context,
+        IIconService iconService,
+        IDialogService dialogService)
         : base(context)
     {
         _iconService = iconService;
+        _dialogService = dialogService;
 
         Shortcuts.CollectionChanged += Shortcuts_CollectionChanged;
     }
@@ -75,6 +81,28 @@ public class DocumentShortcutsSectionViewModel : ProjectSettingsSectionViewModel
         };
 
         Shortcuts.Add(CreateShortcut(documentShortcut));
+    }
+
+    /// <summary>
+    /// Replaces a shortcut's resource with one chosen from the project.
+    /// </summary>
+    public async Task PickResourceAsync(DocumentShortcutViewModel shortcut)
+    {
+        // No extension filter: a shortcut opens whatever editor the file resolves to, so every file is a
+        // candidate.
+        var extensions = Array.Empty<string>();
+
+        var pickResult = await _dialogService.ShowResourcePickerDialogAsync(
+            extensions, ProjectSettingsLabels.ShortcutPickerTitle);
+
+        // The dialog reports a dismissal as a failure, so the shortcut keeps the resource it had.
+        if (pickResult.IsFailure)
+        {
+            return;
+        }
+
+        // The bare path, so a picked resource reads the same as a typed one.
+        shortcut.Resource = pickResult.Value.Path;
     }
 
     /// <summary>

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/ProjectSettingsEditorViewModel.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/ProjectSettingsEditorViewModel.cs
@@ -1,4 +1,5 @@
 using Celbridge.Commands;
+using Celbridge.Dialog;
 using Celbridge.FileSystem;
 using Celbridge.Logging;
 using Celbridge.Messaging;
@@ -106,7 +107,8 @@ public partial class ProjectSettingsEditorViewModel : ObservableObject
         ISettingsService settingsService,
         IPackageLocalizationService packageLocalization,
         IFileTypeCatalog fileTypeCatalog,
-        IIconService iconService)
+        IIconService iconService,
+        IDialogService dialogService)
     {
         _logger = logger;
         _projectService = projectService;
@@ -127,7 +129,7 @@ public partial class ProjectSettingsEditorViewModel : ObservableObject
         PackagesSection = new PackagesSectionViewModel(_context, packageLocalization);
         FileEditorsSection = new FileEditorsSectionViewModel(_context, fileTypeCatalog, _stringLocalizer);
         PagesSection = new PagesSectionViewModel(_context);
-        DocumentShortcutsSection = new DocumentShortcutsSectionViewModel(_context, iconService);
+        DocumentShortcutsSection = new DocumentShortcutsSectionViewModel(_context, iconService, dialogService);
         FeatureFlagsSection = new FeatureFlagsSectionViewModel(_context, _stringLocalizer);
 
         _messengerService.Register<ResourceChangedMessage>(this, OnResourceChanged);

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/ProjectSettingsLabels.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/ProjectSettingsLabels.cs
@@ -45,6 +45,8 @@ internal static class ProjectSettingsLabels
     public static string ShortcutResourceHint => Localizer.GetString("ProjectSettings_ShortcutResourceHint");
     public static string ShortcutInvalidResource => Localizer.GetString("ProjectSettings_ShortcutInvalidResource");
     public static string ShortcutMissingResource => Localizer.GetString("ProjectSettings_ShortcutMissingResource");
+    public static string ShortcutBrowseTooltip => Localizer.GetString("ProjectSettings_ShortcutBrowseTooltip");
+    public static string ShortcutPickerTitle => Localizer.GetString("ProjectSettings_ShortcutPickerTitle");
     public static string ShortcutOpenTooltip => Localizer.GetString("ProjectSettings_ShortcutOpenTooltip");
     public static string ShortcutAreaLabel => Localizer.GetString("ProjectSettings_ShortcutAreaLabel");
     public static string ShortcutAreaHint => Localizer.GetString("ProjectSettings_ShortcutAreaHint");

--- a/Source/Workspace/Celbridge.ProjectSettings/Views/DocumentShortcutsSectionView.xaml
+++ b/Source/Workspace/Celbridge.ProjectSettings/Views/DocumentShortcutsSectionView.xaml
@@ -26,6 +26,7 @@
     <DataTemplate x:Key="ShortcutActionsTemplate" x:DataType="vm:DocumentShortcutViewModel">
       <controls:IconButton VerticalAlignment="Center"
                            IsEnabled="{x:Bind CanOpen, Mode=OneWay}"
+                           AutomationProperties.Name="{x:Bind OpenTooltip}"
                            ToolTipService.ToolTip="{x:Bind OpenTooltip}"
                            Click="OpenShortcutButton_Click">
         <controls:Icon IconName="bs-arrow-up-right" FontSize="{StaticResource IconSizeMedium}" />
@@ -38,10 +39,26 @@
         <StackPanel Spacing="2">
           <TextBlock Text="{x:Bind ResourceLabel}"
                      Style="{StaticResource FieldLabelTextStyle}" />
-          <TextBox IsSpellCheckEnabled="False"
-                   PlaceholderText="{x:Bind ResourcePlaceholder}"
-                   Text="{x:Bind Resource, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
-                   KeyDown="CommitField_KeyDown" />
+          <Grid ColumnSpacing="4">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBox Grid.Column="0"
+                     IsSpellCheckEnabled="False"
+                     PlaceholderText="{x:Bind ResourcePlaceholder}"
+                     Text="{x:Bind Resource, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
+                     KeyDown="CommitField_KeyDown" />
+
+            <controls:IconButton Grid.Column="1"
+                                 VerticalAlignment="Center"
+                                 AutomationProperties.Name="{x:Bind BrowseTooltip}"
+                                 ToolTipService.ToolTip="{x:Bind BrowseTooltip}"
+                                 Click="BrowseResourceButton_Click">
+              <controls:Icon IconName="bs-three-dots" FontSize="{StaticResource IconSizeMedium}" />
+            </controls:IconButton>
+          </Grid>
           <TextBlock Text="{x:Bind ResourceHint}"
                      Style="{StaticResource SupportingTextStyle}"
                      TextWrapping="Wrap" />

--- a/Source/Workspace/Celbridge.ProjectSettings/Views/DocumentShortcutsSectionView.xaml.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/Views/DocumentShortcutsSectionView.xaml.cs
@@ -37,6 +37,18 @@ public sealed partial class DocumentShortcutsSectionView : UserControl
         ViewModel?.AddShortcut();
     }
 
+    private void BrowseResourceButton_Click(object sender, RoutedEventArgs e)
+    {
+        var browseButton = (FrameworkElement)sender;
+        if (browseButton.DataContext is not DocumentShortcutViewModel shortcut
+            || ViewModel is null)
+        {
+            return;
+        }
+
+        _ = ViewModel.PickResourceAsync(shortcut);
+    }
+
     private void OpenShortcutButton_Click(object sender, RoutedEventArgs e)
     {
         var openButton = (FrameworkElement)sender;


### PR DESCRIPTION
This pull request enhances the document shortcut management experience in project settings by allowing users to browse and select a file resource via a dialog, rather than typing the file path manually. It introduces a resource picker dialog, updates the UI to include a browse button, and adds supporting localization strings and tooltips.

**UI and User Experience Improvements**
* Added a browse button next to the resource text box in the shortcut editor UI, allowing users to select a file using a dialog instead of entering the path manually. The button includes accessibility and tooltip support. (`DocumentShortcutsSectionView.xaml`, `DocumentShortcutsSectionView.xaml.cs`, `DocumentShortcutViewModel.cs`) [[1]](diffhunk://#diff-f6930f70d544b647764dde59954656240a396edb0743d0a337b3a7669be5708eL41-R61) [[2]](diffhunk://#diff-bf5a355887fc44f5f554259a686fd78e74059860333a69f882551388b24394f6R40-R51) [[3]](diffhunk://#diff-aaeda58754845ab85858be3a26c3f66c334fae6c9406113a31e137749cefb5c2R200)
* Updated the resource text box layout to a grid to accommodate the new browse button. (`DocumentShortcutsSectionView.xaml`)
* Added new tooltips and dialog titles for the browse functionality, with corresponding localization entries. (`Resources.resw`, `ProjectSettingsLabels.cs`, `DocumentShortcutViewModel.cs`) [[1]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40R905-R910) [[2]](diffhunk://#diff-6f664e4c0602772191528c5e3a01f0038d06c5b99f81c4175331b0bb51a65ad8R48-R49) [[3]](diffhunk://#diff-aaeda58754845ab85858be3a26c3f66c334fae6c9406113a31e137749cefb5c2R200)

**ViewModel and Dialog Integration**
* Introduced a `PickResourceAsync` method in `DocumentShortcutsSectionViewModel` to handle file selection using the injected `IDialogService`. (`DocumentShortcutsSectionViewModel.cs`)
* Updated constructor signatures and dependency injection to provide `IDialogService` to relevant view models. (`DocumentShortcutsSectionViewModel.cs`, `ProjectSettingsEditorViewModel.cs`) [[1]](diffhunk://#diff-feee6cdf50548fd8021443da4c1375c2ea741a683663b0217bdad9f87f28f649R20) [[2]](diffhunk://#diff-feee6cdf50548fd8021443da4c1375c2ea741a683663b0217bdad9f87f28f649L30-R39) [[3]](diffhunk://#diff-45a6710ff5d59a50dc37af218fef5b55c7aa1b02fe4cd04828ecdd0fb19647faL109-R111) [[4]](diffhunk://#diff-45a6710ff5d59a50dc37af218fef5b55c7aa1b02fe4cd04828ecdd0fb19647faL130-R132)
* Added necessary using directives for dialog service integration. (`DocumentShortcutsSectionViewModel.cs`, `ProjectSettingsEditorViewModel.cs`) [[1]](diffhunk://#diff-feee6cdf50548fd8021443da4c1375c2ea741a683663b0217bdad9f87f28f649R4) [[2]](diffhunk://#diff-45a6710ff5d59a50dc37af218fef5b55c7aa1b02fe4cd04828ecdd0fb19647faR2)

**Accessibility**
* Set `AutomationProperties.Name` for both open and browse buttons to improve accessibility for screen readers. (`DocumentShortcutsSectionView.xaml`) [[1]](diffhunk://#diff-f6930f70d544b647764dde59954656240a396edb0743d0a337b3a7669be5708eR29) [[2]](diffhunk://#diff-f6930f70d544b647764dde59954656240a396edb0743d0a337b3a7669be5708eL41-R61)

These changes collectively make it easier and more intuitive for users to configure document shortcuts in project settings.Add a browse button and resource-picker flow for Document Shortcuts. UI: add a three-dots IconButton with accessible name and tooltip bound to new BrowseTooltip label. View/VM: inject IDialogService into DocumentShortcutsSectionViewModel and ProjectSettingsEditorViewModel; implement PickResourceAsync to show the resource picker and set the shortcut path (no extension filter, cancel preserved). Labels: add localization keys for the browse tooltip and picker title. Small wiring in view code-behind to invoke the pick action.