### PR TITLE
Enhance section tab selections and improve macOS view clipping

### DIFF
--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentsPanel.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentsPanel.cs
@@ -18,6 +18,18 @@ public interface IDocumentsPanel
     ResourceKey ActiveDocument { get; set; }
 
     /// <summary>
+    /// The document the section currently has selected, or Empty when it holds none. A section keeps its
+    /// selection while its area is hidden, so a hidden section still reports one.
+    /// </summary>
+    ResourceKey GetSectionSelection(DocumentSection section);
+
+    /// <summary>
+    /// Selects a document within its own section without making it the active document. A resource that is
+    /// not open in that section is ignored.
+    /// </summary>
+    void SetSectionSelection(DocumentSection section, ResourceKey fileResource);
+
+    /// <summary>
     /// The smallest width the panel can be laid out at, composed from the areas it is currently
     /// presenting and the channels between them.
     /// </summary>

--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentsPanel.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentsPanel.cs
@@ -18,8 +18,8 @@ public interface IDocumentsPanel
     ResourceKey ActiveDocument { get; set; }
 
     /// <summary>
-    /// The document the section currently has selected, or Empty when it holds none. A section keeps its
-    /// selection while its area is hidden, so a hidden section still reports one.
+    /// The document the section currently has selected, or Empty when it holds none. A hidden section
+    /// still reports its selection.
     /// </summary>
     ResourceKey GetSectionSelection(DocumentSection section);
 

--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentsPanel.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentsPanel.cs
@@ -18,18 +18,6 @@ public interface IDocumentsPanel
     ResourceKey ActiveDocument { get; set; }
 
     /// <summary>
-    /// The document the section currently has selected, or Empty when it holds none. A hidden section
-    /// still reports its selection.
-    /// </summary>
-    ResourceKey GetSectionSelection(DocumentSection section);
-
-    /// <summary>
-    /// Selects a document within its own section without making it the active document. A resource that is
-    /// not open in that section is ignored.
-    /// </summary>
-    void SetSectionSelection(DocumentSection section, ResourceKey fileResource);
-
-    /// <summary>
     /// The smallest width the panel can be laid out at, composed from the areas it is currently
     /// presenting and the channels between them.
     /// </summary>
@@ -90,6 +78,12 @@ public interface IDocumentsPanel
     /// keeps its own selection, so this is not the same as the active document.
     /// </summary>
     ResourceKey GetSelectedDocument(DocumentSection section);
+
+    /// <summary>
+    /// Selects a document within its own section without making it the active document. A resource that is
+    /// not open in that section is ignored.
+    /// </summary>
+    void SetSelectedDocument(DocumentSection section, ResourceKey fileResource);
 
     /// <summary>
     /// Gets the document view for an already-opened document.

--- a/Source/Core/Celbridge.Foundation/Documents/IGetDocumentStateCommand.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IGetDocumentStateCommand.cs
@@ -6,14 +6,14 @@ namespace Celbridge.Documents;
 /// Snapshot of the documents panel state produced by IGetDocumentStateCommand.
 /// </summary>
 public record class DocumentStateSnapshot(
-    ResourceKey ActiveDocument,
     IReadOnlyList<DocumentSection> VisibleSections,
-    IReadOnlyList<OpenDocumentInfo> OpenDocuments);
+    IReadOnlyList<OpenDocumentInfo> OpenDocuments,
+    IReadOnlyDictionary<DocumentSection, ResourceKey> SelectedDocuments,
+    ResourceKey ActiveDocument);
 
 /// <summary>
