### PR TITLE
Enhance tab strip behavior for selected tab visibility

### DIFF
--- a/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
+++ b/Source/Core/Celbridge.Foundation/Platform/IPlatformInfo.cs
@@ -95,12 +95,6 @@ public interface IPlatformInfo
     bool RequiresMacOSLayoutRetry { get; }
 
     /// <summary>
-    /// Whether the tab strip must be scrolled manually to reveal the selected tab because the platform does
-    /// not bring it into view automatically. True on macOS.
-    /// </summary>
-    bool RequiresMacOSTabScrollIntoView { get; }
-
-    /// <summary>
     /// Whether wheel input must be translated into horizontal tab-strip scrolling manually because the
     /// platform does not scroll the overflowing strip for a vertical wheel and scrolls it backwards for a
     /// horizontal one. True on macOS.

--- a/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
+++ b/Source/Core/Celbridge.Utilities/Platform/PlatformInfo.cs
@@ -66,8 +66,6 @@ public sealed class PlatformInfo : IPlatformInfo
 
     public bool RequiresMacOSLayoutRetry => OperatingSystem.IsMacOS();
 
-    public bool RequiresMacOSTabScrollIntoView => OperatingSystem.IsMacOS();
-
     public bool RequiresMacOSTabWheelScroll => OperatingSystem.IsMacOS();
 
     public bool RequiresMacOSKeyCommandRouting => OperatingSystem.IsMacOS();

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
@@ -116,8 +116,8 @@ public sealed partial class DocumentSectionView : UserControl
         TabView.Loaded += OnTabViewLoaded;
 
         // A narrower strip moves the scroll indicator and can change whether it is needed at all. It also
-        // leaves the active tab clipped off-screen on macOS, where the strip does not re-reveal the selection
-        // on its own, so a window resize or a change in the number of sections has to re-scroll it into view.
+        // leaves the selected tab clipped off-screen, so a window resize or a change in the number of
+        // sections has to re-scroll it into view.
         TabView.SizeChanged += OnTabViewSizeChanged;
     }
 
@@ -237,11 +237,7 @@ public sealed partial class DocumentSectionView : UserControl
             return;
         }
 
-        if (TabView.SelectedItem is DocumentTab selectedTab)
-        {
-            // No-ops on the heads whose strip reveals the selection itself.
-            ScrollTabIntoView(selectedTab);
-        }
+        RevealSelectedTab();
 
         // The strip is still mid-arrange while its size change is raised, so its leading edge only settles on
         // the following cycle.
@@ -543,18 +539,24 @@ public sealed partial class DocumentSectionView : UserControl
     }
 
     /// <summary>
-    /// Scrolls the tab strip so the given tab is visible when it lies outside the visible area. macOS only:
-    /// the Uno TabView does not bring the selected tab into view on its own, so the strip's scroll offset is
-    /// driven directly once its layout has settled.
+    /// Restores the invariant that the selected tab is visible. Called after anything that changes the
+    /// strip's geometry, and a no-op while the selected tab is already fully in view.
+    /// </summary>
+    private void RevealSelectedTab()
+    {
+        if (TabView.SelectedItem is DocumentTab selectedTab)
+        {
+            ScrollTabIntoView(selectedTab);
+        }
+    }
+
+    /// <summary>
+    /// Scrolls the tab strip so the given tab is visible when it lies outside the visible area. The strip's
+    /// scroll offset is driven directly, because neither head reveals a tab that is selected in the same pass
+    /// that adds it, and the strip's own overflow arrows are hidden.
     /// </summary>
     private void ScrollTabIntoView(DocumentTab tab)
     {
-        if (!_platformInfo.RequiresMacOSTabScrollIntoView)
-        {
-            // The packaged Windows TabView brings the selected tab into view on its own.
-            return;
-        }
-
         // Defer to the next dispatcher cycle so the tab strip has completed layout. A tab that was just
         // added, or a selection that changes the strip's extent, has no scroll geometry to act on until
         // the layout pass runs, so measuring synchronously here would read stale bounds.
@@ -752,6 +754,10 @@ public sealed partial class DocumentSectionView : UserControl
         // tabs at the leading edge while showing a blank gap at the trailing edge. Re-clamp once
         // layout has settled.
         _ = DispatcherQueue.TryEnqueue(ClampTabStripScrollOffset);
+
+        // Adding or removing a tab changes the width the strip lays its tabs out in, which can leave the
+        // selected tab clipped. Enqueued after the clamp so the clamp cannot undo the reveal.
+        _ = DispatcherQueue.TryEnqueue(RevealSelectedTab);
 
         // Opening or closing a tab changes how much there is to scroll, and the indicator is attached late
         // enough that a section's first tabs can arrive before it exists.

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
@@ -574,12 +574,23 @@ public sealed partial class DocumentSectionView : UserControl
                 return;
             }
 
