### PR TITLE
Improve macOS tab strip wheel axis handling and gesture tracking

### DIFF
--- a/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
+++ b/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
@@ -101,8 +101,9 @@ public interface IPlatformInfo
     bool RequiresMacOSTabScrollIntoView { get; }
 
     /// <summary>
-    /// Whether the mouse wheel must be translated into horizontal tab-strip scrolling manually because the
-    /// platform does not scroll the overflowing strip in response to the wheel. True on macOS.
+    /// Whether wheel input must be translated into horizontal tab-strip scrolling manually because the
+    /// platform does not scroll the overflowing strip for a vertical wheel and scrolls it backwards for a
+    /// horizontal one. True on macOS.
     /// </summary>
     bool RequiresMacOSTabWheelScroll { get; }
 

--- a/Source/Tests/Documents/WheelGestureAxisTrackerTests.cs
+++ b/Source/Tests/Documents/WheelGestureAxisTrackerTests.cs
@@ -1,0 +1,87 @@
+using Celbridge.Documents.Helpers;
+
+namespace Celbridge.Tests.Documents;
+
+/// <summary>
+/// Covers WheelGestureAxisTracker: which of a gesture's events count as travelling along the axis it
+/// scrolls on, and how a pause in the events starts a fresh gesture that can take the other axis.
+/// </summary>
+[TestFixture]
+public class WheelGestureAxisTrackerTests
+{
+    private const ulong GestureStart = 1_000_000;
+    private const ulong EventInterval = 10_000;
+    private const ulong LongerThanGestureGap = 300_000;
+
+    private WheelGestureAxisTracker _tracker = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _tracker = new WheelGestureAxisTracker();
+    }
+
+    [Test]
+    public void MouseWheelNotches_AllTravelAlongTheGestureAxis()
+    {
+        ulong timestamp = GestureStart;
+
+        for (int notch = 0; notch < 5; notch++)
+        {
+            bool isOnGestureAxis = _tracker.IsOnGestureAxis(timestamp, isHorizontalWheel: false, wheelDelta: -30);
+
+            isOnGestureAxis.Should().BeTrue();
+            timestamp += EventInterval;
+        }
+    }
+
+    [Test]
+    public void HorizontalSwipe_RejectsTheVerticalDriftBetweenItsEvents()
+    {
+        ulong timestamp = GestureStart;
+
+        // The first event of the swipe establishes the horizontal axis.
+        _tracker.IsOnGestureAxis(timestamp, isHorizontalWheel: true, wheelDelta: -1).Should().BeTrue();
+
+        // A slow swipe travels a pixel at a time, so its drift is the same size as the swipe itself.
+        for (int index = 0; index < 4; index++)
+        {
+            timestamp += EventInterval;
+            _tracker.IsOnGestureAxis(timestamp, isHorizontalWheel: false, wheelDelta: 1).Should().BeFalse();
+
+            timestamp += EventInterval;
+            _tracker.IsOnGestureAxis(timestamp, isHorizontalWheel: true, wheelDelta: -1).Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void VerticalSwipe_RejectsTheHorizontalDriftBetweenItsEvents()
+    {
+        ulong timestamp = GestureStart;
+
+        _tracker.IsOnGestureAxis(timestamp, isHorizontalWheel: false, wheelDelta: -8).Should().BeTrue();
+
+        timestamp += EventInterval;
+        _tracker.IsOnGestureAxis(timestamp, isHorizontalWheel: true, wheelDelta: 1).Should().BeFalse();
+
+        timestamp += EventInterval;
+        _tracker.IsOnGestureAxis(timestamp, isHorizontalWheel: false, wheelDelta: -6).Should().BeTrue();
+    }
+
+    [Test]
+    public void PauseAfterASwipe_LetsTheNextGestureTakeTheOtherAxis()
+    {
+        ulong timestamp = GestureStart;
+
+        for (int index = 0; index < 5; index++)
+        {
+            _tracker.IsOnGestureAxis(timestamp, isHorizontalWheel: true, wheelDelta: -20).Should().BeTrue();
+            timestamp += EventInterval;
+        }
+
+        // Without the pause resetting the gesture, the horizontal travel already recorded would outweigh
+        // this event and reject it.
+        timestamp += LongerThanGestureGap;
+        _tracker.IsOnGestureAxis(timestamp, isHorizontalWheel: false, wheelDelta: -10).Should().BeTrue();
+    }
+}

--- a/Source/Workspace/Celbridge.Documents/Helpers/WheelGestureAxisTracker.cs
+++ b/Source/Workspace/Celbridge.Documents/Helpers/WheelGestureAxisTracker.cs
@@ -1,0 +1,45 @@
+namespace Celbridge.Documents.Helpers;
+
+/// <summary>
+/// Follows a wheel gesture across the events it arrives as, and reports which of them travel along the axis
+/// that gesture is scrolling on. macOS puts each trackpad event on one axis only, dropping the travel along
+/// the other, so a swipe arrives interleaved with events carrying nothing but the finger's drift.
+/// </summary>
+public class WheelGestureAxisTracker
+{
+    // A gap this long in the events ends the gesture they belong to, in the microseconds pointer timestamps
+    // are counted in.
+    private const ulong GestureGapMicroseconds = 200_000;
+
+    private ulong _lastTimestamp;
+    private double _horizontalDistance;
+    private double _verticalDistance;
+
+    /// <summary>
+    /// Records a wheel event and reports whether it travels along the gesture's axis. The axis that has
+    /// travelled furthest since the gesture began is the one it is scrolling on, so the drift events are
+    /// rejected however many of them arrive. A tie goes to the horizontal axis.
+    /// </summary>
+    public bool IsOnGestureAxis(ulong timestamp, bool isHorizontalWheel, int wheelDelta)
+    {
+        if (timestamp - _lastTimestamp > GestureGapMicroseconds)
+        {
+            _horizontalDistance = 0;
+            _verticalDistance = 0;
+        }
+
+        _lastTimestamp = timestamp;
+
+        double distance = Math.Abs(wheelDelta);
+        if (isHorizontalWheel)
+        {
+            _horizontalDistance += distance;
+
+            return _horizontalDistance >= _verticalDistance;
+        }
+
+        _verticalDistance += distance;
+
+        return _verticalDistance > _horizontalDistance;
+    }
+}

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
@@ -32,6 +32,8 @@ public sealed partial class DocumentSectionView : UserControl
     private bool _isShuttingDown = false;
     private bool _scrollButtonsHidden;
     private bool _scrollIndicatorAttached;
+    private bool _tabStripWheelHandlerAttached;
+    private readonly WheelGestureAxisTracker _wheelGestureAxisTracker;
     private Storyboard? _perimeterStoryboard;
 
     // The tab list template's two overflow arrows, named by their containers because that is what carries
@@ -102,6 +104,7 @@ public sealed partial class DocumentSectionView : UserControl
         _webViewFocusRegistry = ServiceLocator.AcquireService<IWebViewFocusRegistry>();
         _tabPointerPressedHandler = OnTabPointerPressed;
         _tabStripWheelHandler = OnTabStripPointerWheelChanged;
+        _wheelGestureAxisTracker = new WheelGestureAxisTracker();
         _documentPointerPressedHandler = OnDocumentPointerPressed;
         DisableBuiltInTabDrag();
 
@@ -116,14 +119,6 @@ public sealed partial class DocumentSectionView : UserControl
         // leaves the active tab clipped off-screen on macOS, where the strip does not re-reveal the selection
         // on its own, so a window resize or a change in the number of sections has to re-scroll it into view.
         TabView.SizeChanged += OnTabViewSizeChanged;
-
-        // On macOS the overflowing strip does not scroll in response to the mouse wheel, so translate the
-        // wheel into horizontal scrolling ourselves. Subscribe for handled events too because the strip's
-        // internal ScrollViewer can mark the wheel handled without scrolling.
-        if (_platformInfo.RequiresMacOSTabWheelScroll)
-        {
-            TabView.AddHandler(PointerWheelChangedEvent, _tabStripWheelHandler, handledEventsToo: true);
-        }
     }
 
     // The web surfaces report a click anywhere over them, while managed focus only moves for a press that