-/// Read-only query that captures the current documents panel state (active document,
-/// visible sections, open documents) in a snapshot. Routed through the command queue so
-/// callers observe state that is consistent with all previously enqueued commands.
+/// Read-only query that captures the current documents panel state in a snapshot. Routed through the
+/// command queue so callers observe state that is consistent with all previously enqueued commands.
 /// </summary>
 public interface IGetDocumentStateCommand : IExecutableCommand<DocumentStateSnapshot>
 {

--- a/Source/Core/Celbridge.Tools/Guides/Tools/document_get_state.md
+++ b/Source/Core/Celbridge.Tools/Guides/Tools/document_get_state.md
@@ -27,11 +27,12 @@ The Focus and Presentation layout modes give the active document's area the whol
 
 A JSON object with these fields:
 
-- `activeDocument` (string) — resource key of the active document, or empty when no document is active.
 - `visibleSections` (array of string) — the section names currently on screen, in reading order.
 - `openDocuments` (array) — every open document tab, including tabs in a collapsed area. Each entry has:
   - `resource` (string) — the document's resource key.
   - `section` (string) — which section the tab lives in, as one of the names above.
   - `tabOrder` (int) — position within that section's tab strip.
-  - `isActive` (bool) — `true` for the active tab in its section.
+  - `isActive` (bool) — `true` for the one active document.
   - `editorId` (string) — the bound editor id (e.g. `"celbridge.code"`), or empty when no editor is bound yet.
+- `selectedDocuments` (object) — the document each section is currently showing, keyed by section name. A section holding no documents is omitted, and a section whose area is hidden still reports its selection.
+- `activeDocument` (string) — resource key of the active document, or empty when no document is active. It is one of the selected documents above: the one the user is working in.

--- a/Source/Core/Celbridge.Tools/Tools/Document/DocumentStateProvider.cs
+++ b/Source/Core/Celbridge.Tools/Tools/Document/DocumentStateProvider.cs
@@ -7,9 +7,10 @@ namespace Celbridge.Tools;
 /// Result returned by document_get_state with the visual state of the document editor.
 /// </summary>
 public record class DocumentStateResult(
-    string ActiveDocument,
     List<string> VisibleSections,
-    List<OpenDocumentEntry> OpenDocuments);
+    List<OpenDocumentEntry> OpenDocuments,
+    Dictionary<string, string> SelectedDocuments,
+    string ActiveDocument);
 
 /// <summary>
 /// An open document entry within the document_get_state result.
@@ -67,14 +68,18 @@ internal sealed class DocumentStateProvider : IDocumentStateProvider
             .Select(section => section.ToToken())
             .ToList();
 
+        var selectedDocuments = snapshot.SelectedDocuments
+            .ToDictionary(entry => entry.Key.ToToken(), entry => entry.Value.ToString());
+
         // An empty active document key (no document open) serialises as the
         // empty string rather than the canonical "project:" form, so the
         // response field is a clean signal that nothing is active.
         var activeDocumentString = activeDocument.IsEmpty ? string.Empty : activeDocument.ToString();
 
         return new DocumentStateResult(
-            activeDocumentString,
             visibleSections,
-            documents);
+            documents,
+            selectedDocuments,
+            activeDocumentString);
     }
 }

--- a/Source/Tests/Server/AgentResponseFilterTests.cs
+++ b/Source/Tests/Server/AgentResponseFilterTests.cs
@@ -232,6 +232,7 @@ public class AgentResponseFilterTests
         _documentStateProvider.Result = new DocumentStateResult(
             ActiveDocument: "/Notes/README.md",
             VisibleSections: new List<string> { "main_left" },
+            SelectedDocuments: new Dictionary<string, string> { ["main_left"] = "/Notes/README.md" },
             OpenDocuments: new List<OpenDocumentEntry>
             {
                 new OpenDocumentEntry("/Notes/README.md", "main_left", 0, true, "markdown"),
@@ -619,7 +620,7 @@ public class AgentResponseFilterTests
     private sealed class FakeDocumentStateProvider : IDocumentStateProvider
     {
         public Result<DocumentStateResult> Result { get; set; } =
-            new DocumentStateResult("", new List<string> { "main_left" }, new List<OpenDocumentEntry>());
+            new DocumentStateResult(new List<string> { "main_left" }, new List<OpenDocumentEntry>(), new Dictionary<string, string>(), "");
 
         public Task<Result<DocumentStateResult>> GetStateAsync() => Task.FromResult(Result);
     }

--- a/Source/Tests/Tools/DocumentToolTests.cs
+++ b/Source/Tests/Tools/DocumentToolTests.cs
@@ -49,12 +49,13 @@ public class DocumentToolTests
     {
         var activeResource = new ResourceKey("notes/readme.md");
         var snapshot = new DocumentStateSnapshot(
-            activeResource,
             new List<DocumentSection> { DocumentSection.MainLeft },
             new List<OpenDocumentInfo>
             {
                 new(activeResource, new DocumentAddress(0, DocumentSection.MainLeft, 0), EditorId.Empty)
-            });
+            },
+            new Dictionary<DocumentSection, ResourceKey>(),
+            activeResource);
         StubGetStateSnapshot(snapshot);
 
         var tools = new DocumentTools(_services);
@@ -77,13 +78,18 @@ public class DocumentToolTests
         var activeResource = new ResourceKey("src/main.py");
         var otherResource = new ResourceKey("tests/test_main.py");
         var snapshot = new DocumentStateSnapshot(
-            activeResource,
             new List<DocumentSection> { DocumentSection.MainLeft, DocumentSection.MainRight },
             new List<OpenDocumentInfo>
             {
                 new(activeResource, new DocumentAddress(0, DocumentSection.MainLeft, 0), EditorId.Empty),
                 new(otherResource, new DocumentAddress(0, DocumentSection.MainRight, 0), EditorId.Empty)
-            });
+            },
+            new Dictionary<DocumentSection, ResourceKey>
+            {
+                [DocumentSection.MainLeft] = activeResource,
+                [DocumentSection.MainRight] = otherResource
+            },
+            activeResource);
         StubGetStateSnapshot(snapshot);
 
         var tools = new DocumentTools(_services);