+            // Measure before disturbing the strip. A tab the user clicked is arranged already and is
+            // usually in view, and the realization pass below moves the offset whether or not there was
+            // anything to reveal, which lands the strip back near its first tab.
+            var container = tabListView.ContainerFromItem(tab) as FrameworkElement;
+            if (container is not null &&
+                container.ActualWidth > 0 &&
+                GetRevealOffset(container, scrollViewer) is null)
+            {
+                return;
+            }
+
             // Realize the container for an off-screen (virtualized) tab and force the strip to lay out, so
             // the measurements below reflect the settled geometry rather than a transient resize state.
             tabListView.ScrollIntoView(tab, ScrollIntoViewAlignment.Default);
             tabListView.UpdateLayout();
 
-            var container = tabListView.ContainerFromItem(tab) as FrameworkElement;
+            container = tabListView.ContainerFromItem(tab) as FrameworkElement;
             if (container is null ||
                 container.ActualWidth == 0)
             {
@@ -589,32 +600,40 @@ public sealed partial class DocumentSectionView : UserControl
                 return;
             }
 
-            // Position of the tab relative to the visible viewport. A negative value means the tab is clipped
-            // off the leading edge; a right edge past the viewport width means it is clipped off the trailing
-            // edge. The minimum scroll that clears the offending edge keeps the rest of the strip stable.
-            double tabViewportX = TabViewportLeft(container, scrollViewer);
-            double tabWidth = container.ActualWidth;
-            double viewportWidth = scrollViewer.ViewportWidth;
-            double currentOffset = scrollViewer.HorizontalOffset;
-
-            double? targetOffset = null;
-            if (tabViewportX < 0)
-            {
-                targetOffset = currentOffset + tabViewportX;
-            }
-            else if (tabViewportX + tabWidth > viewportWidth)
-            {
-                targetOffset = currentOffset + (tabViewportX + tabWidth - viewportWidth);
-            }
-
-            if (targetOffset is null)
+            if (GetRevealOffset(container, scrollViewer) is not double targetOffset)
             {
                 return;
             }
 
-            double clampedOffset = Math.Clamp(targetOffset.Value, 0, scrollViewer.ScrollableWidth);
+            double clampedOffset = Math.Clamp(targetOffset, 0, scrollViewer.ScrollableWidth);
             scrollViewer.ChangeView(clampedOffset, null, null, disableAnimation: true);
         });
+    }
+
+    /// <summary>
+    /// The scroll offset that brings a tab container fully into the strip's viewport, or null when the tab is
+    /// already fully visible. A tab whose left edge sits before the viewport is clipped off the leading edge,
+    /// and one whose right edge sits past the viewport width is clipped off the trailing edge. Revealing by
+    /// the minimum that clears the offending edge keeps the rest of the strip where the user left it.
+    /// </summary>
+    private static double? GetRevealOffset(FrameworkElement container, ScrollViewer scrollViewer)
+    {
+        double tabViewportX = TabViewportLeft(container, scrollViewer);
+        double tabWidth = container.ActualWidth;
+        double viewportWidth = scrollViewer.ViewportWidth;
+        double currentOffset = scrollViewer.HorizontalOffset;
+
+        if (tabViewportX < 0)
+        {
+            return currentOffset + tabViewportX;
+        }
+
+        if (tabViewportX + tabWidth > viewportWidth)
+        {
+            return currentOffset + (tabViewportX + tabWidth - viewportWidth);
+        }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request refactors the logic for ensuring the selected tab in the tab strip is visible, making the behavior platform-agnostic and improving reliability. The main change is the removal of the macOS-specific `RequiresMacOSTabScrollIntoView` property, with the reveal logic now always applied regardless of platform. The code has also been restructured for clarity and efficiency, with a new helper method to calculate the necessary scroll offset.

**Tab strip visibility and scroll behavior:**

* Removed the `RequiresMacOSTabScrollIntoView` property from the `IPlatformInfo` interface and its implementation, making the logic for revealing the selected tab platform-agnostic. [[1]](diffhunk://#diff-b257f60457d58b6ae4298898a1a2d694c9bf680f8559f312927c0d4eaa15fc9eL97-L102) [[2]](diffhunk://#diff-2f19b32886f05d35ec891cc468f7e8aed6872c8db3de61eb9e52880397581945L69-L70)
* Refactored the tab reveal logic: replaced calls to `ScrollTabIntoView` with a new `RevealSelectedTab` method, which checks if the selected tab needs to be revealed and calls `ScrollTabIntoView` only if necessary. [[1]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L240-R240) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L546-R559)
* Improved the `ScrollTabIntoView` method to avoid unnecessary scrolling by measuring if the selected tab is already fully visible before changing the scroll offset, using the new `GetRevealOffset` helper. [[1]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R577-R593) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L590-R636)
* Added the `GetRevealOffset` helper method to compute the minimal scroll offset required to bring a tab fully into view, returning `null` if no scrolling is needed.

**UI event handling and comments:**

* Updated event handlers and comments to reflect the new, platform-agnostic behavior and clarified the logic for when the tab strip should be re-scrolled (e.g., after tab addition/removal or window resize). [[1]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L119-R120) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R777-R780)