### PR TITLE
Add shared ESLint config and lint cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           fail-on-error: true
 
   js-test:
-    name: Run JS Tests
+    name: Run JS Tests and Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -73,6 +73,12 @@ jobs:
       - name: Run JS tests
         working-directory: ./Source
         run: npm test
+
+      # Runs even when the tests fail, so one run reports both.
+      - name: Run JS lint
+        if: always()
+        working-directory: ./Source
+        run: npm run lint
 
   python-test:
     name: Run Python Tests

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/core/webview-tools-shim.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/core/webview-tools-shim.js
@@ -106,7 +106,7 @@
         });
         try {
             Object.defineProperty(console, '__celWrapped', { value: true, enumerable: false });
-        } catch (_) {
+        } catch {
             console.__celWrapped = true;
         }
     }
@@ -131,7 +131,7 @@
                 && window.webkit.messageHandlers.unoWebView) {
                 window.webkit.messageHandlers.unoWebView.postMessage(envelope);
             }
-        } catch (_) {
+        } catch {
             // Reporting a crash must never cause one.
         }
     }
@@ -253,10 +253,10 @@
             try {
                 var label = document.querySelector('label[for="' + cssEscape(el.id) + '"]');
                 if (label) {
-                    var text = (label.textContent || '').trim();
-                    if (text) return text;
+                    var labelText = (label.textContent || '').trim();
+                    if (labelText) return labelText;
                 }
-            } catch (_) { /* fallthrough */ }
+            } catch { /* fallthrough */ }
         }
 
         var alt = el.getAttribute('alt');
@@ -318,7 +318,7 @@
                 if (document.querySelectorAll(idSelector).length === 1) {
                     return idSelector;
                 }
-            } catch (_) { /* fallthrough */ }
+            } catch { /* fallthrough */ }
         }
 
         var parts = [];
@@ -412,7 +412,7 @@
         for (var i = 0; i < keys.length; i++) {
             try {
                 result[keys[i]] = style.getPropertyValue(keys[i]);
-            } catch (_) { /* skip */ }
+            } catch { /* skip */ }
         }
         return result;
     }
@@ -521,7 +521,7 @@
                     }
                 }
             }
-        } catch (_) { /* swallow */ }
+        } catch { /* swallow */ }
         return result;
     }
 
@@ -534,7 +534,7 @@
             if (body instanceof Blob) return '[Blob ' + body.size + ' bytes]';
             if (body instanceof ArrayBuffer) return '[ArrayBuffer ' + body.byteLength + ' bytes]';
             return '[' + (body.constructor && body.constructor.name ? body.constructor.name : 'body') + ']';
-        } catch (_) {
+        } catch {
             return '[unreadable body]';
         }
     }
@@ -562,7 +562,7 @@
                 if (init && init.body !== undefined) {
                     requestBodyDescription = describeRequestBody(init.body);
                 }
-            } catch (_) {
+            } catch {
                 url = String(input);
                 method = 'GET';
                 requestHeaders = {};
@@ -571,7 +571,7 @@
             return originalFetch(input, init).then(function (response) {
                 var duration = ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - perfStart;
                 var clone;
-                try { clone = response.clone(); } catch (_) { clone = null; }
+                try { clone = response.clone(); } catch { clone = null; }
                 var responseHeaders = headersToObject(response.headers);
                 var contentLengthHeader = responseHeaders['content-length'] || responseHeaders['Content-Length'];
                 var responseSize = contentLengthHeader ? Number(contentLengthHeader) || 0 : 0;
@@ -624,7 +624,7 @@
         };
         try {
             Object.defineProperty(wrappedFetch, '__celWrapped', { value: true, enumerable: false });
-        } catch (_) {
+        } catch {
             wrappedFetch.__celWrapped = true;
         }
         window.fetch = wrappedFetch;
@@ -692,7 +692,7 @@
                         } else {
                             entry.responseBody = { text: '[' + responseType + ']', truncatedBytes: 0 };
                         }
-                    } catch (_) { /* swallow */ }
+                    } catch { /* swallow */ }
                     pushNetworkEntry(entry);
                 };
 