@@ -91,6 +97,11 @@ public class DocumentToolTests
 
         root.GetProperty("visibleSections").EnumerateArray().Select(section => section.GetString()).Should().Equal("main_left", "main_right");
         root.GetProperty("openDocuments").GetArrayLength().Should().Be(2);
+
+        // Each section reports what it is showing, while only one of them is the active document.
+        var selectedDocuments = root.GetProperty("selectedDocuments");
+        selectedDocuments.GetProperty("main_left").GetString().Should().Be("project:src/main.py");
+        selectedDocuments.GetProperty("main_right").GetString().Should().Be("project:tests/test_main.py");
 
         var documents = root.GetProperty("openDocuments");
         var activeDoc = documents.EnumerateArray().First(d => d.GetProperty("isActive").GetBoolean());
@@ -107,12 +118,13 @@ public class DocumentToolTests
     {
         var resource = new ResourceKey("packages/widget/index.html");
         var snapshot = new DocumentStateSnapshot(
-            resource,
             new List<DocumentSection> { DocumentSection.MainLeft },
             new List<OpenDocumentInfo>
             {
                 new(resource, new DocumentAddress(0, DocumentSection.MainLeft, 0), new EditorId("celbridge.html-viewer"))
-            });
+            },
+            new Dictionary<DocumentSection, ResourceKey>(),
+            resource);
         StubGetStateSnapshot(snapshot);
 
         var tools = new DocumentTools(_services);
@@ -127,12 +139,13 @@ public class DocumentToolTests
     {
         var resource = new ResourceKey("notes/readme.md");
         var snapshot = new DocumentStateSnapshot(
-            resource,
             new List<DocumentSection> { DocumentSection.MainLeft },
             new List<OpenDocumentInfo>
             {
                 new(resource, new DocumentAddress(0, DocumentSection.MainLeft, 0), EditorId.Empty)
-            });
+            },
+            new Dictionary<DocumentSection, ResourceKey>(),
+            resource);
         StubGetStateSnapshot(snapshot);
 
         var tools = new DocumentTools(_services);
@@ -146,9 +159,10 @@ public class DocumentToolTests
     public async Task GetState_NoDocumentsOpen()
     {
         var snapshot = new DocumentStateSnapshot(
-            ResourceKey.Empty,
             new List<DocumentSection> { DocumentSection.MainLeft },
-            new List<OpenDocumentInfo>());
+            new List<OpenDocumentInfo>(),
+            new Dictionary<DocumentSection, ResourceKey>(),
+            ResourceKey.Empty);
         StubGetStateSnapshot(snapshot);
 
         var tools = new DocumentTools(_services);

--- a/Source/Workspace/Celbridge.Documents/Commands/GetDocumentStateCommand.cs
+++ b/Source/Workspace/Celbridge.Documents/Commands/GetDocumentStateCommand.cs
@@ -1,4 +1,5 @@
 using Celbridge.Commands;
+using Celbridge.Utilities;
 using Celbridge.Workspace;
 
 namespace Celbridge.Documents.Commands;
@@ -11,9 +12,10 @@ public class GetDocumentStateCommand : CommandBase, IGetDocumentStateCommand
 
     public DocumentStateSnapshot ResultValue { get; private set; }
         = new DocumentStateSnapshot(
-            ResourceKey.Empty,
             new[] { DocumentSection.MainLeft },
-            Array.Empty<OpenDocumentInfo>());
+            Array.Empty<OpenDocumentInfo>(),
+            new Dictionary<DocumentSection, ResourceKey>(),
+            ResourceKey.Empty);
 
     public GetDocumentStateCommand(IWorkspaceWrapper workspaceWrapper)
     {
@@ -30,7 +32,17 @@ public class GetDocumentStateCommand : CommandBase, IGetDocumentStateCommand
         var visibleSections = documentsService.VisibleSections;
         var openDocuments = documentsService.GetOpenDocuments();
 
-        ResultValue = new DocumentStateSnapshot(activeDocument, visibleSections, openDocuments);
+        var selectedDocuments = new Dictionary<DocumentSection, ResourceKey>();
+        foreach (var section in DocumentLayoutHelper.AllSections)
+        {
+            var selectedDocument = documentsService.GetSelectedDocument(section);
+            if (!selectedDocument.IsEmpty)
+            {
+                selectedDocuments[section] = selectedDocument;
+            }
+        }
+
+        ResultValue = new DocumentStateSnapshot(visibleSections, openDocuments, selectedDocuments, activeDocument);
 
         return Result.Ok();
     }

