### PR TITLE
Enhance WebView DevTools integration and target naming

### DIFF
--- a/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
@@ -275,6 +275,57 @@ public static class MacOSWebViewInterop
         SendMessage(webView, closeSelector);
     }
 
+    /// <summary>
+    /// Opts the web view into remote inspection, which is what makes the hosted page reachable from Safari's
+    /// Develop menu. Returns whether the view reports the requested state afterwards. The managed
+    /// AreDevToolsEnabled is stored and never reaches WebKit on the Skia head, so this is the only way to
+    /// enable inspection on macOS.
+    /// </summary>
+    public static bool SetInspectable(IntPtr webView, bool inspectable)
+    {
+        if (webView == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        // Public API since macOS 13.3, so the probe only guards against a system older than that.
+        var inspectableSelector = GetSelector("setInspectable:");
+        if (SendMessage(webView, GetSelector("respondsToSelector:"), inspectableSelector) == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        SendMessageVoidBool(webView, inspectableSelector, inspectable);
+
+        // Read back rather than trust the send, so a property that stores the value and acts on nothing is
+        // reported as a failure.
+        return SendMessageReturnBool(webView, GetSelector("isInspectable")) == inspectable;
+    }
+
+    /// <summary>
+    /// Names the web view in the remote inspector's target list, replacing the URL-derived label a debugger
+    /// would otherwise show. Returns whether the name reads back.
+    /// </summary>
+    public static bool SetRemoteInspectionName(IntPtr webView, string name)
+    {
+        if (webView == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        var nameSelector = GetSelector("_setRemoteInspectionNameOverride:");
+        if (SendMessage(webView, GetSelector("respondsToSelector:"), nameSelector) == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        SendMessageVoid(webView, nameSelector, CreateNSString(name));
+
+        var appliedName = SendMessage(webView, GetSelector("_remoteInspectionNameOverride"));
+
+        return ReadNSString(appliedName) == name;
+    }
+
     private delegate void SetMaintainsInactiveSelection(IntPtr page, byte maintains);
 
     // Resolved once: this runs on every focus grant, and neither the symbol nor the selector changes.

--- a/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
@@ -20,6 +20,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
 
     private bool _checkedBackgroundActivity;
     private bool _checkedInactiveSelection;
+    private bool _reportedRemoteInspection;
 
     // The find methods receive only a CoreWebView2, so sessions are keyed by it to recover per-find state.
     private readonly Dictionary<CoreWebView2, FindSession> _findSessions = new();
@@ -435,6 +436,60 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
     {
         // The Skia heads' managed WebView2 surface does not implement zoom control, and user zoom is not
         // wired there, so there is nothing to toggle.
+    }
+
+    public void SetDevToolsEnabled(CoreWebView2 coreWebView2, bool enabled, string targetName)
+    {
+        // Honoured by the real WebView2 behind the Windows-under-Skia head. Stored and ignored on the macOS
+        // and Linux heads, which is why macOS goes on to opt the native view in itself.
+        coreWebView2.Settings.AreDevToolsEnabled = enabled;
+
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        if (!MacOSWebViewInterop.TryGetNativeWebViewHandle(coreWebView2, out var nativeHandle, out var detail))
+        {
+            _logger.LogWarning("Could not set the WebView developer tools state: {Detail}", detail);
+            return;
+        }
+
+        MacOSWebViewInterop.RetainNativeWebView(nativeHandle);
+
+        var inspectable = MacOSWebViewInterop.SetInspectable(nativeHandle, enabled);
+
+        var named = !enabled
+            || MacOSWebViewInterop.SetRemoteInspectionName(nativeHandle, targetName);
+
+        ReportRemoteInspectionOnce(enabled, inspectable && named);
+    }
+
+    // Reported once per session because a silent no-op here leaves every hosted page undebuggable, with
+    // nothing in the log to say so.
+    internal void ReportRemoteInspectionOnce(bool enabled, bool applied)
+    {
+        if (_reportedRemoteInspection)
+        {
+            return;
+        }
+
+        _reportedRemoteInspection = true;
+
+        if (!applied)
+        {
+            _logger.LogWarning(
+                "WebKit did not accept an inspection setting, so hosted pages may not appear in Safari's Develop menu");
+            return;
+        }
+
+        if (enabled)
+        {
+            _logger.LogDebug("Hosted pages are inspectable from Safari's Develop menu");
+            return;
+        }
+
+        _logger.LogDebug("Hosted pages are not inspectable: web inspection is disabled");
     }
 
     private string ResolveSafariVersion()

--- a/Source/Core/Celbridge.WebHost/Platform/WindowsWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/WindowsWebViewAdapter.cs
@@ -157,6 +157,12 @@ public sealed class WindowsWebViewAdapter : IWebViewAdapter
         coreWebView2.Settings.IsZoomControlEnabled = enabled;
     }
 
+    public void SetDevToolsEnabled(CoreWebView2 coreWebView2, bool enabled, string targetName)
+    {
+        // Chromium's DevTools open against one page, so the target name has nothing to distinguish here.
+        coreWebView2.Settings.AreDevToolsEnabled = enabled;
+    }
+
     // Windows uses Chromium's built-in find bar (ProvidesBuiltInFind is true), so the host never drives find
     // through the adapter here. These no-ops satisfy the shared adapter contract.
     public async Task StartFindAsync(CoreWebView2 coreWebView2, string term, FindOptions options)

--- a/Source/Core/Celbridge.WebHost/Services/IWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Services/IWebViewAdapter.cs
@@ -150,6 +150,15 @@ public interface IWebViewAdapter
     void SetZoomControlEnabled(CoreWebView2 coreWebView2, bool enabled);
 
     /// <summary>
+    /// Enables or disables the developer tools for the page, and names it in the debugger's target list,
+    /// which otherwise identifies every hosted editor by its index.html URL. The Windows heads take the
+    /// WebView2 setting, which Chromium acts on. That setting never reaches WebKit on the macOS Skia head, so
+    /// the native WKWebView is opted into remote inspection instead, which is what lists the page in Safari's
+    /// Develop menu. The Linux Skia head has no developer tools wired.
+    /// </summary>
+    void SetDevToolsEnabled(CoreWebView2 coreWebView2, bool enabled, string targetName);
+
+    /// <summary>
     /// Begins (or restarts) a whole-page find for the given term, selecting and scrolling to the first match.
     /// Drives the native WKWebView findString on macOS. Inert where ProvidesBuiltInFind is true (the Windows
     /// heads), whose backend supplies its own find bar. Match progress is reported through

--- a/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
@@ -224,7 +224,7 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
             RegisterWebSurfaceFocus(_webView, ReleaseFocus, GrantDomFocusAsync);
 
             var devToolsEnabled = _webViewService.IsDevToolsFeatureEnabled();
-            _webViewAdapter.SetDevToolsEnabled(_webView.CoreWebView2, devToolsEnabled, FileResource.ToString());
+            _webViewAdapter.SetDevToolsEnabled(_webView.CoreWebView2, devToolsEnabled, FileResource.ResourceName);
 
             // The .webview browser and HTML viewer render page content, so keep user zoom enabled.
             _webViewAdapter.SetZoomControlEnabled(_webView.CoreWebView2, true);

--- a/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
+++ b/Source/Modules/Celbridge.WebView/Views/WebViewDocumentView.xaml.cs
@@ -223,7 +223,8 @@ public sealed partial class WebViewDocumentView : DocumentView, IHostInput, IFin
             // relies on the registry's native click monitor instead.
             RegisterWebSurfaceFocus(_webView, ReleaseFocus, GrantDomFocusAsync);
 
-            _webView.CoreWebView2.Settings.AreDevToolsEnabled = _webViewService.IsDevToolsFeatureEnabled();
+            var devToolsEnabled = _webViewService.IsDevToolsFeatureEnabled();
+            _webViewAdapter.SetDevToolsEnabled(_webView.CoreWebView2, devToolsEnabled, FileResource.ToString());
 
             // The .webview browser and HTML viewer render page content, so keep user zoom enabled.
             _webViewAdapter.SetZoomControlEnabled(_webView.CoreWebView2, true);

--- a/Source/Tests/WebHost/WebViewDevToolsStateTests.cs
+++ b/Source/Tests/WebHost/WebViewDevToolsStateTests.cs
@@ -1,0 +1,38 @@
+using Celbridge.Logging;
+using Celbridge.WebHost.Platform;
+
+namespace Celbridge.Tests.WebHost;
+
+[TestFixture]
+public class WebViewDevToolsStateTests
+{
+    private ILogger<SkiaWebViewAdapter> _logger = null!;
+    private SkiaWebViewAdapter _adapter = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _logger = Substitute.For<ILogger<SkiaWebViewAdapter>>();
+        _adapter = new SkiaWebViewAdapter(_logger);
+    }
+
+    [Test]
+    public void ReportRemoteInspectionOnce_CalledForEveryWebView_ReportsOnlyTheFirst()
+    {
+        _adapter.ReportRemoteInspectionOnce(enabled: true, applied: true);
+        _adapter.ReportRemoteInspectionOnce(enabled: true, applied: true);
+        _adapter.ReportRemoteInspectionOnce(enabled: false, applied: true);
+
+        _logger.Received(1).LogDebug(Arg.Any<string?>(), Arg.Any<object?[]>());
+        _logger.DidNotReceive().LogWarning(Arg.Any<string?>(), Arg.Any<object?[]>());
+    }
+
+    [Test]
+    public void ReportRemoteInspectionOnce_SettingNotAccepted_WarnsThatPagesCannotBeInspected()
+    {
+        _adapter.ReportRemoteInspectionOnce(enabled: true, applied: false);
+
+        _logger.Received(1).LogWarning(Arg.Any<string?>(), Arg.Any<object?[]>());
+        _logger.DidNotReceive().LogDebug(Arg.Any<string?>(), Arg.Any<object?[]>());
+    }
+}

--- a/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
@@ -12,6 +12,7 @@ using Celbridge.Projects;
 using Celbridge.Reports;
 using Celbridge.Server;
 using Celbridge.UserInterface;
+using Celbridge.UserInterface.Helpers;
 using Celbridge.WebHost;
 using Celbridge.WebHost.Services;
 using Celbridge.Workspace;
@@ -350,6 +351,22 @@ public sealed class CustomEditorController : IHostInput, IHostContext, IEditTarg
         }
     }
 