@@ -721,7 +721,7 @@
 
         try {
             Object.defineProperty(XMLHttpRequest.prototype, '__celWrapped', { value: true, enumerable: false });
-        } catch (_) {
+        } catch {
             XMLHttpRequest.prototype.__celWrapped = true;
         }
     }
@@ -866,7 +866,7 @@
                     clientY: clientY,
                     button: 0
                 });
-            } catch (e) {
+            } catch {
                 ev = document.createEvent ? document.createEvent('MouseEvents') : null;
                 if (ev && typeof ev.initMouseEvent === 'function') {
                     ev.initMouseEvent(phases[i], true, true, window, 0, 0, 0, clientX, clientY, false, false, false, false, 0, null);
@@ -931,7 +931,7 @@
                 } else {
                     element.value = args.value;
                 }
-            } catch (_) {
+            } catch {
                 element.value = args.value;
             }
         } else {
@@ -942,13 +942,13 @@
         var changeEvent;
         try {
             inputEvent = new Event('input', { bubbles: true });
-        } catch (_) {
+        } catch {
             inputEvent = document.createEvent ? document.createEvent('Event') : null;
             if (inputEvent && typeof inputEvent.initEvent === 'function') inputEvent.initEvent('input', true, true);
         }
         try {
             changeEvent = new Event('change', { bubbles: true });
-        } catch (_) {
+        } catch {
             changeEvent = document.createEvent ? document.createEvent('Event') : null;
             if (changeEvent && typeof changeEvent.initEvent === 'function') changeEvent.initEvent('change', true, true);
         }

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/tests/celbridge.test.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/tests/celbridge.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Celbridge } from './celbridge.js';
 
 /**
@@ -479,7 +479,7 @@ describe('Celbridge', () => {
 
     describe('edge cases', () => {
         it('should handle response with no matching request', async () => {
-            const { client, simulateResponse } = createTestClient();
+            const { simulateResponse } = createTestClient();
 
             // This should not throw, just log a warning
             expect(() => simulateResponse(999, { content: 'orphan' })).not.toThrow();
@@ -489,7 +489,7 @@ describe('Celbridge', () => {
             const sentMessages = [];
             let messageHandler = null;
 
-            const client = new Celbridge({
+            new Celbridge({
                 postMessage: (msg) => sentMessages.push(msg),
                 onMessage: (handler) => { messageHandler = handler; }
             });

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/editor-controller.js
@@ -15,7 +15,6 @@ export class EditorController {
     #containerElement = null;
     #isInitialized = false;
     #isReloadingExternally = false;
-    #currentLanguage = 'plaintext';
     #pendingNavigation = null;
     #onContentChanged = () => {};
     #onScrollChanged = () => {};
@@ -59,7 +58,6 @@ export class EditorController {
 
     setLanguage(language) {
         if (this.#editor && language) {
-            this.#currentLanguage = language;
             monaco.editor.setModelLanguage(this.#editor.getModel(), language);
         }
     }

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/preview-pipeline.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/js/preview-pipeline.js
@@ -13,7 +13,6 @@ import { attachDividerDrag } from './divider-drag.js';
 import { updateViewModeButtons, syncSnippetButtonForViewMode } from './toolbar.js';
 
 export class PreviewPipeline {
-    #editorController;
     #initialViewMode;
     #onLinkClicked;
     #viewModeController;
@@ -25,7 +24,6 @@ export class PreviewPipeline {
         panes,
         onLinkClicked
     }) {
-        this.#editorController = editorController;
         this.#initialViewMode = initialViewMode ?? ViewMode.Source;
         this.#onLinkClicked = onLinkClicked ?? (() => {});
 

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/markdown-preview/preview-module.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/CodeEditor/markdown-preview/preview-module.js
@@ -18,7 +18,6 @@ let previewFind = null;
 // html[data-theme], which preview.css and highlight.css key off, and keeps it in sync on changes.
 let previewThemeListenerRegistered = false;
 let documentBasePath = '';
-let currentContent = '';
 let previewContentElement = null;
 let previewContainerElement = null;
 let suppressScrollSync = false;
@@ -70,7 +69,7 @@ function configureMarked() {
                 .toLowerCase()
                 .trim()
                 .replace(/\s+/g, '-')
-                .replace(/[^\w\-]/g, '');
+                .replace(/[^\w-]/g, '');
             return `<h${token.depth} id="${slug}"${sourceAttr(token)}>${text}</h${token.depth}>\n`;
         },
 
@@ -404,7 +403,6 @@ export function render(markdown) {
         return;
     }
 
-    currentContent = markdown ?? '';
     const savedScrollTop = previewContainerElement ? previewContainerElement.scrollTop : 0;
 
     if (!markdown || markdown.trim() === '') {
@@ -432,7 +430,7 @@ export function render(markdown) {
                 </div>
                 <pre style="white-space: pre-wrap; word-wrap: break-word;">${escaped}</pre>
             `;
-        } catch (fallbackError) {
+        } catch {
             previewContentElement.innerHTML = `<p style="color: var(--hl-keyword);">Error rendering markdown: ${error.message}</p>`;
         }
     }

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Notes/js/note-link-popover.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Notes/js/note-link-popover.js
@@ -11,7 +11,6 @@ let editorWrapper = null;
 let deleteBtnEl = null;
 let openBtnEl = null;
 let currentLinkEl = null;
-let currentSelectionRange = null;
 let originalHref = '';
 let isExistingLink = false;
 let isPickerOpen = false;
@@ -115,7 +114,6 @@ function showPopoverForLink(linkEl) {
     hideAllPopovers();
 
     currentLinkEl = linkEl;
-    currentSelectionRange = null;
     createModeRange = null;
     isExistingLink = true;
 
@@ -164,7 +162,6 @@ export function showPopoverForSelection() {
     const trimmedTo = to - trailingSpaces;
     if (trimmedFrom >= trimmedTo) return false;
 
-    currentSelectionRange = { from: trimmedFrom, to: trimmedTo };
     createModeRange = { from: trimmedFrom, to: trimmedTo };
     currentLinkEl = null;
     isExistingLink = false;
@@ -232,7 +229,6 @@ function removeLink() {
 function hidePopover() {
     linkPopoverEl.classList.remove('visible');
     currentLinkEl = null;
-    currentSelectionRange = null;
     createModeRange = null;
     isExistingLink = false;
     originalHref = '';
@@ -298,7 +294,7 @@ function getActiveLinkInfo() {
     if (!linkMark) return null;
 
     const domAtPos = ctx.editor.view.domAtPos(from);
-    let linkEl = null;
+    let linkEl;
     if (domAtPos.node.nodeType === Node.TEXT_NODE) {
         linkEl = domAtPos.node.parentElement?.closest('a');
     } else {

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Notes/js/note-table-popover.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Notes/js/note-table-popover.js
@@ -31,7 +31,8 @@ export function createTableExtensions() {
     const AutoSizeTable = Table.extend({
         renderHTML({ HTMLAttributes }) {
             // Remove any width-related styles that TipTap adds by default
-            const { style, ...restAttributes } = HTMLAttributes;
+            const restAttributes = { ...HTMLAttributes };
+            delete restAttributes.style;
             return ['table', restAttributes, ['tbody', 0]];
         },
     });

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/Notes/js/note.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/Notes/js/note.js
@@ -1,7 +1,7 @@
 // Note editor entry point
 // TipTap-based rich text editor using native JSON storage format
 
-import { Editor, StarterKit, Link, Placeholder, TaskList, TaskItem, CellSelection, TableMap } from '../lib/tiptap.js';
+import { Editor, StarterKit, Link, Placeholder, TaskList, TaskItem, CellSelection } from '../lib/tiptap.js';
 import { t } from '/assets/celbridge-client/localization.js';
 import celbridge from '/assets/celbridge-client/celbridge.js';
 import { ContentLoadedReason, projectUrl } from '/assets/celbridge-client/api/document-api.js';
@@ -493,7 +493,7 @@ async function initializeEditor() {
                 if (content) {
                     try {
                         jsonContent = JSON.parse(content);
-                    } catch (e) {
+                    } catch {
                         console.warn('[Note] Failed to parse content as JSON, using empty document');
                     }
                 }

--- a/Source/Modules/Celbridge.DocumentEditors/Editors/UtilityDemo/js/utility-demo.js
+++ b/Source/Modules/Celbridge.DocumentEditors/Editors/UtilityDemo/js/utility-demo.js
@@ -71,7 +71,7 @@ function parseText(content) {
     try {
         const state = JSON.parse(content);
         return typeof state.text === 'string' ? state.text : '';
-    } catch (e) {
+    } catch {
         // Tolerate a file that is not the JSON envelope (e.g. hand-edited) by treating it as plain text.
         return content;
     }

--- a/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
+++ b/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
@@ -179,7 +179,7 @@ function listenForChanges() {
     // in for a "doc modified" signal SpreadJS doesn't expose directly. Mouse-
     // driven selection changes bypass commandManager — SelectionChanged in
     // bindSheetEvents covers that gap.
-    commandManager.addListener('appListener', (args) => {
+    commandManager.addListener('appListener', () => {
         if (frameworkReadOnly) return;
         client.document.notifyChanged();
     });
@@ -288,7 +288,7 @@ function handleTabKey(shift) {
     let spread;
     try {
         spread = designer.getWorkbook();
-    } catch (err) {
+    } catch {
         return;
     }
 

--- a/Source/Workspace/Celbridge.Console/Web/Console/console-toml.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console-toml.js
@@ -71,7 +71,7 @@ export function parseConsoleToml(text) {
 
     for (let index = 0; index < lines.length; index++) {
         // A multi-line block is read before comment stripping, so a '#' inside a script survives.
-        const blockMatch = lines[index].match(/^\s*([^=\[]+?)\s*=\s*('''|\"\"\")(.*)$/);
+        const blockMatch = lines[index].match(/^\s*([^=[]+?)\s*=\s*('''|""")(.*)$/);
         if (blockMatch && !blockMatch[3].includes(blockMatch[2])) {
             const blockKey = parseKey(blockMatch[1].trim());
             const delimiter = blockMatch[2];

--- a/Source/Workspace/Celbridge.Console/Web/Console/console.js
+++ b/Source/Workspace/Celbridge.Console/Web/Console/console.js
@@ -16,7 +16,6 @@ import {
     parseEnvironmentLines,
     parseExtensionList,
     configsEqual,
-    buildStartConfig,
 } from './console-config.js';
 
 const client = celbridge;
@@ -925,7 +924,7 @@ async function main() {
                         requestAnimationFrame(() => { settingsScroll.scrollTop = state.scrollTop; });
                     }
                 }
-            } catch (error) {
+            } catch {
                 // Ignore malformed state. Fall back to the defaults.
             }
         },

--- a/Source/eslint.config.js
+++ b/Source/eslint.config.js
@@ -1,0 +1,113 @@
+// Recommended correctness rules only. Formatting is owned by .editorconfig, so no
+// stylistic rules are configured here.
+
+import js from '@eslint/js';
+import globals from 'globals';
+
+// Third party code we vendor rather than author: xterm and TipTap bundles under
+// lib/, the Monaco distribution under min/vs/, and the project templates.
+const vendoredPaths = [
+    '**/node_modules/**',
+    '**/bin/**',
+    '**/obj/**',
+    '**/lib/**',
+    '**/min/vs/**',
+    '**/fixtures/**',
+    '**/.venv/**',
+    'Templates/**'
+];
+
+// Build scripts and Vitest configuration run under Node, everything else in a WebView.
+const nodeScripts = [
+    '**/build/vendor.js',
+    '**/vitest.config.js'
+];
+
+const testScripts = [
+    '**/tests/**/*.js'
+];
+
+export default [
+    {
+        ignores: vendoredPaths
+    },
+
+    js.configs.recommended,
+
+    {
+        rules: {
+            // The shim rethrows without attaching the caught error as a cause, which is
+            // the convention here.
+            'preserve-caught-error': 'off'
+        }
+    },
+
+    {
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            globals: globals.browser
+        }
+    },
+
+    {
+        files: nodeScripts,
+        languageOptions: {
+            globals: globals.node
+        }
+    },
+
+    {
+        // Tests exercise browser code from a Node process, so both sets apply.
+        files: testScripts,
+        languageOptions: {
+            globals: {
+                ...globals.browser,
+                ...globals.node
+            }
+        }
+    },
+
+    {
+        // Injected into the page as a classic script rather than imported as a module.
+        files: ['Core/Celbridge.WebHost/Web/celbridge-client/core/webview-tools-shim.js'],
+        languageOptions: {
+            sourceType: 'script'
+        }
+    },
+
+    {
+        // Monaco and its AMD loader both arrive from script tags on the editor page.
+        files: ['Modules/Celbridge.DocumentEditors/Editors/CodeEditor/**/*.js'],
+        languageOptions: {
+            globals: {
+                monaco: 'readonly',
+                require: 'readonly'
+            }
+        }
+    },
+
+    {
+        // SpreadJS publishes its whole API under the GC namespace from a script tag.
+        files: ['Modules/Celbridge.Spreadsheet/Package/**/*.js'],
+        languageOptions: {
+            globals: {
+                GC: 'readonly'
+            }
+        }
+    },
+
+    {
+        // xterm and its addons are loaded from script tags in the console page.
+        files: ['Workspace/Celbridge.Console/Web/Console/**/*.js'],
+        languageOptions: {
+            globals: {
+                Terminal: 'readonly',
+                FitAddon: 'readonly',
+                ClipboardAddon: 'readonly',
+                Unicode11Addon: 'readonly',
+                WebLinksAddon: 'readonly'
+            }
+        }
+    }
+];