--- a/Source/Workspace/Celbridge.Documents/Platform/MacOSHostedViewClipRepair.cs
+++ b/Source/Workspace/Celbridge.Documents/Platform/MacOSHostedViewClipRepair.cs
@@ -1,0 +1,30 @@
+using Microsoft.UI.Xaml;
+
+namespace Celbridge.Documents.Platform;
+
+/// <summary>
+/// Restores the clip that lets the documents panel's hosted native views show through the Skia canvas.
+/// No-op off macOS.
+/// </summary>
+// UNO-BUG: the Skia canvas covers the native views restored into the panel, so a restored document shows
+// nothing until the visual tree changes.
+internal static class MacOSHostedViewClipRepair
+{
+    /// <summary>
+    /// Cycles the panel's visibility so the clip is recomputed against arranged geometry. Both states are
+    /// applied in one dispatcher turn, so the collapsed panel is never presented.
+    /// </summary>
+    public static void Repair(IDocumentsPanel documentsPanel)
+    {
+        if (!OperatingSystem.IsMacOS()
+            || documentsPanel is not FrameworkElement panel)
+        {
+            return;
+        }
+
+        panel.Visibility = Visibility.Collapsed;
+        panel.UpdateLayout();
+        panel.Visibility = Visibility.Visible;
+        panel.UpdateLayout();
+    }
+}

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentLayoutStore.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentLayoutStore.cs
@@ -257,9 +257,7 @@ public class DocumentLayoutStore
             return;
         }
 
-        await RestoreDocumentsAsync(
-            storedLayout.OpenDocumentAddresses,
-            storedLayout.EditorStates);
+        await RestoreDocumentsAsync(storedLayout.OpenDocumentAddresses, storedLayout.EditorStates);
 
         // A document whose file has gone since the last session leaves the section it was restoring into
         // empty, so fold away any split that ended up with nothing in it.
@@ -410,7 +408,6 @@ public class DocumentLayoutStore
         }
     }
 
-
     private void RestoreSectionSelections(IReadOnlyDictionary<string, string>? sectionSelections)
     {
         if (sectionSelections is null)
@@ -427,6 +424,7 @@ public class DocumentLayoutStore
 
             if (!ResourceKey.TryCreate(resource, out var fileResource))
             {
+                _logger.LogWarning($"Invalid resource key '{resource}' found for a previously selected document");
                 continue;
             }
 

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentLayoutStore.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentLayoutStore.cs
@@ -13,7 +13,7 @@ public class DocumentLayoutStore
 {
     private const string OpenDocumentAddressesKey = "OpenDocumentAddresses";
     private const string ActiveDocumentKey = "ActiveDocument";
-    private const string SectionSelectionsKey = "SectionSelections";
+    private const string SelectedDocumentsKey = "SelectedDocuments";
     private const string AreaSplitRatiosKey = "AreaSplitRatios";
     private const string DocumentEditorStatesKey = "DocumentEditorStates";
 
@@ -64,7 +64,7 @@ public class DocumentLayoutStore
 
             await propertyBag.SetPropertyAsync(OpenDocumentAddressesKey, openDocumentAddresses);
 
-            await StoreSectionSelectionsAsync();
+            await StoreSelectedDocumentsAsync();
         }
         catch (Exception ex)
         {
@@ -83,7 +83,7 @@ public class DocumentLayoutStore
             var activeDocument = DocumentsPanel.ActiveDocument;
             await propertyBag.SetPropertyAsync(ActiveDocumentKey, activeDocument.ToString());
 
-            await StoreSectionSelectionsAsync();
+            await StoreSelectedDocumentsAsync();
         }
         catch (Exception ex)
         {
@@ -92,23 +92,23 @@ public class DocumentLayoutStore
     }
 
     // A section keeps its own selected tab.
-    private async Task StoreSectionSelectionsAsync()
+    private async Task StoreSelectedDocumentsAsync()
     {
         try
         {
             var propertyBag = GetPropertyBag();
 
-            var sectionSelections = new Dictionary<string, string>();
+            var selectedDocuments = new Dictionary<string, string>();
             foreach (var section in DocumentLayoutHelper.AllSections)
             {
-                var selectedDocument = DocumentsPanel.GetSectionSelection(section);
+                var selectedDocument = DocumentsPanel.GetSelectedDocument(section);
                 if (!selectedDocument.IsEmpty)
                 {
-                    sectionSelections[section.ToToken()] = selectedDocument.ToString();
+                    selectedDocuments[section.ToToken()] = selectedDocument.ToString();
                 }
             }
 
-            await propertyBag.SetPropertyAsync(SectionSelectionsKey, sectionSelections);
+            await propertyBag.SetPropertyAsync(SelectedDocumentsKey, selectedDocuments);
         }
         catch (Exception ex)
         {
@@ -268,7 +268,7 @@ public class DocumentLayoutStore
 
         // Section selections are applied before the active document, so the active document wins the
         // selection in the section that holds it.
-        RestoreSectionSelections(storedLayout.SectionSelections);
+        RestoreSelectedDocuments(storedLayout.SelectedDocuments);
 
         RestoreActiveDocument(storedLayout.ActiveDocument);
     }
@@ -278,7 +278,7 @@ public class DocumentLayoutStore
         List<StoredDocumentAddress>? OpenDocumentAddresses,
         Dictionary<string, string>? EditorStates,
         string? ActiveDocument,
-        Dictionary<string, string>? SectionSelections);
+        Dictionary<string, string>? SelectedDocuments);
 
     private async Task<StoredLayout> LoadStoredLayoutAsync()
     {
@@ -296,10 +296,10 @@ public class DocumentLayoutStore
         var activeDocument = await TryLoadPropertyAsync<string>(
             propertyBag, ActiveDocumentKey);
 
-        var sectionSelections = await TryLoadPropertyAsync<Dictionary<string, string>>(
-            propertyBag, SectionSelectionsKey);
+        var selectedDocuments = await TryLoadPropertyAsync<Dictionary<string, string>>(
+            propertyBag, SelectedDocumentsKey);
 
-        return new StoredLayout(areaSplitRatios, openDocumentAddresses, editorStates, activeDocument, sectionSelections);
+        return new StoredLayout(areaSplitRatios, openDocumentAddresses, editorStates, activeDocument, selectedDocuments);
     }
 
     // Reads one stored value, treating one that cannot be read as absent. Layout written by an