+    // Names the page the way the document tab labels it: a utility by its display name, a document by its
+    // file name. A utility's resource key carries its package and extension, which reads as machine text.
+    private string GetDevToolsTargetName()
+    {
+        Guard.IsNotNull(_contribution);
+
+        if (!_contribution.IsUtility)
+        {
+            return _viewModel.FileResource.ResourceName;
+        }
+
+        var localizationService = _serviceProvider.GetRequiredService<IPackageLocalizationService>();
+
+        return PackageDisplayText.Resolve(localizationService, _contribution.Package, _contribution.DisplayName);
+    }
+
     // Configures a live WebView (CoreWebView2 ready): host channel, RPC targets, tool bridge, navigation gate,
     // and the editor load.
     private async Task ConfigureWebViewHostAsync(ICustomEditorLoader editorLoader)
@@ -361,7 +378,7 @@ public sealed class CustomEditorController : IHostInput, IHostContext, IEditTarg
         // or when the user has not enabled the WebViewDevTools feature flag.
         var devToolsBlocked = _contribution.Package.DevToolsBlocked;
         var devToolsEnabled = !devToolsBlocked && _webViewService.IsDevToolsFeatureEnabled();
-        _webViewAdapter.SetDevToolsEnabled(WebView.CoreWebView2, devToolsEnabled, _viewModel.FileResource.ToString());
+        _webViewAdapter.SetDevToolsEnabled(WebView.CoreWebView2, devToolsEnabled, GetDevToolsTargetName());
 
         // A custom editor is application chrome, not a browsable page, so disable WebView zoom (Ctrl+/-,
         // Ctrl+scroll). It reads as part of the app and follows OS display scaling like the native panels.