@@ -224,14 +219,14 @@ public sealed partial class DocumentSectionView : UserControl
         UpdateTabStripBorderLines();
         FixTabStripBandHeight();
         HideTabStripScrollButtons();
-        AttachTabStripScrollIndicator();
+        AttachTabStripScrollHandlers();
 
         _ = DispatcherQueue.TryEnqueue(() =>
         {
             UpdateTabStripBorderLines();
             FixTabStripBandHeight();
             HideTabStripScrollButtons();
-            AttachTabStripScrollIndicator();
+            AttachTabStripScrollHandlers();
         });
     }
 
@@ -762,7 +757,7 @@ public sealed partial class DocumentSectionView : UserControl
         // enough that a section's first tabs can arrive before it exists.
         _ = DispatcherQueue.TryEnqueue(() =>
         {
-            AttachTabStripScrollIndicator();
+            AttachTabStripScrollHandlers();
             UpdateTabStripScrollIndicator();
         });
     }
@@ -829,17 +824,23 @@ public sealed partial class DocumentSectionView : UserControl
         _scrollButtonsHidden = true;
     }
 
-    // Wires the scroll indicator to the strip's own ScrollViewer, which only exists once the tab list's
-    // template has been applied.
-    private void AttachTabStripScrollIndicator()
+    // Wires the parts that need the strip's own ScrollViewer, which only exists once the tab list's template
+    // has been applied.
+    private void AttachTabStripScrollHandlers()
     {
-        if (_scrollIndicatorAttached)
+        var scrollViewer = GetTabStripScrollViewer();
+        if (scrollViewer is null)
         {
             return;
         }
 
-        var scrollViewer = GetTabStripScrollViewer();
-        if (scrollViewer is null)
+        AttachTabStripScrollIndicator(scrollViewer);
+        AttachTabStripWheelHandler(scrollViewer);
+    }
+
+    private void AttachTabStripScrollIndicator(ScrollViewer scrollViewer)
+    {
+        if (_scrollIndicatorAttached)
         {
             return;
         }
@@ -849,6 +850,31 @@ public sealed partial class DocumentSectionView : UserControl
         _scrollIndicatorAttached = true;
 
         UpdateTabStripScrollIndicator();
+    }
+
+    // UNO-BUG: the tab strip's ScrollViewer scrolls horizontal wheel input the wrong way on macOS.
+    /// <summary>
+    /// Takes over wheel scrolling of the tab strip on macOS. Registered inside the strip's ScrollViewer, on
+    /// the presenter the wheel passes through first, so the event is handled before the ScrollViewer's own
+    /// wheel handling sees it.
+    /// </summary>
+    private void AttachTabStripWheelHandler(ScrollViewer scrollViewer)
+    {
+        if (!_platformInfo.RequiresMacOSTabWheelScroll ||
+            _tabStripWheelHandlerAttached)
+        {
+            return;
+        }
+
+        // The presenter fills the strip's viewport, so every wheel event over the strip bubbles through it.
+        var scrollPresenter = VisualTree.FindDescendant<ScrollContentPresenter>(scrollViewer);
+        if (scrollPresenter is null)
+        {
+            return;
+        }
+
+        scrollPresenter.AddHandler(PointerWheelChangedEvent, _tabStripWheelHandler, handledEventsToo: true);
+        _tabStripWheelHandlerAttached = true;
     }
 
     private void OnTabStripViewChanged(object? sender, ScrollViewerViewChangedEventArgs e)