@@ -408,14 +408,14 @@ public class DocumentLayoutStore
         }
     }
 
-    private void RestoreSectionSelections(IReadOnlyDictionary<string, string>? sectionSelections)
+    private void RestoreSelectedDocuments(IReadOnlyDictionary<string, string>? selectedDocuments)
     {
-        if (sectionSelections is null)
+        if (selectedDocuments is null)
         {
             return;
         }
 
-        foreach (var (sectionToken, resource) in sectionSelections)
+        foreach (var (sectionToken, resource) in selectedDocuments)
         {
             if (!DocumentSectionTokens.TryParse(sectionToken, out var section))
             {
@@ -428,7 +428,7 @@ public class DocumentLayoutStore
                 continue;
             }
 
-            DocumentsPanel.SetSectionSelection(section, fileResource);
+            DocumentsPanel.SetSelectedDocument(section, fileResource);
         }
     }
 

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentLayoutStore.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentLayoutStore.cs
@@ -13,6 +13,7 @@ public class DocumentLayoutStore
 {
     private const string OpenDocumentAddressesKey = "OpenDocumentAddresses";
     private const string ActiveDocumentKey = "ActiveDocument";
+    private const string SectionSelectionsKey = "SectionSelections";
     private const string AreaSplitRatiosKey = "AreaSplitRatios";
     private const string DocumentEditorStatesKey = "DocumentEditorStates";
 
@@ -62,6 +63,8 @@ public class DocumentLayoutStore
                 .ToList();
 
             await propertyBag.SetPropertyAsync(OpenDocumentAddressesKey, openDocumentAddresses);
+
+            await StoreSectionSelectionsAsync();
         }
         catch (Exception ex)
         {
@@ -79,10 +82,38 @@ public class DocumentLayoutStore
             // reports Empty until the workspace page finishes loading, and this runs before that.
             var activeDocument = DocumentsPanel.ActiveDocument;
             await propertyBag.SetPropertyAsync(ActiveDocumentKey, activeDocument.ToString());
+
+            await StoreSectionSelectionsAsync();
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to store the active document");
+        }
+    }
+
+    // A section keeps its own selected tab, so every section restores showing what the user left it
+    // showing.
+    private async Task StoreSectionSelectionsAsync()
+    {
+        try
+        {
+            var propertyBag = GetPropertyBag();
+
+            var sectionSelections = new Dictionary<string, string>();
+            foreach (var section in DocumentLayoutHelper.AllSections)
+            {
+                var selectedDocument = DocumentsPanel.GetSectionSelection(section);
+                if (!selectedDocument.IsEmpty)
+                {
+                    sectionSelections[section.ToToken()] = selectedDocument.ToString();
+                }
+            }
+
+            await propertyBag.SetPropertyAsync(SectionSelectionsKey, sectionSelections);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to store the section selections");
         }
     }
 