--- a/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
@@ -360,8 +360,8 @@ public sealed class CustomEditorController : IHostInput, IHostContext, IEditTarg
         // DevTools is off when the hosting package blocks it (sensitive material)
         // or when the user has not enabled the WebViewDevTools feature flag.
         var devToolsBlocked = _contribution.Package.DevToolsBlocked;
-        WebView.CoreWebView2.Settings.AreDevToolsEnabled =
-            !devToolsBlocked && _webViewService.IsDevToolsFeatureEnabled();
+        var devToolsEnabled = !devToolsBlocked && _webViewService.IsDevToolsFeatureEnabled();
+        _webViewAdapter.SetDevToolsEnabled(WebView.CoreWebView2, devToolsEnabled, _viewModel.FileResource.ToString());
 
         // A custom editor is application chrome, not a browsable page, so disable WebView zoom (Ctrl+/-,
         // Ctrl+scroll). It reads as part of the app and follows OS display scaling like the native panels.


### PR DESCRIPTION
This pull request adds cross-platform support for enabling and naming WebView developer tools, improving the debugging experience—especially for macOS, where pages can now be inspected via Safari’s Develop menu. The changes introduce a new `SetDevToolsEnabled` method to the `IWebViewAdapter` interface and its implementations, ensure the developer tools state is correctly set and reported, and provide a consistent way to name the debug target. Unit tests are also included to verify the new behavior.

