### PR TITLE
Add npm audit to CI and refresh lockfile for security checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
         working-directory: ./Source
         run: npm install
 
+      # Checks the lockfile against the npm advisory database, so this can start failing
+      # without a code change when a new advisory is published against a pinned version.
+      - name: Audit dependencies
+        working-directory: ./Source
+        run: npm audit --audit-level=moderate
+
       - name: Run JS tests
         working-directory: ./Source
         run: npm test

--- a/Source/package-lock.json
+++ b/Source/package-lock.json
@@ -776,16 +776,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/celbridge-client": {
@@ -1883,9 +1883,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2002,9 +2002,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2022,7 +2022,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2196,9 +2196,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
This pull request improves the project's dependency management and security by adding an automated audit step to the CI workflow and updating several npm package dependencies to their latest versions. These changes help ensure that the codebase remains secure and up-to-date with the latest patches.

Dependency management and security improvements:

* Added an "Audit dependencies" step to the CI workflow (`.github/workflows/ci.yml`) to automatically check for vulnerabilities in dependencies using `npm audit --audit-level=moderate`.

Dependency updates:

* Upgraded `brace-expansion` from version 5.0.7 to 5.0.9, and updated its required Node.js engine versions.
* Upgraded `nanoid` from version 3.3.15 to 3.3.18, and updated the dependency version in `postcss`. [[1]](diffhunk://#diff-b2459d0c9bf8f6ff6a1971718625deed8b893821fa6dd355c49d7cd14d0afa42L1886-R1888) [[2]](diffhunk://#diff-b2459d0c9bf8f6ff6a1971718625deed8b893821fa6dd355c49d7cd14d0afa42L2025-R2025)
* Upgraded `postcss` from version 8.5.16 to 8.5.26.
* Upgraded `undici` from version 7.28.0 to 7.29.0.Update the JavaScript CI job to run `npm audit --audit-level=moderate` after install, with a note that failures can appear when new advisories are published. Regenerate the lockfile to pull in newer transitive package versions that align with the audit/security check.