### PR TITLE
Move PageManifestParser to Utilities for shared TOML parsing

### DIFF
--- a/Source/Core/Celbridge.Tools/Tools/Page/PageTools.Publish.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Page/PageTools.Publish.cs
@@ -2,8 +2,6 @@ using System.IO.Compression;
 using System.Text.Json;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
-using Tomlyn;
-using Tomlyn.Model;
 using MemoryStream = System.IO.MemoryStream;
 using Path = System.IO.Path;
 
@@ -202,37 +200,15 @@ public partial class PageTools
         {
             return Result.Fail($"Failed to read page manifest: {readResult.FirstErrorMessage}");
         }
-        var tomlContent = readResult.Value;
 
-        TomlTable? tomlTable;
-        try
+        var parseResult = PageManifestParser.ParsePublishPath(readResult.Value);
+        if (parseResult.IsFailure)
         {
-            tomlTable = TomlSerializer.Deserialize<TomlTable>(tomlContent);
-        }
-        catch (TomlException exception)
-        {
-            return Result.Fail($"Invalid TOML in page manifest: {exception.Message}");
+            return Result<string>.Fail($"{parseResult.FirstErrorMessage}: {manifestPath}")
+                .WithErrors(parseResult);
         }
 
-        if (tomlTable is null)
-        {
-            return Result.Fail($"Page manifest '{PageConstants.ManifestFileName}' is empty or not a valid TOML table.");
-        }
-
-        if (!tomlTable.TryGetValue("publish", out var publishSection)
-            || publishSection is not TomlTable publishTable)
-        {
-            return Result.Fail($"Page manifest is missing the required [publish] section in '{PageConstants.ManifestFileName}'.");
-        }
-
-        if (!publishTable.TryGetValue("path", out var pathValue)
-            || pathValue is not string pathString
-            || string.IsNullOrWhiteSpace(pathString))
-        {
-            return Result.Fail($"Page manifest is missing a required 'path' field in the [publish] section.");
-        }
-
-        return pathString.Trim();
+        return parseResult;
     }
 
     // Zips the whole folder, including pages.toml. The current server reads the

--- a/Source/Core/Celbridge.Utilities/Celbridge.Utilities.csproj
+++ b/Source/Core/Celbridge.Utilities/Celbridge.Utilities.csproj
@@ -25,5 +25,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Celbridge.Foundation\Celbridge.Foundation.csproj" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <PackageReference Include="Tomlyn" />
+  </ItemGroup>
+
 </Project>

--- a/Source/Core/Celbridge.Utilities/Helpers/PageManifestParser.cs
+++ b/Source/Core/Celbridge.Utilities/Helpers/PageManifestParser.cs
@@ -1,8 +1,8 @@
-using Celbridge.Utilities;
+using Celbridge.FileSystem;
 using Tomlyn;
 using Tomlyn.Model;
 
-namespace Celbridge.Projects;
+namespace Celbridge.Utilities;
 
 /// <summary>
 /// Reads a page manifest (pages.toml): the required [publish].path that names the served path of a page's

--- a/Source/Tests/Utilities/PageManifestParserTests.cs
+++ b/Source/Tests/Utilities/PageManifestParserTests.cs
@@ -1,6 +1,4 @@
-using Celbridge.Projects;
-
-namespace Celbridge.Tests.Projects;
+namespace Celbridge.Tests.Utilities;
 
 /// <summary>
 /// Unit tests for PageManifestParser, which reads the [publish].path from a page's pages.toml manifest.

--- a/Source/Workspace/Celbridge.ProjectSettings/ViewModels/PagesSectionViewModel.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/ViewModels/PagesSectionViewModel.cs
@@ -1,7 +1,7 @@
 using System.Collections.ObjectModel;
 using Celbridge.Packages;
-using Celbridge.Projects;
 using Celbridge.Resources;
+using Celbridge.Utilities;
 
 namespace Celbridge.ProjectSettings.ViewModels;
 


### PR DESCRIPTION
This pull request refactors how the `[publish].path` field is parsed from a page manifest, centralizing the logic in the `PageManifestParser` and updating references throughout the codebase. It also moves and renames related files and updates dependencies to ensure consistent TOML parsing.

**Refactoring and code organization:**

* Moved `PageManifestParser` from `Celbridge.Projects` to `Celbridge.Utilities`, updated its namespace to `Celbridge.Utilities`, and updated all references to use the new location. [[1]](diffhunk://#diff-250e50113e0a15880b8f630882a6f7eae15d101ac45354bc00a6938b4ad80afbL1-R5) [[2]](diffhunk://#diff-eb49f5ccc47f9b3355bde71719a42531b590eaa1786d7d6b8421b9c591ef5d16L3-R4) [[3]](diffhunk://#diff-553c1ad6df2984e4dbcf9fcede042fe233a84449fc0d1947f8ca015f34d99ed6L1-R1)
* Renamed the corresponding test file to `PageManifestParserTests.cs` and moved it to `Celbridge.Tests.Utilities`.

**Manifest parsing logic improvements:**

* Refactored `ReadManifestPublishPathAsync` in `PageTools.Publish.cs` to delegate TOML parsing to `PageManifestParser.ParsePublishPath`, improving error handling and code clarity.

**Dependency management:**

* Added the `Tomlyn` package as a dependency to `Celbridge.Utilities` to support TOML parsing.

**Code cleanup:**

* Removed direct `Tomlyn` and `Tomlyn.Model` imports from `PageTools.Publish.cs`, since parsing is now handled by the utility.Relocates `PageManifestParser` from `Celbridge.Projects` into `Celbridge.Utilities` so TOML manifest parsing can be shared across components. `PageTools.Publish` now uses the shared parser instead of duplicating `[publish].path` parsing logic, and returns parser failures with manifest path context. Updated project and test namespaces/usings accordingly, and added `Tomlyn` to `Celbridge.Utilities` for the parser dependency.