### PR TITLE
Refactor tab indicators and improve tab reveal behavior

### DIFF
--- a/Source/Celbridge/Celbridge.Application.csproj
+++ b/Source/Celbridge/Celbridge.Application.csproj
@@ -13,7 +13,7 @@
          TFM agrees. The Uno.Sdk maps it to $(Version) on the platform heads but not the plain net10.0 TFM,
          which would otherwise default to 1.0.0 and fail project load in Visual Studio. The packaged
          Windows Identity Version in Package.appxmanifest is separate, keep it in sync. -->
-    <ApplicationDisplayVersion>0.3.0</ApplicationDisplayVersion>
+    <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
     <Version>$(ApplicationDisplayVersion)</Version>
     <ApplicationPublisher>An Tulcha</ApplicationPublisher>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.cs
@@ -550,6 +550,10 @@ public sealed partial class DocumentSectionContainer
                     tab.ViewModel.FileResource == _activeDocument;
                 tab.UpdateActiveDocumentState(isActiveDocument, _isPanelFocused);
             }
+
+            // The section draws the indicator over whichever of its tabs the loop just marked, so it is
+            // placed once the whole section has been marked rather than once per tab.
+            sectionView.UpdateActiveDocumentIndicator();
         }
     }
 

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionContainer.cs
@@ -544,16 +544,19 @@ public sealed partial class DocumentSectionContainer
         {
             bool isActiveSection = sectionView.Section == _activeSection;
 
+            bool sectionChanged = false;
             foreach (var tab in sectionView.GetAllTabs())
             {
                 bool isActiveDocument = isActiveSection &&
                     tab.ViewModel.FileResource == _activeDocument;
-                tab.UpdateActiveDocumentState(isActiveDocument, _isPanelFocused);
+                sectionChanged |= tab.UpdateActiveDocumentState(isActiveDocument, _isPanelFocused);
             }
 
-            // The section draws the indicator over whichever of its tabs the loop just marked, so it is
-            // placed once the whole section has been marked rather than once per tab.
-            sectionView.UpdateActiveDocumentIndicator();
+            // The section draws the indicator over whichever of its tabs is the active document.
+            if (sectionChanged)
+            {
+                sectionView.UpdateActiveDocumentIndicator();
+            }
         }
     }
 

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml
@@ -29,10 +29,13 @@
                  FontStyle="Italic"/>
     </Border>
     
-    <!-- TabView for documents -->
+    <!-- TabView for documents. The stock padding holds the tab list eight pixels down the band. Cleared so the
+         whole band belongs to the tabs, which keep a gap of their own above themselves for the active document
+         indicator to sit in. -->
     <TabView x:Name="TabView"
              AutomationProperties.AutomationId="document-tab-strip"
              IsAddTabButtonVisible="False"
+             Padding="0"
              TabWidthMode="SizeToContent"
              VerticalAlignment="Stretch"
              CanReorderTabs="True"
@@ -62,6 +65,25 @@
                                    HorizontalAlignment="Left"
                                    VerticalAlignment="Top"
                                    Visibility="Collapsed"/>
+
+    <!-- Active document indicator, drawn in the gap the tabs keep above themselves. Kept outside the tabs
+         because a tab clips its content to its own rounded corners, so a bar drawn inside one cannot reach
+         that gap. Placed over the active tab from code-behind, which is where the strip's geometry is known. -->
+    <Grid x:Name="ActiveDocumentIndicator"
+          Height="3"
+          HorizontalAlignment="Left"
+          VerticalAlignment="Top"
+          IsHitTestVisible="False"
+          Visibility="Collapsed">
+      <!-- The neutral bar marks the active document. The accent bar over it marks the documents panel holding
+           the keyboard, so the bar reads as accent only while the document shortcuts are live. -->
+      <Border Background="{ThemeResource ButtonActiveBackgroundBrush}"
+              CornerRadius="1.5"/>
+      <Border x:Name="FocusedDocumentIndicator"
+              Background="{ThemeResource AccentContrastBrush}"
+              CornerRadius="1.5"
+              Visibility="Collapsed"/>
+    </Grid>
 
     <!-- Attention flash outline, tracing the same edges and corners as the section's own chrome. -->
     <Border x:Name="PerimeterOverlay"

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml
@@ -29,9 +29,8 @@
                  FontStyle="Italic"/>
     </Border>
     
-    <!-- TabView for documents. The stock padding holds the tab list eight pixels down the band. Cleared so the
-         whole band belongs to the tabs, which keep a gap of their own above themselves for the active document
-         indicator to sit in. -->
+    <!-- TabView for documents. The stock padding indents the tab list down the band. The tabs hold their own
+         gap above themselves, so it is cleared here. -->
     <TabView x:Name="TabView"
              AutomationProperties.AutomationId="document-tab-strip"
              IsAddTabButtonVisible="False"
@@ -66,17 +65,16 @@
                                    VerticalAlignment="Top"
                                    Visibility="Collapsed"/>
 
-    <!-- Active document indicator, drawn in the gap the tabs keep above themselves. Kept outside the tabs
-         because a tab clips its content to its own rounded corners, so a bar drawn inside one cannot reach
-         that gap. Placed over the active tab from code-behind, which is where the strip's geometry is known. -->
+    <!-- Active document indicator, drawn in the gap above the tabs and placed over the active tab from
+         code-behind. A tab clips its content to its rounded corners, so the bar cannot live inside one. -->
     <Grid x:Name="ActiveDocumentIndicator"
           Height="3"
           HorizontalAlignment="Left"
           VerticalAlignment="Top"
           IsHitTestVisible="False"
           Visibility="Collapsed">
