### PR TITLE
Refine destructive confirmation dialog behavior

### DIFF
--- a/Source/Core/Celbridge.Foundation/Dialog/ConfirmationDialogOptions.cs
+++ b/Source/Core/Celbridge.Foundation/Dialog/ConfirmationDialogOptions.cs
@@ -16,8 +16,8 @@ public record ConfirmationDialogOptions
     public string? SecondaryButtonText { get; init; }
 
     /// <summary>
-    /// When true, the confirm button is styled as a destructive action and keyboard focus starts on
-    /// the cancel button, so pressing Enter cancels rather than carrying out the action. Defaults to false.
+    /// When true, the cancel button becomes the accented default and takes initial focus, so pressing
+    /// Enter cancels. Use for actions that cannot be undone. Defaults to false.
     /// </summary>
     public bool IsDestructive { get; init; }
 }

--- a/Source/Core/Celbridge.Foundation/Dialog/IConfirmationDialog.cs
+++ b/Source/Core/Celbridge.Foundation/Dialog/IConfirmationDialog.cs
@@ -26,8 +26,8 @@ public interface IConfirmationDialog
     string SecondaryButtonText { get; set; }
 
     /// <summary>
-    /// When true, the confirm button is styled as a destructive action and keyboard focus starts on
-    /// the cancel button, so pressing Enter cancels rather than carrying out the action.
+    /// When true, the cancel button becomes the accented default and takes initial focus, so pressing
+    /// Enter cancels. Use for actions that cannot be undone.
     /// </summary>
     bool IsDestructive { get; set; }
 

--- a/Source/Core/Celbridge.UserInterface/Views/Dialogs/ConfirmationDialog.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Dialogs/ConfirmationDialog.xaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Celbridge.UserInterface.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
     Title="{x:Bind ViewModel.TitleText, Mode=OneWay}">
 
     <Grid HorizontalAlignment="Left"

--- a/Source/Core/Celbridge.UserInterface/Views/Dialogs/ConfirmationDialog.xaml.cs
+++ b/Source/Core/Celbridge.UserInterface/Views/Dialogs/ConfirmationDialog.xaml.cs
@@ -76,9 +76,9 @@ public sealed partial class ConfirmationDialog : ContentDialog, IConfirmationDia
     {
         if (IsDestructive)
         {
-            // The confirm button stays accented as the action, but keyboard focus starts on Cancel and
-            // no button is the Enter default, so pressing Enter cannot carry out the action by mistake.
-            DefaultButton = ContentDialogButton.None;
+            // Cancel is the accented default and takes initial focus, so the accent and the Enter key
+            // agree, and Enter cannot carry out an action that has no way back.
+            DefaultButton = ContentDialogButton.Secondary;
             Opened += OnDestructiveDialogOpened;
         }
         else

--- a/Source/Workspace/Celbridge.Explorer/Commands/DeleteResourceDialogCommand.cs
+++ b/Source/Workspace/Celbridge.Explorer/Commands/DeleteResourceDialogCommand.cs
@@ -134,8 +134,7 @@ public class DeleteResourceDialogCommand : CommandBase, IDeleteResourceDialogCom
 
         var confirmationOptions = new ConfirmationDialogOptions
         {
-            PrimaryButtonText = deleteString,
-            IsDestructive = true
+            PrimaryButtonText = deleteString
         };
         var showResult = await _dialogService.ShowConfirmationDialogAsync(deleteString, confirmDeleteString, confirmationOptions);
         if (showResult.IsSuccess)

--- a/Source/Workspace/Celbridge.Resources/Commands/DeleteResourceCommand.cs
+++ b/Source/Workspace/Celbridge.Resources/Commands/DeleteResourceCommand.cs
@@ -149,8 +149,7 @@ public class DeleteResourceCommand : CommandBase, IDeleteResourceCommand
                 case DeleteReferencePolicy.RequireConfirmation:
                     var dialogResult = await _dialogService.ShowConfirmationDialogAsync(
                         titleText: "Delete resources with existing references?",
-                        messageText: BuildConfirmationMessage(Resources, externalReferencers),
-                        options: new ConfirmationDialogOptions { IsDestructive = true });
+                        messageText: BuildConfirmationMessage(Resources, externalReferencers));
 
                     if (dialogResult.IsFailure
                         || !dialogResult.Value)

--- a/Source/package-lock.json
+++ b/Source/package-lock.json
@@ -293,23 +293,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }


### PR DESCRIPTION
Fixes #913

Updates destructive confirmation dialogs so Cancel is the default/acc­ented action and receives initial focus, making Enter cancel by default. The dialog no longer hardcodes an accented primary button style, and delete-resource flows stop opting into destructive mode so their Delete action remains the expected default.