@@ -973,9 +999,10 @@ public sealed partial class DocumentSectionView : UserControl
     }
 
     /// <summary>
-    /// Scrolls the overflowing tab strip horizontally in response to the mouse wheel. macOS only: the Uno
-    /// TabView does not translate vertical wheel input into horizontal strip scrolling the way the packaged
-    /// Windows TabView does, so the strip's scroll offset is driven directly.
+    /// Scrolls the overflowing tab strip horizontally in response to the wheel, covering both the vertical
+    /// wheel of a mouse and the horizontal scrolling of a trackpad. macOS only: the Uno TabView does not
+    /// translate vertical wheel input into horizontal strip scrolling the way the packaged Windows TabView
+    /// does, and it scrolls horizontal input backwards, so the strip's scroll offset is driven directly.
     /// </summary>
     private void OnTabStripPointerWheelChanged(object sender, PointerRoutedEventArgs e)
     {
@@ -991,27 +1018,28 @@ public sealed partial class DocumentSectionView : UserControl
             return;
         }
 
-        // Only the tab strip should react. A wheel over the document content below it falls outside the
-        // strip's ScrollViewer, so leave it unhandled to scroll that content.
         var pointerPoint = e.GetCurrentPoint(scrollViewer);
-        var position = pointerPoint.Position;
-        bool isOverTabStrip = position.X >= 0 &&
-            position.X <= scrollViewer.ViewportWidth &&
-            position.Y >= 0 &&
-            position.Y <= scrollViewer.ActualHeight;
-        if (!isOverTabStrip)
-        {
-            return;
-        }
-
         int wheelDelta = pointerPoint.Properties.MouseWheelDelta;
         if (wheelDelta == 0)
         {
             return;
         }
 