-      <!-- The neutral bar marks the active document. The accent bar over it marks the documents panel holding
-           the keyboard, so the bar reads as accent only while the document shortcuts are live. -->
+      <!-- The neutral bar marks the active document. The accent bar over it marks the documents panel
+           holding the keyboard. -->
       <Border Background="{ThemeResource ButtonActiveBackgroundBrush}"
               CornerRadius="1.5"/>
       <Border x:Name="FocusedDocumentIndicator"

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
@@ -36,17 +36,17 @@ public sealed partial class DocumentSectionView : UserControl
     private readonly WheelGestureAxisTracker _wheelGestureAxisTracker;
     private Storyboard? _perimeterStoryboard;
 
-    // How far below the top of the strip the active document indicator sits, inside the gap the tabs keep
-    // above themselves.
-    private const double ActiveDocumentIndicatorInset = 1;
+    // The gap the active document indicator leaves between itself and the tab below it. What the tab's own
+    // gap leaves over goes above the bar.
+    private const double ActiveDocumentIndicatorGapToTab = 3;
 
-    // How far inside its tab each end of the active document indicator stops. The bar floats above the tab
-    // rather than touching it, so the eye lines it up against the tab's top edge, which the corner radius
-    // draws in on both sides. The trailing end is held further in than the leading one: a tab has its
-    // neighbour beside it to be read against, while the last tab in the strip has only the gutter, and the
-    // overhang shows there.
+    // How far inside its tab each end of the active document indicator stops. The two differ deliberately:
+    // the trailing end needs more to clear the gutter beside the last tab in the strip.
     private const double ActiveDocumentIndicatorLeadingInset = 2;
     private const double ActiveDocumentIndicatorTrailingInset = 6;
+
+    // The distance below which a scroll would move the strip by less than a pixel.
+    private const double RevealAlignmentTolerance = 0.5;
 
     // The tab list template's two overflow arrows, named by their containers because that is what carries
     // the width each arrow costs the strip.
@@ -132,6 +132,11 @@ public sealed partial class DocumentSectionView : UserControl
         // leaves the selected tab clipped off-screen, so a window resize or a change in the number of
         // sections has to re-scroll it into view.
         TabView.SizeChanged += OnTabViewSizeChanged;
+
+        // The toolbars in these slots share the band with the tab list, so their width decides where the tabs
+        // start and the overlays drawn over the tabs move with them.
+        HeaderPresenter.SizeChanged += OnTabStripPresenterSizeChanged;
+        FooterPresenter.SizeChanged += OnTabStripPresenterSizeChanged;
     }
 
     // The web surfaces report a click anywhere over them, while managed focus only moves for a press that
@@ -620,57 +625,55 @@ public sealed partial class DocumentSectionView : UserControl
         });
     }
 
-    // Scrolls the strip by the least it takes to bring the tab fully into view, and leaves the strip alone
-    // while the tab is already there.
+    /// <summary>
+    /// Scrolls the strip by the least it takes to bring a tab fully into view, and leaves the strip alone
+    /// while the tab is already there. A tab whose leading edge sits before the viewport is clipped off that
+    /// edge, and one whose trailing edge sits past the viewport width is clipped off the other, so revealing
+    /// by the minimum that clears the offending edge keeps the rest of the strip where the user left it.
+    /// </summary>
     private static void ScrollToRevealTab(FrameworkElement container, ScrollViewer scrollViewer)
     {
-        if (GetRevealOffset(container, scrollViewer) is not double targetOffset)
+        double viewportWidth = scrollViewer.ViewportWidth;
+        if (viewportWidth <= 0)
+        {
+            // The strip has not been arranged, so there is no viewport to measure a tab against.
+            return;
+        }
+
+        double tabViewportX = TabViewportLeft(container, scrollViewer);
+        double tabWidth = container.ActualWidth;
+        double currentOffset = scrollViewer.HorizontalOffset;
+
+        double targetOffset;
+        if (tabWidth >= viewportWidth)
+        {
+            // A tab too wide for the strip cannot be brought fully into view, so its leading edge is the one
+            // to show. The name starts there, while the trailing edge carries only the close button.
+            targetOffset = currentOffset + tabViewportX;
+        }
+        else if (tabViewportX < 0)
+        {
+            targetOffset = currentOffset + tabViewportX;
+        }
+        else if (tabViewportX + tabWidth > viewportWidth)
+        {
+            targetOffset = currentOffset + (tabViewportX + tabWidth - viewportWidth);
+        }
+        else
         {
             return;
         }
 
         double clampedOffset = Math.Clamp(targetOffset, 0, scrollViewer.ScrollableWidth);
+
+        // Transformed coordinates carry a fraction, so a tab already sitting where it is wanted still measures
+        // a hair off. Scrolling by less than a pixel would move nothing.
+        if (Math.Abs(clampedOffset - currentOffset) < RevealAlignmentTolerance)
+        {
+            return;
+        }
+
         scrollViewer.ChangeView(clampedOffset, null, null, disableAnimation: true);
-    }
-
-    /// <summary>
-    /// The scroll offset that brings a tab container fully into the strip's viewport, or null when the tab is
-    /// already fully visible. A tab whose left edge sits before the viewport is clipped off the leading edge,
-    /// and one whose right edge sits past the viewport width is clipped off the trailing edge. Revealing by
-    /// the minimum that clears the offending edge keeps the rest of the strip where the user left it.
-    /// </summary>
-    private static double? GetRevealOffset(FrameworkElement container, ScrollViewer scrollViewer)
-    {
-        double tabViewportX = TabViewportLeft(container, scrollViewer);
-        double tabWidth = container.ActualWidth;
-        double viewportWidth = scrollViewer.ViewportWidth;
-        double currentOffset = scrollViewer.HorizontalOffset;
-
-        // A tab too wide for the strip cannot be brought fully into view, so its leading edge is the edge to
-        // show: the document's name starts there, while the trailing edge carries only the close button. The
-        // trailing check below would otherwise stay true however far the strip scrolled, and take the name off
-        // the leading edge to satisfy it.
-        if (tabWidth >= viewportWidth)
-        {
-            if (tabViewportX == 0)
-            {
-                return null;
-            }
-
-            return currentOffset + tabViewportX;
-        }
-
-        if (tabViewportX < 0)
-        {
-            return currentOffset + tabViewportX;
-        }
-
-        if (tabViewportX + tabWidth > viewportWidth)
-        {
-            return currentOffset + (tabViewportX + tabWidth - viewportWidth);
-        }
-
-        return null;
     }
 
     /// <summary>