--- a/Source/package-lock.json
+++ b/Source/package-lock.json
@@ -12,7 +12,9 @@
         "Workspace/Celbridge.Console/Web/Console"
       ],
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "eslint": "^10.0.2",
+        "globals": "^17.11.0",
         "jsdom": "^29.0.0",
         "vitest": "^4.0.0"
       }
@@ -225,6 +227,27 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1134,6 +1157,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ignore": {

--- a/Source/package.json
+++ b/Source/package.json
@@ -1,6 +1,7 @@
 {
   "name": "celbridge",
   "private": true,
+  "type": "module",
   "workspaces": [
     "Core/Celbridge.WebHost/Web/celbridge-client",
     "Modules/Celbridge.DocumentEditors/Editors/CodeEditor",
@@ -10,14 +11,16 @@
   "scripts": {
     "test": "npm run test --workspaces --if-present",
     "test:watch": "npm run test:watch --workspaces --if-present",
-    "lint": "npm run lint --workspaces --if-present",
+    "lint": "eslint .",
     "vendor:icons": "npm run vendor --prefix Core/Celbridge.UserInterface/Assets/Fonts/BootstrapIcons/build",
     "vendor:notes": "npm run vendor --prefix Modules/Celbridge.DocumentEditors/Editors/Notes/lib/build",
     "vendor:console": "npm run vendor --prefix Workspace/Celbridge.Console/Web/Console/lib/build"
   },
   "devDependencies": {
-    "vitest": "^4.0.0",
+    "@eslint/js": "^10.0.1",
     "eslint": "^10.0.2",
-    "jsdom": "^29.0.0"
+    "globals": "^17.11.0",
+    "jsdom": "^29.0.0",
+    "vitest": "^4.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "celbridge",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Introduces a root flat ESLint configuration for the Source workspace, including browser/node globals, test environment handling, and project-specific script-tag globals (Monaco, SpreadJS, xterm). The npm lint script now runs ESLint directly at the root. Existing JS files were cleaned up to satisfy the new rules (unused vars/imports removed, catch bindings dropped when unused, and minor regex/object cleanup), with lockfile updates only for the new lint dependencies.