-        // A forward wheel notch (positive delta) reveals earlier tabs, matching the packaged Windows TabView.
-        ScrollTabStripBy(-wheelDelta);
+        bool isHorizontalWheel = pointerPoint.Properties.IsHorizontalMouseWheel;
+        bool isOnGestureAxis = _wheelGestureAxisTracker.IsOnGestureAxis(
+            pointerPoint.Timestamp,
+            isHorizontalWheel,
+            wheelDelta);
+        if (isOnGestureAxis)
+        {
+            // A forward wheel notch (positive delta) reveals earlier tabs, matching the packaged Windows
+            // TabView. macOS reports a trackpad swipe towards the earlier tabs with that same sign, so one
+            // rule serves the horizontal wheel as well as the vertical one.
+            ScrollTabStripBy(-wheelDelta);
+        }
+
+        // Handled even for an event left off the gesture's axis, so that it stops short of the ScrollViewer,
+        // which would otherwise scroll horizontal input the other way and undo this.
         e.Handled = true;
     }
 


### PR DESCRIPTION
This pull request improves the handling of wheel gestures for horizontal tab-strip scrolling on macOS, addressing platform-specific quirks and making the code more robust and testable. The main changes include implementing a new `WheelGestureAxisTracker` utility to distinguish between intentional scrolling and incidental drift, refactoring how and where the custom wheel handler is attached, and updating tests and documentation accordingly.

**Wheel gesture handling improvements:**

* Introduced the `WheelGestureAxisTracker` class in `Celbridge.Documents.Helpers`, which tracks wheel gesture axes to distinguish between scrolling and drift, ensuring only intended axis movements scroll the tab strip.
* Updated the tab strip wheel handler (`OnTabStripPointerWheelChanged`) to use `WheelGestureAxisTracker`, so only gestures along the dominant axis scroll the strip, and all wheel events are marked handled to prevent incorrect native scrolling. [[1]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L994-R1042) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L976-R1005)

**Platform-specific fixes and refactoring:**

* Changed the logic for attaching the wheel handler: now, `AttachTabStripScrollHandlers` ensures the handler is registered on the correct element (`ScrollContentPresenter`) only on macOS, and only once, fixing previous issues with event handling and code duplication. [[1]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L832-R843) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R855-R879) [[3]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L227-R229) [[4]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L765-R760)
* Updated the summary and naming in the `IPlatformInfo` interface to clarify that both vertical and horizontal wheel input need custom handling on macOS, reflecting the new logic.

**Testing:**

* Added a comprehensive test suite for `WheelGestureAxisTracker` in `WheelGestureAxisTrackerTests.cs`, covering gesture axis detection, rejection of drift, and behavior after gesture pauses.Adds a `WheelGestureAxisTracker` to classify wheel events by active gesture axis, so trackpad drift events are ignored while true horizontal/vertical gesture movement is applied. Updates `DocumentSectionView` to attach wheel handling at the tab strip presenter level on macOS, preventing Uno’s reversed horizontal scroll behavior, and includes focused tests for gesture continuity, drift rejection, and pause-based axis reset.