@@ -227,7 +258,9 @@ public class DocumentLayoutStore
             return;
         }
 
-        await RestoreDocumentsAsync(storedLayout.OpenDocumentAddresses, storedLayout.EditorStates);
+        await RestoreDocumentsAsync(
+            storedLayout.OpenDocumentAddresses,
+            storedLayout.EditorStates);
 
         // A document whose file has gone since the last session leaves the section it was restoring into
         // empty, so fold away any split that ended up with nothing in it.
@@ -236,6 +269,10 @@ public class DocumentLayoutStore
             DocumentsPanel.ReconcileAreaSplit(area);
         }
 
+        // Section selections are applied before the active document, so the active document wins the
+        // selection in the section that holds it.
+        RestoreSectionSelections(storedLayout.SectionSelections);
+
         RestoreActiveDocument(storedLayout.ActiveDocument);
     }
 
@@ -243,7 +280,8 @@ public class DocumentLayoutStore
         Dictionary<string, StoredAreaSplitRatio>? AreaSplitRatios,
         List<StoredDocumentAddress>? OpenDocumentAddresses,
         Dictionary<string, string>? EditorStates,
-        string? ActiveDocument);
+        string? ActiveDocument,
+        Dictionary<string, string>? SectionSelections);
 
     private async Task<StoredLayout> LoadStoredLayoutAsync()
     {
@@ -261,7 +299,10 @@ public class DocumentLayoutStore
         var activeDocument = await TryLoadPropertyAsync<string>(
             propertyBag, ActiveDocumentKey);
 
-        return new StoredLayout(areaSplitRatios, openDocumentAddresses, editorStates, activeDocument);
+        var sectionSelections = await TryLoadPropertyAsync<Dictionary<string, string>>(
+            propertyBag, SectionSelectionsKey);
+
+        return new StoredLayout(areaSplitRatios, openDocumentAddresses, editorStates, activeDocument, sectionSelections);
     }
 
     // Reads one stored value, treating one that cannot be read as absent. Layout written by an
@@ -367,6 +408,30 @@ public class DocumentLayoutStore
                 _logger.LogWarning(openResult, $"Failed to open previously open document '{fileResource}'");
                 await StoreDocumentEditorStateAsync(fileResource, null);
             }
+        }
+    }
+
+
+    private void RestoreSectionSelections(IReadOnlyDictionary<string, string>? sectionSelections)
+    {
+        if (sectionSelections is null)
+        {
+            return;
+        }
+
+        foreach (var (sectionToken, resource) in sectionSelections)
+        {
+            if (!DocumentSectionTokens.TryParse(sectionToken, out var section))
+            {
+                continue;
+            }
+
+            if (!ResourceKey.TryCreate(resource, out var fileResource))
+            {
+                continue;
+            }
+
+            DocumentsPanel.SetSectionSelection(section, fileResource);
         }
     }
 

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentLayoutStore.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentLayoutStore.cs
@@ -91,8 +91,7 @@ public class DocumentLayoutStore
         }
     }
 
-    // A section keeps its own selected tab, so every section restores showing what the user left it
-    // showing.
+    // A section keeps its own selected tab.
     private async Task StoreSectionSelectionsAsync()
     {
         try

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -282,10 +282,10 @@ public class DocumentsService : IDocumentsService, IDisposable
         RepairHostedViewClip();
     }
 