@@ -899,9 +902,8 @@ public sealed partial class DocumentSectionView : UserControl
         AttachTabStripScrollIndicator(scrollViewer);
         AttachTabStripWheelHandler(scrollViewer);
 
-        // Left to itself the strip scrolls a tab into view whenever that tab takes focus, landing wherever the
-        // framework chooses rather than at the least scroll that shows the tab, and sometimes short of the
-        // edge it scrolled towards. Revealing runs from the selection instead, once the strip has settled.
+        // The strip scrolls a tab into view whenever that tab takes focus. Revealing is driven from the
+        // selection, so that is turned off.
         scrollViewer.BringIntoViewOnFocusChange = false;
     }
 
@@ -913,6 +915,18 @@ public sealed partial class DocumentSectionView : UserControl
         }
 
         RevealSelectedTab();
+    }
+
+    private void OnTabStripPresenterSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (_isShuttingDown)
+        {
+            return;
+        }
+
+        // The strip is still mid-arrange while the size change is raised, so the tabs only settle on the
+        // following cycle.
+        _ = DispatcherQueue.TryEnqueue(UpdateTabStripOverlays);
     }
 
     private void AttachTabStripScrollIndicator(ScrollViewer scrollViewer)
@@ -965,9 +979,7 @@ public sealed partial class DocumentSectionView : UserControl
         scrollViewer?.ChangeView(offset, null, null, disableAnimation: true);
     }
 
-    // The strip draws two overlays outside the tabs themselves: the scroll indicator along the band's bottom
-    // edge, and the active document indicator in the gap above the tabs. Both are placed from the strip's
-    // geometry, so both are refreshed whenever that geometry moves.
+    // Both overlays are placed from the strip's geometry, so both are refreshed together.
     private void UpdateTabStripOverlays()
     {
         UpdateTabStripScrollIndicator();
@@ -975,8 +987,8 @@ public sealed partial class DocumentSectionView : UserControl
     }
 
     /// <summary>
-    /// Places the active document indicator over the tab holding the active document, and hides it while this
-    /// section has no such tab or that tab has scrolled out of the strip.
+    /// Places the active document indicator over the tab holding the active document, and hides it when this
+    /// section has no such tab.
     /// </summary>
     public void UpdateActiveDocumentIndicator()
     {
@@ -1015,9 +1027,7 @@ public sealed partial class DocumentSectionView : UserControl
             .TransformToVisual(RootGrid)
             .TransformBounds(new Rect(0, 0, activeTab.ActualWidth, activeTab.ActualHeight));
 
-        // The strip scrolls under the indicator rather than carrying it, so whatever of the tab has passed
-        // either end of the strip comes off the bar instead of being drawn over the chrome beside it. The
-        // inset is taken off the tab before that, so a bar the strip has clipped still stops short of its tab.
+        // The indicator is drawn outside the strip, so the bar is clipped to the strip's own edges.
         double left = Math.Max(tabBounds.Left + ActiveDocumentIndicatorLeadingInset, stripBounds.Left);
         double right = Math.Min(tabBounds.Right - ActiveDocumentIndicatorTrailingInset, stripBounds.Right);
         if (right - left < 1)
@@ -1027,11 +1037,10 @@ public sealed partial class DocumentSectionView : UserControl
             return;
         }
 
-        // The bar sits nearer the top of the strip than the tab below it, rather than centred in the gap: the
-        // section's own edge runs directly above the bar and reads as part of the space over it, so an equal
-        // split leaves the top looking the wider of the two. Measured from the top of the strip rather than of
-        // the section, which the section's edge holds a pixel below it.
-        double indicatorTop = stripBounds.Top + ActiveDocumentIndicatorInset;
+        double indicatorTop = stripBounds.Top
+            + DocumentTab.StripTopGap
+            - ActiveDocumentIndicator.Height
+            - ActiveDocumentIndicatorGapToTab;
 
         ActiveDocumentIndicator.Visibility = Visibility.Visible;
         ActiveDocumentIndicator.Width = right - left;
@@ -1068,11 +1077,8 @@ public sealed partial class DocumentSectionView : UserControl
             .TransformToVisual(RootGrid)
             .TransformBounds(new Rect(0, 0, scrollViewer.ActualWidth, scrollViewer.ActualHeight));
 
