### PR TITLE
Fix macOS modifier state for shortcuts

### DIFF
--- a/Source/Core/Celbridge.UserInterface/Helpers/EditKeyboard.cs
+++ b/Source/Core/Celbridge.UserInterface/Helpers/EditKeyboard.cs
@@ -1,4 +1,5 @@
 using Celbridge.Platform;
+using Celbridge.UserInterface.Platform;
 using Microsoft.UI.Input;
 using Windows.System;
 using Windows.UI.Core;
@@ -7,9 +8,12 @@ namespace Celbridge.UserInterface.Helpers;
 
 /// <summary>
 /// Resolves the platform-specific keyboard modifiers and keys for the standard edit shortcuts, so no
-/// surface checks them itself. The command modifier is Control on Windows and Linux, and Command (which
-/// the macOS Skia head surfaces as the left Windows key) on macOS. The delete key is Delete on every
-/// head, plus Backspace on macOS.
+/// surface checks them itself. The command modifier is Control on Windows and Linux, and Command on macOS.
+/// The delete key is Delete on every head, plus Backspace on macOS.
+///
+/// macOS answers every modifier question from AppKit rather than from the key state Uno accumulates: a
+/// modifier released while a native web view holds the keyboard never reaches Uno's managed key pipeline,
+/// so its cached state stays down and every later keystroke reads as a chord.
 /// </summary>
 public static class EditKeyboard
 {
@@ -18,29 +22,42 @@ public static class EditKeyboard
     /// </summary>
     public static bool IsCommandModifierDown()
     {
-        var control = IsKeyDown(VirtualKey.Control);
-
-        var platformInfo = ServiceLocator.AcquireService<IPlatformInfo>();
-        if (platformInfo.CommandModifier == CommandModifierKey.Command)
+        var macOSModifiers = MacOSKeyboardModifiers.GetCurrentState();
+        if (macOSModifiers is not null)
         {
-            // The macOS head surfaces only the left Command key as a key code. Control stays folded in
-            // as the fallback, so this is additive.
-            var command = IsKeyDown(VirtualKey.LeftWindows);
-            return control || command;
+            return macOSModifiers.Command;
         }
 
-        return control;
+        return IsKeyDown(VirtualKey.Control);
     }
 
     /// <summary>
     /// Whether the Shift modifier is currently down.
     /// </summary>
-    public static bool IsShiftDown() => IsKeyDown(VirtualKey.Shift);
+    public static bool IsShiftDown()
+    {
+        var macOSModifiers = MacOSKeyboardModifiers.GetCurrentState();
+        if (macOSModifiers is not null)
+        {
+            return macOSModifiers.Shift;
+        }
+
+        return IsKeyDown(VirtualKey.Shift);
+    }
 
     /// <summary>
     /// Whether the Alt modifier (Option on macOS) is currently down.
     /// </summary>
-    public static bool IsAltDown() => IsKeyDown(VirtualKey.Menu);
+    public static bool IsAltDown()
+    {
+        var macOSModifiers = MacOSKeyboardModifiers.GetCurrentState();
+        if (macOSModifiers is not null)
+        {
+            return macOSModifiers.Option;
+        }
+
+        return IsKeyDown(VirtualKey.Menu);
+    }
 
     /// <summary>
     /// Whether the key is the platform delete key (Delete, plus Backspace on macOS).

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyEventMonitor.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyEventMonitor.cs
@@ -31,12 +31,6 @@ internal static class MacOSKeyEventMonitor
     // kVK_Tab hardware key code.
     private const ulong TabKeyCode = 48;
 
-    // NSEventModifierFlag bit positions.
-    private const ulong ModifierFlagShift = 1UL << 17;
-    private const ulong ModifierFlagControl = 1UL << 18;
-    private const ulong ModifierFlagOption = 1UL << 19;
-    private const ulong ModifierFlagCommand = 1UL << 20;
-
     // objc_msgSend for +addLocalMonitorForEventsMatchingMask:handler: (an NSUInteger mask then a block).
     [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
     private static extern IntPtr SendMessageAddMonitor(IntPtr receiver, IntPtr selector, nuint mask, IntPtr block);
@@ -132,7 +126,7 @@ internal static class MacOSKeyEventMonitor
             var modifierFlags = SendMessageReturnNuint(nsEvent, GetSelector("modifierFlags"));
 
             bool isTab = keyCode == TabKeyCode;
-            bool isCommand = (modifierFlags & ModifierFlagCommand) != 0;
+            bool isCommand = (modifierFlags & MacOSKeyboardModifiers.CommandFlag) != 0;
 
             // Pass through anything that is neither Tab nor a Command chord before touching focus.
             if (!isTab
@@ -149,7 +143,7 @@ internal static class MacOSKeyEventMonitor
                 return nsEvent;
             }
 
-            var shift = (modifierFlags & ModifierFlagShift) != 0;
+            var shift = (modifierFlags & MacOSKeyboardModifiers.ShiftFlag) != 0;
 
             if (isTab)
             {
@@ -220,7 +214,7 @@ internal static class MacOSKeyEventMonitor
     // True for Command+F. Command+Shift+F is not a find shortcut, so Shift is rejected.
     private static bool IsFindShortcut(char? shortcutCharacter, ulong modifierFlags)
     {
-        if ((modifierFlags & ModifierFlagShift) != 0)
+        if ((modifierFlags & MacOSKeyboardModifiers.ShiftFlag) != 0)
         {
             return false;
         }
@@ -233,9 +227,9 @@ internal static class MacOSKeyEventMonitor
     // chord built over the same letter.
     private static bool IsPlainCommandChord(ulong modifierFlags)
     {
-        bool command = (modifierFlags & ModifierFlagCommand) != 0;
-        bool control = (modifierFlags & ModifierFlagControl) != 0;
-        bool option = (modifierFlags & ModifierFlagOption) != 0;
+        bool command = (modifierFlags & MacOSKeyboardModifiers.CommandFlag) != 0;
+        bool control = (modifierFlags & MacOSKeyboardModifiers.ControlFlag) != 0;
+        bool option = (modifierFlags & MacOSKeyboardModifiers.OptionFlag) != 0;
 
         return command
             && !control

--- a/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyboardModifiers.cs
+++ b/Source/Core/Celbridge.UserInterface/Platform/MacOSKeyboardModifiers.cs
@@ -1,0 +1,42 @@
+using static Celbridge.Utilities.Platform.ObjectiveCRuntime;
+
+namespace Celbridge.UserInterface.Platform;
+
+/// <summary>
+/// The modifier keys held at the moment the state was read.
+/// </summary>
+internal record MacOSModifierState(bool Command, bool Control, bool Shift, bool Option);
+
+/// <summary>
+/// Reads the modifier keys AppKit reports as held right now. Uno derives its own modifier state from the
+/// managed key events it raises, so a modifier whose release it never sees stays down for every later key.
+/// AppKit answers for the hardware instead. macOS-only.
+/// </summary>
+internal static class MacOSKeyboardModifiers
+{
+    // NSEventModifierFlag bit positions.
+    public const ulong ShiftFlag = 1UL << 17;
+    public const ulong ControlFlag = 1UL << 18;
+    public const ulong OptionFlag = 1UL << 19;
+    public const ulong CommandFlag = 1UL << 20;
+
+    /// <summary>
+    /// The modifier keys currently held, or null on every other platform.
+    /// </summary>
+    public static MacOSModifierState? GetCurrentState()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return null;
+        }
+
+        var modifierFlags = (ulong)SendMessageReturnNuint(GetClass("NSEvent"), GetSelector("modifierFlags"));
+
+        var command = (modifierFlags & CommandFlag) != 0;
+        var control = (modifierFlags & ControlFlag) != 0;
+        var shift = (modifierFlags & ShiftFlag) != 0;
+        var option = (modifierFlags & OptionFlag) != 0;
+
+        return new MacOSModifierState(command, control, shift, option);
+    }
+}

--- a/Source/Core/Celbridge.UserInterface/Services/KeyboardShortcutService.cs
+++ b/Source/Core/Celbridge.UserInterface/Services/KeyboardShortcutService.cs
@@ -19,6 +19,15 @@ public class KeyboardShortcutService : IKeyboardShortcutService
 
     public bool HandleShortcut(VirtualKey key, bool control, bool shift, bool alt)
     {
+        // Every shortcut here is a chord, so an unmodified key cannot match one. Characters typed into a
+        // hosted editor reach this method as managed key events.
+        if (!control
+            && !shift
+            && !alt)
+        {
+            return false;
+        }
+
         // All platforms redo shortcut: Ctrl+Shift+Z
         if (control && shift && key == VirtualKey.Z)
         {

--- a/Source/Core/Celbridge.UserInterface/Views/MainPage.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/MainPage.xaml.cs
@@ -192,8 +192,7 @@ public partial class MainPage : Page
 
     private bool OnKeyDown(VirtualKey key)
     {
-        // The command modifier folds in Cmd on macOS (which the head reports as the left Windows key),
-        // so Cmd+Z / Cmd+Shift+Z drive undo/redo there.
+        // The command modifier folds in Cmd on macOS, so Cmd+Z / Cmd+Shift+Z drive undo/redo there.
         var control = EditKeyboard.IsCommandModifierDown();
         var shift = EditKeyboard.IsShiftDown();
         var alt = EditKeyboard.IsAltDown();

--- a/Source/Tests/UserInterface/KeyboardShortcutServiceTests.cs
+++ b/Source/Tests/UserInterface/KeyboardShortcutServiceTests.cs
@@ -1,0 +1,118 @@
+using Celbridge.Messaging;
+using Celbridge.Messaging.Services;
+using Celbridge.Platform;
+using Celbridge.UserInterface;
+using Celbridge.UserInterface.Services;
+using Windows.System;
+
+namespace Celbridge.Tests.UserInterface;
+
+/// <summary>
+/// Unit tests for the global keyboard shortcut table. A real MessengerService carries the requests the
+/// service broadcasts, so each test asserts on the message a chord produces.
+/// </summary>
+[TestFixture]
+public class KeyboardShortcutServiceTests
+{
+    private IMessengerService _messengerService = null!;
+    private IPlatformInfo _platformInfo = null!;
+    private KeyboardShortcutService _shortcutService = null!;
+    private object _recipient = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _messengerService = new MessengerService();
+        _platformInfo = Substitute.For<IPlatformInfo>();
+        _shortcutService = new KeyboardShortcutService(_messengerService, _platformInfo);
+        _recipient = new object();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _messengerService.UnregisterAll(_recipient);
+    }
+
+    [Test]
+    public void CommandW_RequestsCloseActiveDocument()
+    {
+        var closeRequested = false;
+        _messengerService.Register<CloseActiveDocumentRequestedMessage>(_recipient, (r, m) => closeRequested = true);
+
+        var handled = _shortcutService.HandleShortcut(VirtualKey.W, control: true, shift: false, alt: false);
+
+        handled.Should().BeTrue();
+        closeRequested.Should().BeTrue();
+    }
+
+    [Test]
+    public void CommandShiftW_RequestsCloseAllDocuments()
+    {
+        var closeAllRequested = false;
+        _messengerService.Register<CloseAllDocumentsRequestedMessage>(_recipient, (r, m) => closeAllRequested = true);
+
+        var handled = _shortcutService.HandleShortcut(VirtualKey.W, control: true, shift: true, alt: false);
+
+        handled.Should().BeTrue();
+        closeAllRequested.Should().BeTrue();
+    }
+
+    [Test]
+    public void CommandZ_RequestsUndo()
+    {
+        var undoRequested = false;
+        _messengerService.Register<UndoRequestedMessage>(_recipient, (r, m) => undoRequested = true);
+
+        var handled = _shortcutService.HandleShortcut(VirtualKey.Z, control: true, shift: false, alt: false);
+
+        handled.Should().BeTrue();
+        undoRequested.Should().BeTrue();
+    }
+
+    [Test]
+    public void UnmodifiedKey_RequestsNothing()
+    {
+        // Every character typed into a hosted editor reaches the table as a managed key event, so an
+        // unmodified key must never match a shortcut.
+        var closeRequested = false;
+        var undoRequested = false;
+        _messengerService.Register<CloseActiveDocumentRequestedMessage>(_recipient, (r, m) => closeRequested = true);
+        _messengerService.Register<UndoRequestedMessage>(_recipient, (r, m) => undoRequested = true);
+
+        var closeHandled = _shortcutService.HandleShortcut(VirtualKey.W, control: false, shift: false, alt: false);
+        var undoHandled = _shortcutService.HandleShortcut(VirtualKey.Z, control: false, shift: false, alt: false);
+
+        closeHandled.Should().BeFalse();
+        undoHandled.Should().BeFalse();
+        closeRequested.Should().BeFalse();
+        undoRequested.Should().BeFalse();
+    }
+
+    [Test]
+    public void ControlY_RequestsRedoOnlyWhereTheHeadTreatsItAsRedo()
+    {
+        _platformInfo.TreatsCtrlYAsRedo.Returns(false);
+
+        var redoRequested = false;
+        _messengerService.Register<RedoRequestedMessage>(_recipient, (r, m) => redoRequested = true);
+
+        var handled = _shortcutService.HandleShortcut(VirtualKey.Y, control: true, shift: false, alt: false);
+
+        handled.Should().BeFalse();
+        redoRequested.Should().BeFalse();
+    }
+
+    [Test]
+    public void KeyName_ResolvesToTheSameShortcut()
+    {
+        // The WebView RPC entry point reports the key by name.
+        var closeRequested = false;
+        _messengerService.Register<CloseActiveDocumentRequestedMessage>(_recipient, (r, m) => closeRequested = true);
+
+        var handled = _shortcutService.HandleShortcut("w", control: true, shift: false, alt: false);
+
+        handled.Should().BeTrue();
+        closeRequested.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Fixes #891

Read macOS modifier keys directly from AppKit via a new `MacOSKeyboardModifiers` helper so stale Uno key-state does not cause phantom shortcut chords after native WebView interactions. `EditKeyboard` now uses this state for command/shift/option detection, and `MacOSKeyEventMonitor` reuses the shared modifier flag constants.

The shortcut service now rejects unmodified keys up front to avoid matching plain typed characters, and new `KeyboardShortcutServiceTests` cover core shortcut routing, platform-specific Ctrl+Y redo behavior, unmodified-key no-op behavior, and key-name handling.