### PR TITLE
Fix asset exclusions in Release builds

### DIFF
--- a/Source/Celbridge/Package.appxmanifest
+++ b/Source/Celbridge/Package.appxmanifest
@@ -5,7 +5,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity  Name="org.celbridge.Celbridge" Version="0.3.0.0" Publisher="CN=AnTulcha"/>
+  <Identity  Name="org.celbridge.Celbridge" Version="1.0.0.0" Publisher="CN=AnTulcha"/>
   <Properties >
     <DisplayName>Celbridge</DisplayName>
     <PublisherDisplayName>celbridge.org</PublisherDisplayName>

--- a/Source/Core/Celbridge.Projects/Celbridge.Projects.csproj
+++ b/Source/Core/Celbridge.Projects/Celbridge.Projects.csproj
@@ -13,7 +13,7 @@
          so they do not exist when the SDK evaluates the default Assets glob on a clean checkout. Exclude
          them from that glob and re-include them in IncludeGeneratedTemplateZips once they have been
          produced, so they reliably reach consumers' output. -->
-    <DefaultItemExcludes>$(DefaultItemExcludes);Assets\Templates\*.zip</DefaultItemExcludes>
+    <CelbridgeDefaultItemExcludes>$(CelbridgeDefaultItemExcludes);Assets\Templates\*.zip</CelbridgeDefaultItemExcludes>
 
     <UnoFeatures>
       CSharpMarkup;

--- a/Source/Core/Celbridge.UserInterface/Celbridge.UserInterface.csproj
+++ b/Source/Core/Celbridge.UserInterface/Celbridge.UserInterface.csproj
@@ -38,7 +38,7 @@
     <!-- ColorTokens.xaml is generated during the build, so it does not exist when the SDK evaluates its
          default XAML glob on a clean checkout. Exclude it from that glob and declare it explicitly below,
          which holds the item from evaluation onwards whether or not the file is there yet. -->
-    <DefaultItemExcludes>$(DefaultItemExcludes);Resources\ColorTokens.xaml</DefaultItemExcludes>
+    <CelbridgeDefaultItemExcludes>$(CelbridgeDefaultItemExcludes);Resources\ColorTokens.xaml</CelbridgeDefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefaultItemExcludes>$(DefaultItemExcludes);Assets\Fonts\**\*.json;Assets\Fonts\**\build\**</DefaultItemExcludes>
+    <CelbridgeDefaultItemExcludes>$(CelbridgeDefaultItemExcludes);Assets\Fonts\**\*.json;Assets\Fonts\**\build\**</CelbridgeDefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Directory.Build.targets
+++ b/Source/Directory.Build.targets
@@ -27,6 +27,17 @@
   </PropertyGroup>
 
   <!--
+    Uno.DefaultItems.targets assigns to DefaultItemExcludes rather than appending to it when Optimize is
+    true, so every exclusion a project declares is discarded in Release configurations. Projects that keep
+    a generated file out of the SDK's default globs add it to CelbridgeDefaultItemExcludes instead, which
+    is applied here, after the Uno SDK targets have been imported. Property evaluation finishes before any
+    item is evaluated, so the globs still see these exclusions even though they are declared this late.
+  -->
+  <PropertyGroup Condition="'$(CelbridgeDefaultItemExcludes)' != ''">
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(CelbridgeDefaultItemExcludes)</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <!--
     Distribute the Celbridge.FileSystem.Analyzers gateway analyzer (CEL_FS_001)
     to every product project. OutputItemType="Analyzer" with
     ReferenceOutputAssembly="false" adds it as an analyzer only, not a compile

--- a/Source/Workspace/Celbridge.Python/Celbridge.Python.csproj
+++ b/Source/Workspace/Celbridge.Python/Celbridge.Python.csproj
@@ -27,7 +27,7 @@
     <!-- The wheel is generated during the build and re-included by IncludeGeneratedPythonWheel.
          Excluding it from the default Assets glob avoids a duplicate MSIX payload (APPX1101) on the
          packaged Windows head. -->
-    <DefaultItemExcludes>$(DefaultItemExcludes);Assets\Python\*.whl</DefaultItemExcludes>
+    <CelbridgeDefaultItemExcludes>$(CelbridgeDefaultItemExcludes);Assets\Python\*.whl</CelbridgeDefaultItemExcludes>
 
   </PropertyGroup>
 


### PR DESCRIPTION
This pull request updates how file exclusions are handled in project files to address issues with the Uno SDK's handling of the `DefaultItemExcludes` property, especially in Release builds. Instead of appending directly to `DefaultItemExcludes`, projects now use a new property, `CelbridgeDefaultItemExcludes`, which is applied centrally after Uno SDK targets are imported. Additionally, the app manifest version is updated to 1.0.0.0.

**Build and Packaging Improvements:**

* Introduced a new property, `CelbridgeDefaultItemExcludes`, in all affected `.csproj` files (such as `Celbridge.Projects.csproj`, `Celbridge.UserInterface.csproj`, and `Celbridge.Python.csproj`) to replace direct modifications of `DefaultItemExcludes`. This prevents exclusion rules from being discarded in Release configurations due to Uno SDK behavior. [[1]](diffhunk://#diff-290e27932da08e64139cb22a3fe89ef4027e80c4c301b2d42fd4b06e657aad67L16-R16) [[2]](diffhunk://#diff-dae56a37eb82418d58703ec4b76036fe76651da44f49cb8866b3fc9bbe1fca3fL41-R41) [[3]](diffhunk://#diff-dae56a37eb82418d58703ec4b76036fe76651da44f49cb8866b3fc9bbe1fca3fL53-R53) [[4]](diffhunk://#diff-68fd6444d9acfba102f213b612a19d887fd6b04185e822bf2912e404ca3b675fL30-R30)
* Updated `Directory.Build.targets` to append the contents of `CelbridgeDefaultItemExcludes` to `DefaultItemExcludes` after Uno SDK targets are imported, ensuring all exclusions are respected in both Debug and Release builds.

**Versioning:**

* Bumped the application version in `Package.appxmanifest` from `0.3.0.0` to `1.0.0.0` to reflect a new release milestone.