-        // The band is pinned to the authored strip height, so the indicator's place down the band is the same
-        // in every section. Measured from the top of the strip rather than of the section, which the section's
-        // own edge holds a pixel below it. The pixel the bar keeps below itself clears the document
-        // underneath: on macOS that is a native web view drawn over managed content, which clips a bar flush
-        // with the band's bottom edge.
+        // The pixel the bar keeps below itself clears the macOS web view, which clips a bar flush with the
+        // band's bottom edge.
         double indicatorTop = stripBounds.Top + stripHeight - ScrollIndicator.Height - 1;
 
         ScrollIndicator.Width = stripBounds.Width;

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
@@ -126,6 +126,7 @@ public sealed partial class DocumentSectionView : UserControl
         RootGrid.AddHandler(PointerPressedEvent, _documentPointerPressedHandler, handledEventsToo: true);
 
         TabView.Loaded += OnTabViewLoaded;
+        TabView.SelectionChanged += OnTabViewSelectionChanged;
 
         // A narrower strip moves the scroll indicator and can change whether it is needed at all. It also
         // leaves the selected tab clipped off-screen, so a window resize or a change in the number of
@@ -574,52 +575,62 @@ public sealed partial class DocumentSectionView : UserControl
         // the layout pass runs, so measuring synchronously here would read stale bounds.
         DispatcherQueue.TryEnqueue(() =>
         {
+            if (_isShuttingDown)
+            {
+                return;
+            }
+
             var tabListView = VisualTree.FindDescendant<ListViewBase>(TabView);
-            if (tabListView is null)
+            var scrollViewer = GetTabStripScrollViewer();
+            if (tabListView is null ||
+                scrollViewer is null)
             {
                 return;
             }
 
-            var scrollViewer = VisualTree.FindDescendant<ScrollViewer>(tabListView);
-            if (scrollViewer is null)
-            {
-                return;
-            }
-
-            // Measure before disturbing the strip. A tab the user clicked is arranged already and is
-            // usually in view, and the realization pass below moves the offset whether or not there was
-            // anything to reveal, which lands the strip back near its first tab.
-            var container = tabListView.ContainerFromItem(tab) as FrameworkElement;
-            if (container is not null &&
-                container.ActualWidth > 0 &&
-                GetRevealOffset(container, scrollViewer) is null)
-            {
-                return;
-            }
-
-            // Realize the container for an off-screen (virtualized) tab and force the strip to lay out, so
-            // the measurements below reflect the settled geometry rather than a transient resize state.
-            tabListView.ScrollIntoView(tab, ScrollIntoViewAlignment.Default);
+            // Settle the strip before measuring it, so the offset and the bounds read below belong to the
+            // same arrangement.
             tabListView.UpdateLayout();
 
-            container = tabListView.ContainerFromItem(tab) as FrameworkElement;
-            if (container is null ||
-                container.ActualWidth == 0)
+            if (tabListView.ContainerFromItem(tab) is FrameworkElement container &&
+                container.ActualWidth > 0)
             {
-                // Uno can realize a tab many positions off-screen without arranging it (zero bounds). Its
-                // ScrollIntoView above is the best available fallback; driving the scroll from zero geometry
-                // would only push the strip to the wrong place.
+                ScrollToRevealTab(container, scrollViewer);
+
                 return;
             }
 
-            if (GetRevealOffset(container, scrollViewer) is not double targetOffset)
-            {
-                return;
-            }
+            // A virtualized tab has no bounds to measure, and the strip's own reveal is the only thing that
+            // will realize it. Where it lands is then corrected on the following cycle, once it has settled.
+            tabListView.ScrollIntoView(tab, ScrollIntoViewAlignment.Default);
 
-            double clampedOffset = Math.Clamp(targetOffset, 0, scrollViewer.ScrollableWidth);
-            scrollViewer.ChangeView(clampedOffset, null, null, disableAnimation: true);
+            _ = DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isShuttingDown)
+                {
+                    return;
+                }
+
+                if (tabListView.ContainerFromItem(tab) is FrameworkElement realized &&
+                    realized.ActualWidth > 0)
+                {
+                    ScrollToRevealTab(realized, scrollViewer);
+                }
+            });
         });
+    }
+
+    // Scrolls the strip by the least it takes to bring the tab fully into view, and leaves the strip alone
+    // while the tab is already there.
+    private static void ScrollToRevealTab(FrameworkElement container, ScrollViewer scrollViewer)
+    {
+        if (GetRevealOffset(container, scrollViewer) is not double targetOffset)
+        {
+            return;
+        }
+
+        double clampedOffset = Math.Clamp(targetOffset, 0, scrollViewer.ScrollableWidth);
+        scrollViewer.ChangeView(clampedOffset, null, null, disableAnimation: true);
     }
 
     /// <summary>
@@ -634,6 +645,20 @@ public sealed partial class DocumentSectionView : UserControl
         double tabWidth = container.ActualWidth;
         double viewportWidth = scrollViewer.ViewportWidth;
         double currentOffset = scrollViewer.HorizontalOffset;
+
+        // A tab too wide for the strip cannot be brought fully into view, so its leading edge is the edge to
+        // show: the document's name starts there, while the trailing edge carries only the close button. The
+        // trailing check below would otherwise stay true however far the strip scrolled, and take the name off
+        // the leading edge to satisfy it.
+        if (tabWidth >= viewportWidth)
+        {
+            if (tabViewportX == 0)
+            {
+                return null;
+            }
+
+            return currentOffset + tabViewportX;
+        }
 
         if (tabViewportX < 0)
         {
@@ -873,6 +898,21 @@ public sealed partial class DocumentSectionView : UserControl
 
         AttachTabStripScrollIndicator(scrollViewer);
         AttachTabStripWheelHandler(scrollViewer);
+
+        // Left to itself the strip scrolls a tab into view whenever that tab takes focus, landing wherever the
+        // framework chooses rather than at the least scroll that shows the tab, and sometimes short of the
+        // edge it scrolled towards. Revealing runs from the selection instead, once the strip has settled.
+        scrollViewer.BringIntoViewOnFocusChange = false;
+    }
+
+    private void OnTabViewSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isShuttingDown)
+        {
+            return;
+        }
+
+        RevealSelectedTab();
     }
 
     private void AttachTabStripScrollIndicator(ScrollViewer scrollViewer)

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentSectionView.xaml.cs
@@ -36,6 +36,18 @@ public sealed partial class DocumentSectionView : UserControl
     private readonly WheelGestureAxisTracker _wheelGestureAxisTracker;
     private Storyboard? _perimeterStoryboard;
 