-    // UNO-BUG: the Skia canvas paints over the native views restored into the panel instead of leaving them
-    // through, so a restored document shows nothing until the visual tree changes. Cycling the panel's
-    // visibility recomputes the clip against arranged geometry. Both states are applied in one dispatcher
-    // turn, so the collapsed panel is never presented.
+    // UNO-BUG: the Skia canvas covers the native views restored into the panel, so a restored document
+    // shows nothing until the visual tree changes. Cycling the panel's visibility recomputes the clip
+    // against arranged geometry. Both states are applied in one dispatcher turn, so the collapsed panel is
+    // never presented.
     private void RepairHostedViewClip()
     {
         if (!OperatingSystem.IsMacOS()

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -278,6 +278,28 @@ public class DocumentsService : IDocumentsService, IDisposable
         _messengerService.Register<DocumentLayoutChangedMessage>(this, OnDocumentLayoutChangedMessage);
         _messengerService.Register<ActiveDocumentChangedMessage>(this, OnActiveDocumentChangedMessage);
         _messengerService.Register<AreaLayoutChangedMessage>(this, OnAreaLayoutChangedMessage);
+
+        RepairHostedViewClip();
+    }
+
+    // UNO-BUG: the Skia canvas paints over the native views restored into the panel instead of leaving them
+    // through, so a restored document shows nothing until the visual tree changes. Cycling the panel's
+    // visibility recomputes the clip against arranged geometry. Both states are applied in one dispatcher
+    // turn, so the collapsed panel is never presented.
+    private void RepairHostedViewClip()
+    {
+        if (!OperatingSystem.IsMacOS()
+            || DocumentsPanel is not Microsoft.UI.Xaml.FrameworkElement panel)
+        {
+            return;
+        }
+
+        panel.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+        panel.UpdateLayout();
+        panel.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+        panel.UpdateLayout();
+
+        _logger.LogDebug("Repaired the hosted view clip after restoring the documents panel");
     }
 
     private void OnActiveDocumentChangedMessage(object recipient, ActiveDocumentChangedMessage message)

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -1,5 +1,6 @@
 using Celbridge.Commands;
 using Celbridge.Documents.Helpers;
+using Celbridge.Documents.Platform;
 using Celbridge.Logging;
 using Celbridge.Messaging;
 using Celbridge.Modules;
@@ -279,27 +280,7 @@ public class DocumentsService : IDocumentsService, IDisposable
         _messengerService.Register<ActiveDocumentChangedMessage>(this, OnActiveDocumentChangedMessage);
         _messengerService.Register<AreaLayoutChangedMessage>(this, OnAreaLayoutChangedMessage);
 
-        RepairHostedViewClip();
-    }
-
-    // UNO-BUG: the Skia canvas covers the native views restored into the panel, so a restored document
-    // shows nothing until the visual tree changes. Cycling the panel's visibility recomputes the clip
-    // against arranged geometry. Both states are applied in one dispatcher turn, so the collapsed panel is
-    // never presented.
-    private void RepairHostedViewClip()
-    {
-        if (!OperatingSystem.IsMacOS()
-            || DocumentsPanel is not Microsoft.UI.Xaml.FrameworkElement panel)
-        {
-            return;
-        }
-
-        panel.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
-        panel.UpdateLayout();
-        panel.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
-        panel.UpdateLayout();
-
-        _logger.LogDebug("Repaired the hosted view clip after restoring the documents panel");
+        MacOSHostedViewClipRepair.Repair(DocumentsPanel);
     }
 
     private void OnActiveDocumentChangedMessage(object recipient, ActiveDocumentChangedMessage message)

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -42,6 +42,31 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
     public IReadOnlyList<DocumentSection> VisibleSections => SectionContainer.Areas.VisibleSections;
 