**WebView developer tools support and target naming:**

* Added `SetDevToolsEnabled` to `IWebViewAdapter` and implemented it for both `SkiaWebViewAdapter` (macOS and Linux) and `WindowsWebViewAdapter`, enabling or disabling developer tools and setting a custom target name for debugging. On macOS, this opts the native view into remote inspection and sets the target name for Safari’s Develop menu. [[1]](diffhunk://#diff-6a81e30ede7c978712fe0743ed47b87742ba5387bb024ef33f0bde2e6d73a529R152-R160) [[2]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0R441-R494) [[3]](diffhunk://#diff-408450f968c0a4e477b5ed0c0a5563fc710904c0e7aa9ae1f8b73a45df1fbccfR160-R165)
* Updated initialization logic in both `WebViewDocumentView.xaml.cs` and `CustomEditorController.cs` to use the new `SetDevToolsEnabled` method, ensuring the correct state and target name are applied based on feature flags and context. [[1]](diffhunk://#diff-f0f498458e49e66878d20d43c4a5ed6a097092f487fdd83029cd7a7b92b47d37L226-R227) [[2]](diffhunk://#diff-d2998a8e2d1f53809f038c06ae9e0c3a6c529e601511f3cbc3a59446fe46c530L363-R381)
* Added a helper method, `GetDevToolsTargetName`, to generate a user-friendly target name for the debugger, improving clarity when multiple editors are open.

**macOS-specific remote inspection improvements:**

* Implemented native interop methods `SetInspectable` and `SetRemoteInspectionName` in `MacOSWebViewInterop.cs` to control and verify the inspectable state and target naming for WKWebView.
* Added logging and one-time reporting logic to `SkiaWebViewAdapter` to inform users if remote inspection could not be enabled, preventing silent failures. [[1]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0R23) [[2]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0R441-R494)

**Testing:**

* Introduced `WebViewDevToolsStateTests` to verify correct logging/reporting behavior for remote inspection state changes.