+    // How far below the top of the strip the active document indicator sits, inside the gap the tabs keep
+    // above themselves.
+    private const double ActiveDocumentIndicatorInset = 1;
+
+    // How far inside its tab each end of the active document indicator stops. The bar floats above the tab
+    // rather than touching it, so the eye lines it up against the tab's top edge, which the corner radius
+    // draws in on both sides. The trailing end is held further in than the leading one: a tab has its
+    // neighbour beside it to be read against, while the last tab in the strip has only the gutter, and the
+    // overhang shows there.
+    private const double ActiveDocumentIndicatorLeadingInset = 2;
+    private const double ActiveDocumentIndicatorTrailingInset = 6;
+
     // The tab list template's two overflow arrows, named by their containers because that is what carries
     // the width each arrow costs the strip.
     private static readonly string[] TabStripScrollButtonContainerNames =
@@ -241,7 +253,7 @@ public sealed partial class DocumentSectionView : UserControl
 
         // The strip is still mid-arrange while its size change is raised, so its leading edge only settles on
         // the following cycle.
-        _ = DispatcherQueue.TryEnqueue(UpdateTabStripScrollIndicator);
+        _ = DispatcherQueue.TryEnqueue(UpdateTabStripOverlays);
     }
 
     /// <summary>
@@ -783,7 +795,7 @@ public sealed partial class DocumentSectionView : UserControl
         _ = DispatcherQueue.TryEnqueue(() =>
         {
             AttachTabStripScrollHandlers();
-            UpdateTabStripScrollIndicator();
+            UpdateTabStripOverlays();
         });
     }
 
@@ -874,7 +886,7 @@ public sealed partial class DocumentSectionView : UserControl
         ScrollIndicator.ScrollRequested += OnScrollIndicatorScrollRequested;
         _scrollIndicatorAttached = true;
 
-        UpdateTabStripScrollIndicator();
+        UpdateTabStripOverlays();
     }
 
     // UNO-BUG: the tab strip's ScrollViewer scrolls horizontal wheel input the wrong way on macOS.
@@ -904,13 +916,88 @@ public sealed partial class DocumentSectionView : UserControl
 
     private void OnTabStripViewChanged(object? sender, ScrollViewerViewChangedEventArgs e)
     {
-        UpdateTabStripScrollIndicator();
+        UpdateTabStripOverlays();
     }
 
     private void OnScrollIndicatorScrollRequested(double offset)
     {
         var scrollViewer = GetTabStripScrollViewer();
         scrollViewer?.ChangeView(offset, null, null, disableAnimation: true);
+    }
+
+    // The strip draws two overlays outside the tabs themselves: the scroll indicator along the band's bottom
+    // edge, and the active document indicator in the gap above the tabs. Both are placed from the strip's
+    // geometry, so both are refreshed whenever that geometry moves.
+    private void UpdateTabStripOverlays()
+    {
+        UpdateTabStripScrollIndicator();
+        UpdateActiveDocumentIndicator();
+    }
+
+    /// <summary>
+    /// Places the active document indicator over the tab holding the active document, and hides it while this
+    /// section has no such tab or that tab has scrolled out of the strip.
+    /// </summary>
+    public void UpdateActiveDocumentIndicator()
+    {
+        if (_isShuttingDown)
+        {
+            return;
+        }
+
+        DocumentTab? activeTab = null;
+        foreach (var tab in GetAllTabs())
+        {
+            if (tab.IsActiveDocument)
+            {
+                activeTab = tab;
+                break;
+            }
+        }
+
+        var scrollViewer = GetTabStripScrollViewer();
+        if (activeTab is null ||
+            activeTab.ActualWidth <= 0 ||
+            scrollViewer is null ||
+            scrollViewer.ActualWidth <= 0 ||
+            MeasureTabStripHeight() <= 0)
+        {
+            ActiveDocumentIndicator.Visibility = Visibility.Collapsed;
+
+            return;
+        }
+
+        var stripBounds = scrollViewer
+            .TransformToVisual(RootGrid)
+            .TransformBounds(new Rect(0, 0, scrollViewer.ActualWidth, scrollViewer.ActualHeight));
+
+        var tabBounds = activeTab
+            .TransformToVisual(RootGrid)
+            .TransformBounds(new Rect(0, 0, activeTab.ActualWidth, activeTab.ActualHeight));
+
+        // The strip scrolls under the indicator rather than carrying it, so whatever of the tab has passed
+        // either end of the strip comes off the bar instead of being drawn over the chrome beside it. The
+        // inset is taken off the tab before that, so a bar the strip has clipped still stops short of its tab.
+        double left = Math.Max(tabBounds.Left + ActiveDocumentIndicatorLeadingInset, stripBounds.Left);
+        double right = Math.Min(tabBounds.Right - ActiveDocumentIndicatorTrailingInset, stripBounds.Right);
+        if (right - left < 1)
+        {
+            ActiveDocumentIndicator.Visibility = Visibility.Collapsed;
+
+            return;
+        }
+
+        // The bar sits nearer the top of the strip than the tab below it, rather than centred in the gap: the
+        // section's own edge runs directly above the bar and reads as part of the space over it, so an equal
+        // split leaves the top looking the wider of the two. Measured from the top of the strip rather than of
+        // the section, which the section's edge holds a pixel below it.
+        double indicatorTop = stripBounds.Top + ActiveDocumentIndicatorInset;
+
+        ActiveDocumentIndicator.Visibility = Visibility.Visible;
+        ActiveDocumentIndicator.Width = right - left;
+        ActiveDocumentIndicator.Margin = new Thickness(left, indicatorTop, 0, 0);
+
+        FocusedDocumentIndicator.Visibility = activeTab.IsFocusedActiveDocument ? Visibility.Visible : Visibility.Collapsed;
     }
 
     /// <summary>