+    /// <summary>
+    /// The document each section holding documents currently has selected.
+    /// </summary>
+    public ResourceKey GetSectionSelection(DocumentSection section)
+    {
+        var sectionView = SectionContainer.GetSection(section);
+        return sectionView?.GetSelectedDocument() ?? ResourceKey.Empty;
+    }
+
+    /// <summary>
+    /// Selects a document within its own section without making it the active document. A resource that is
+    /// not open in that section is ignored.
+    /// </summary>
+    public void SetSectionSelection(DocumentSection section, ResourceKey fileResource)
+    {
+        var sectionView = SectionContainer.GetSection(section);
+        var documentTab = sectionView?.GetDocumentTab(fileResource);
+        if (documentTab is null)
+        {
+            return;
+        }
+
+        sectionView!.SelectTab(documentTab);
+    }
+
     public ResourceKey ActiveDocument
     {
         get => SectionContainer.ActiveDocument;

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -42,19 +42,12 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
     public IReadOnlyList<DocumentSection> VisibleSections => SectionContainer.Areas.VisibleSections;
 
-    /// <summary>
-    /// The document each section holding documents currently has selected.
-    /// </summary>
     public ResourceKey GetSectionSelection(DocumentSection section)
     {
         var sectionView = SectionContainer.GetSection(section);
         return sectionView?.GetSelectedDocument() ?? ResourceKey.Empty;
     }
 
-    /// <summary>
-    /// Selects a document within its own section without making it the active document. A resource that is
-    /// not open in that section is ignored.
-    /// </summary>
     public void SetSectionSelection(DocumentSection section, ResourceKey fileResource)
     {
         var sectionView = SectionContainer.GetSection(section);

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -42,13 +42,7 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
 
     public IReadOnlyList<DocumentSection> VisibleSections => SectionContainer.Areas.VisibleSections;
 
-    public ResourceKey GetSectionSelection(DocumentSection section)
-    {
-        var sectionView = SectionContainer.GetSection(section);
-        return sectionView?.GetSelectedDocument() ?? ResourceKey.Empty;
-    }
-
-    public void SetSectionSelection(DocumentSection section, ResourceKey fileResource)
+    public void SetSelectedDocument(DocumentSection section, ResourceKey fileResource)
     {
         var sectionView = SectionContainer.GetSection(section);
         var documentTab = sectionView?.GetDocumentTab(fileResource);


### PR DESCRIPTION
This pull request introduces support for tracking and restoring the selected document in each section of the documents panel, in addition to the active document. This allows the UI to remember which tab is selected in every section, not just the one the user is actively working in. The changes span the core data models, persistence logic, and tests, and also include a new utility for macOS UI repair.

**Document selection state enhancements:**

- Added a `selectedDocuments` field to `DocumentStateSnapshot` and `DocumentStateResult` records, representing the selected document in each section, and updated all usages and tests accordingly. [[1]](diffhunk://#diff-2c2fa658eb90398b0168ff5f75f4bc579c2a54aa5f87a43aa6a8ac6529c9558cL9-R16) [[2]](diffhunk://#diff-da3e147156c76fc363f2a6c54a7c2b8878ed1207cf623ab20a5ecf16e3ddc172L10-R13) [[3]](diffhunk://#diff-cfcc57757df653d8590801c36a117abddc5fbd7fb5353c9fe62468e7f1907af4L52-R58) [[4]](diffhunk://#diff-cfcc57757df653d8590801c36a117abddc5fbd7fb5353c9fe62468e7f1907af4L80-R92) [[5]](diffhunk://#diff-cfcc57757df653d8590801c36a117abddc5fbd7fb5353c9fe62468e7f1907af4L110-R127) [[6]](diffhunk://#diff-cfcc57757df653d8590801c36a117abddc5fbd7fb5353c9fe62468e7f1907af4L130-R148) [[7]](diffhunk://#diff-cfcc57757df653d8590801c36a117abddc5fbd7fb5353c9fe62468e7f1907af4L149-R165) [[8]](diffhunk://#diff-7c1cfddf69a86842a99c8a2433d86ff17f6c04c0e85d5900d51236bf66a78ff9L14-R18) [[9]](diffhunk://#diff-7c1cfddf69a86842a99c8a2433d86ff17f6c04c0e85d5900d51236bf66a78ff9L33-R45) [[10]](diffhunk://#diff-d78ede22e7ca84d6e1d3af568b77880eab77f3bfe9e9bab0456417cfcc0ea9ebR235) [[11]](diffhunk://#diff-d78ede22e7ca84d6e1d3af568b77880eab77f3bfe9e9bab0456417cfcc0ea9ebL622-R623)
- Updated the documentation (`document_get_state.md`) to describe the new `selectedDocuments` field and clarify the relationship between `selectedDocuments` and `activeDocument`.

**Persistence and restoration improvements:**

- Implemented storage and restoration of section selections (`selectedDocuments`) in `DocumentLayoutStore`, ensuring the selected tab in each section is saved and restored along with open documents and the active document. [[1]](diffhunk://#diff-65cde7e5e86f137978bcfa185c2ff81af6edaeacee2276c25c6d72c6b4d708a6R16) [[2]](diffhunk://#diff-65cde7e5e86f137978bcfa185c2ff81af6edaeacee2276c25c6d72c6b4d708a6R66-R67) [[3]](diffhunk://#diff-65cde7e5e86f137978bcfa185c2ff81af6edaeacee2276c25c6d72c6b4d708a6R85-R118) [[4]](diffhunk://#diff-65cde7e5e86f137978bcfa185c2ff81af6edaeacee2276c25c6d72c6b4d708a6R269-R281) [[5]](diffhunk://#diff-65cde7e5e86f137978bcfa185c2ff81af6edaeacee2276c25c6d72c6b4d708a6L264-R302) [[6]](diffhunk://#diff-65cde7e5e86f137978bcfa185c2ff81af6edaeacee2276c25c6d72c6b4d708a6R411-R434)

**API and interface updates:**

- Added a new method `SetSelectedDocument` to the `IDocumentsPanel` interface, allowing explicit selection of a document in a given section without making it active.

**Platform-specific utility:**

- Introduced `MacOSHostedViewClipRepair`, a utility to address a UI issue on macOS where native views may be obscured by the Skia canvas after restoring documents.

These changes collectively improve the fidelity of document panel state tracking and restoration, especially for multi-section layouts, and fix related UI and persistence issues.