@@ -935,17 +1022,18 @@ public sealed partial class DocumentSectionView : UserControl
             return;
         }
 
-        // The band is pinned to the authored strip height and starts at the top of the section's content, so
-        // the indicator's place down the band is the same in every section. The pixel it keeps below itself
-        // clears the document underneath: on macOS that is a native web view drawn over managed content,
-        // which clips a bar flush with the band's bottom edge.
-        double indicatorTop = stripHeight - ScrollIndicator.Height - 1;
-
         // Where the tabs start across the band depends on the toolbar in the strip header, so the leading
         // edge is the one part of the placement that has to be measured.
         var stripBounds = scrollViewer
             .TransformToVisual(RootGrid)
             .TransformBounds(new Rect(0, 0, scrollViewer.ActualWidth, scrollViewer.ActualHeight));
+
+        // The band is pinned to the authored strip height, so the indicator's place down the band is the same
+        // in every section. Measured from the top of the strip rather than of the section, which the section's
+        // own edge holds a pixel below it. The pixel the bar keeps below itself clears the document
+        // underneath: on macOS that is a native web view drawn over managed content, which clips a bar flush
+        // with the band's bottom edge.
+        double indicatorTop = stripBounds.Top + stripHeight - ScrollIndicator.Height - 1;
 
         ScrollIndicator.Width = stripBounds.Width;
         ScrollIndicator.Margin = new Thickness(stripBounds.Left, indicatorTop, 0, 0);

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
@@ -75,10 +75,20 @@
                                Margin="0"
                                Visibility="{x:Bind ViewModel.IsUtilityEditor, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
 
-                <TextBlock Text="{x:Bind ViewModel.DocumentName, Mode=OneWay}"
-                           Margin="4,0,0,0"
-                           ToolTipService.ToolTip="{x:Bind ViewModel.TabTooltip, Mode=OneWay}"
-                           ToolTipService.Placement="Bottom" />
+                <!-- The label is held at the width it takes at the heavier weight a selected tab draws it in.
+                     The strip sizes its tabs to their content, so without this a tab widens as it is selected
+                     and every tab after it shifts, which moves the ground under anything measuring the strip.
+                     The sizing copy is laid out but never drawn. -->
+                <Grid Margin="4,0,0,0">
+                    <TextBlock Text="{x:Bind ViewModel.DocumentName, Mode=OneWay}"
+                               FontWeight="SemiBold"
+                               Opacity="0"
+                               IsHitTestVisible="False" />
+
+                    <TextBlock Text="{x:Bind ViewModel.DocumentName, Mode=OneWay}"
+                               ToolTipService.ToolTip="{x:Bind ViewModel.TabTooltip, Mode=OneWay}"
+                               ToolTipService.Placement="Bottom" />
+                </Grid>
             </StackPanel>
         </Grid>
     </muxc:TabViewItem.Header>

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
@@ -8,24 +8,13 @@
     xmlns:controls="using:Celbridge.UserInterface.Views.Controls"
     xmlns:services="using:Celbridge.UserInterface.Services"
     DataContext="{x:Bind ViewModel}"
+    VerticalContentAlignment="Stretch"
     DoubleTapped="DocumentTab_DoubleTapped"
     Tapped="DocumentTab_Tapped"
     DragStarting="DocumentTab_DragStarting">
 
     <muxc:TabViewItem.Resources>
         <services:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
-
-        <!-- The two selection indicator bars sit one over the other and have to line up exactly, so their
-             geometry is declared once here. The bottom margin stops short of the strip's bottom edge so the
-             scroll indicator can sit below it rather than across it while the strip overflows. -->
-        <Style x:Key="SelectionIndicatorStyle" TargetType="Border">
-            <Setter Property="Height" Value="3" />
-            <Setter Property="CornerRadius" Value="1.5" />
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
-            <Setter Property="VerticalAlignment" Value="Bottom" />
-            <Setter Property="Margin" Value="0,0,-36,-1" />
-            <Setter Property="Visibility" Value="Collapsed" />
-        </Style>
     </muxc:TabViewItem.Resources>
 
     <muxc:TabViewItem.ContextFlyout>
@@ -56,17 +45,18 @@
     </muxc:TabViewItem.ContextFlyout>
 
     <muxc:TabViewItem.Header>
-        <Grid Margin="0,-4,0,2">
+        <Grid>
             <!-- Attention flash overlay, pulsed to the accent color by FlashAttention. Behind the label and not hit-testable. -->
             <Border x:Name="AttentionOverlay"
                     Background="{ThemeResource AccentBrush}"
                     CornerRadius="4"
                     Opacity="0"
                     IsHitTestVisible="False"
-                    Margin="0,0,-36,-4" />
+                    Margin="0,0,-36,0" />
 
             <!-- Tab content -->
-            <StackPanel Orientation="Horizontal" Margin="0,4,0,4">
+            <StackPanel Orientation="Horizontal"
+                        VerticalAlignment="Center">
                 <!-- Ordinary document tabs show a file-type icon. A tab a utility editor opens shows that
                      editor's manifest glyph in the tab's own text colour. Every file-type icon is held
                      inside a luminance band that excludes that colour, so an untinted glyph is what marks
@@ -90,17 +80,6 @@
                            ToolTipService.ToolTip="{x:Bind ViewModel.TabTooltip, Mode=OneWay}"
                            ToolTipService.Placement="Bottom" />
             </StackPanel>
-            
-            <!-- Selection indicator. The neutral bar marks the active document. The accent bar over it marks
-                 the documents panel holding the keyboard, so the bar reads as accent only while the document
-                 shortcuts are live. -->
-            <Border x:Name="SelectionIndicator"
-                    Style="{StaticResource SelectionIndicatorStyle}"
-                    Background="{ThemeResource ButtonActiveBackgroundBrush}" />
-
-            <Border x:Name="FocusedSelectionIndicator"
-                    Style="{StaticResource SelectionIndicatorStyle}"
-                    Background="{ThemeResource AccentContrastBrush}" />
         </Grid>
     </muxc:TabViewItem.Header>
 

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
@@ -75,15 +75,14 @@
                                Margin="0"
                                Visibility="{x:Bind ViewModel.IsUtilityEditor, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
 
-                <!-- The label is held at the width it takes at the heavier weight a selected tab draws it in.
-                     The strip sizes its tabs to their content, so without this a tab widens as it is selected
-                     and every tab after it shifts, which moves the ground under anything measuring the strip.
-                     The sizing copy is laid out but never drawn. -->
+                <!-- The hidden copy holds the label at the width it takes when the tab is selected and drawn
+                     at the heavier weight, so selecting a tab does not widen it. -->
                 <Grid Margin="4,0,0,0">
                     <TextBlock Text="{x:Bind ViewModel.DocumentName, Mode=OneWay}"
                                FontWeight="SemiBold"
                                Opacity="0"
-                               IsHitTestVisible="False" />
+                               IsHitTestVisible="False"
+                               AutomationProperties.AccessibilityView="Raw" />
 
                     <TextBlock Text="{x:Bind ViewModel.DocumentName, Mode=OneWay}"
                                ToolTipService.ToolTip="{x:Bind ViewModel.TabTooltip, Mode=OneWay}"

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
@@ -5,6 +5,7 @@ using Celbridge.Platform;
 using Celbridge.UserInterface;
 using Celbridge.UserInterface.Helpers;
 using Celbridge.UserInterface.Services;
+using Celbridge.Workspace;
 using Microsoft.Extensions.Localization;
 using Microsoft.UI.Xaml.Media.Animation;
 
@@ -42,6 +43,13 @@ public partial class DocumentTab : TabViewItem
     private readonly IMessengerService _messengerService;
     private readonly IPlatformInfo _platformInfo;
 
+    /// <summary>
+    /// The gap the tab keeps between itself and the top of the strip band. The section draws the active
+    /// document indicator in it, which is what stops that bar sharing an edge with either the tab or the
+    /// section.
+    /// </summary>
+    public const double StripTopGap = 7;
+
     // How long after handling a double tap a second one is treated as the duplicate event rather than a
     // new gesture. Wide enough to cover the duplicate, which trails by a few milliseconds, and well short
     // of the two further presses a real second double-click needs.
@@ -53,7 +61,7 @@ public partial class DocumentTab : TabViewItem
     // When the last double tap was handled, used to discard the duplicate that follows it.
     private DateTime _lastDoubleTapTime;
 
-    // Whether the documents panel holds the keyboard, which the selection indicator's tone shows.
+    // Whether the documents panel holds the keyboard, which the active document indicator's tone shows.
     private bool _isPanelFocused;
 
     public DocumentTabViewModel ViewModel { get; }
@@ -78,6 +86,12 @@ public partial class DocumentTab : TabViewItem
     /// Gets whether this tab is the active document.
     /// </summary>
     public bool IsActiveDocument { get; private set; }
+
+    /// <summary>
+    /// Gets whether this tab is the active document while the documents panel holds the keyboard, which is
+    /// what the active document indicator shows in the accent colour.
+    /// </summary>
+    public bool IsFocusedActiveDocument => IsActiveDocument && _isPanelFocused;
 
     /// <summary>
     /// Briefly pulses the tab's background to the accent color to draw the user's attention to it, then fades
@@ -114,6 +128,11 @@ public partial class DocumentTab : TabViewItem
     public DocumentTab()
     {
         this.InitializeComponent();
+
+        // The tab takes the strip band less the gap it holds above itself, so it runs from under the active
+        // document indicator down to the document it heads.
+        Height = WorkspaceConstants.SectionTabStripHeight - StripTopGap;
+        Margin = new Thickness(0, StripTopGap, 0, 0);
 
         _stringLocalizer = ServiceLocator.AcquireService<IStringLocalizer>();
         _commandService = ServiceLocator.AcquireService<ICommandService>();
@@ -211,24 +230,14 @@ public partial class DocumentTab : TabViewItem
     }
 
     /// <summary>
-    /// Updates the visual state to indicate whether this tab is the active document, and whether the
-    /// documents panel holds the keyboard.
+    /// Records whether this tab is the active document, and whether the documents panel holds the keyboard.
+    /// The section reads both back when it places the active document indicator, which it draws itself since
+    /// a tab clips anything drawn inside it to its own rounded corners.
     /// </summary>
     public void UpdateActiveDocumentState(bool isActiveDocument, bool isPanelFocused)
     {
-        if (IsActiveDocument == isActiveDocument
-            && _isPanelFocused == isPanelFocused)
-        {
-            return;
-        }
-
         IsActiveDocument = isActiveDocument;
         _isPanelFocused = isPanelFocused;
-
-        SelectionIndicator.Visibility = isActiveDocument ? Visibility.Visible : Visibility.Collapsed;
-
-        bool isFocusedActiveDocument = isActiveDocument && isPanelFocused;
-        FocusedSelectionIndicator.Visibility = isFocusedActiveDocument ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void ContextMenu_Close(object sender, RoutedEventArgs e)

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
@@ -44,9 +44,7 @@ public partial class DocumentTab : TabViewItem
     private readonly IPlatformInfo _platformInfo;
 
     /// <summary>
-    /// The gap the tab keeps between itself and the top of the strip band. The section draws the active
-    /// document indicator in it, which is what stops that bar sharing an edge with either the tab or the
-    /// section.
+    /// The gap the tab keeps between itself and the top of the strip band.
     /// </summary>
     public const double StripTopGap = 7;
 
@@ -88,8 +86,7 @@ public partial class DocumentTab : TabViewItem
     public bool IsActiveDocument { get; private set; }
 
     /// <summary>
-    /// Gets whether this tab is the active document while the documents panel holds the keyboard, which is
-    /// what the active document indicator shows in the accent colour.
+    /// Gets whether this tab is the active document while the documents panel holds the keyboard.
     /// </summary>
     public bool IsFocusedActiveDocument => IsActiveDocument && _isPanelFocused;
 
@@ -129,8 +126,7 @@ public partial class DocumentTab : TabViewItem
     {
         this.InitializeComponent();
 
-        // The tab takes the strip band less the gap it holds above itself, so it runs from under the active
-        // document indicator down to the document it heads.
+        // The tab takes the strip band less the gap it holds above itself.
         Height = WorkspaceConstants.SectionTabStripHeight - StripTopGap;
         Margin = new Thickness(0, StripTopGap, 0, 0);
 
@@ -231,13 +227,20 @@ public partial class DocumentTab : TabViewItem
 
     /// <summary>
     /// Records whether this tab is the active document, and whether the documents panel holds the keyboard.
-    /// The section reads both back when it places the active document indicator, which it draws itself since
-    /// a tab clips anything drawn inside it to its own rounded corners.
+    /// Returns whether either of them changed.
     /// </summary>
-    public void UpdateActiveDocumentState(bool isActiveDocument, bool isPanelFocused)
+    public bool UpdateActiveDocumentState(bool isActiveDocument, bool isPanelFocused)
     {
+        if (IsActiveDocument == isActiveDocument
+            && _isPanelFocused == isPanelFocused)
+        {
+            return false;
+        }
+
         IsActiveDocument = isActiveDocument;
         _isPanelFocused = isPanelFocused;
+
+        return true;
     }
 
     private void ContextMenu_Close(object sender, RoutedEventArgs e)


### PR DESCRIPTION
This pull request introduces a new visual indicator for the active document tab in the document tab strip and refines the scrolling and layout logic for tabs. The main changes include adding and positioning the active document indicator, updating how overlays are refreshed, and improving tab reveal behavior. Additionally, some UI padding and margin adjustments ensure the new indicator integrates cleanly with existing elements.

**Active Document Indicator and Overlay Placement:**

* Added an `ActiveDocumentIndicator` overlay to `DocumentSectionView.xaml`, which visually marks the active document tab and distinguishes focus state with an accent bar (`FocusedDocumentIndicator`).
* Implemented `UpdateActiveDocumentIndicator()` in `DocumentSectionView.xaml.cs` to position and show/hide the indicator based on the active tab’s geometry and focus state.
* Refactored all tab strip overlay updates (including scroll indicator and active document indicator) into a unified `UpdateTabStripOverlays()` method, ensuring overlays update together when the tab strip changes. [[1]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L907-R973) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L786-R826) [[3]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L244-R262) [[4]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968L877-R943)

**Tab Scrolling and Selection Behavior:**

* Improved tab reveal logic in `ScrollTabIntoView()` to ensure the selected tab is scrolled fully into view, including handling virtualized tabs and avoiding unnecessary scrolls for sub-pixel adjustments.
* Added event handlers to trigger overlay updates and tab reveal on selection changes and tab strip resizing, ensuring visual elements stay in sync with user actions. [[1]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R129-R139) [[2]](diffhunk://#diff-cf2a55fc40ab8265d545d5eb95bc99d7243a4bf1f5803393db2f9a4211d8d968R904-R929)

**UI and Layout Adjustments:**

* Set `TabView.Padding="0"` and adjusted tab header and overlay margins to remove redundant gaps and ensure the new indicator aligns cleanly above tabs. [[1]](diffhunk://#diff-653b67fc1e1111ac33543fbbe336209a80e3ab5bf8d4ab4a2e0064b73e14c160L32-R37) [[2]](diffhunk://#diff-1bf3e290fbf0c21992e36fbb4c71f091898b973e0820d664620d3c609b0b041bL59-R59)
* Removed the old in-tab selection indicator style from `DocumentTab.xaml`, as the active document indicator is now drawn outside the tab.

**Other:**

* Updated `ApplicationDisplayVersion` to `1.0.0` in the application project file, reflecting a new release milestone.

These changes collectively improve the clarity of which document is active, polish tab strip behavior, and lay groundwork for further UI refinement.