### PR TITLE
Enhance macOS WebView keepalive, logging, and error diagnostics

### DIFF
--- a/Source/Core/Celbridge.Host/Services/ProxyHostChannel.cs
+++ b/Source/Core/Celbridge.Host/Services/ProxyHostChannel.cs
@@ -41,6 +41,34 @@ public sealed class ProxyHostChannel : IHostChannel, IDisposable
         _logger = ServiceLocator.AcquireService<ILogger<ProxyHostChannel>>();
     }
 
+    /// <summary>
+    /// Whether a transport is bound.
+    /// </summary>
+    public bool IsBound
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _boundChannel is not null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The number of outbound messages buffered while no transport is bound.
+    /// </summary>
+    public int PendingOutboundCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _pendingOutbound.Count;
+            }
+        }
+    }
+
     public void PostMessage(string json)
     {
         IHostChannel? boundChannel;

--- a/Source/Core/Celbridge.Host/Services/ProxyHostChannel.cs
+++ b/Source/Core/Celbridge.Host/Services/ProxyHostChannel.cs
@@ -42,30 +42,14 @@ public sealed class ProxyHostChannel : IHostChannel, IDisposable
     }
 
     /// <summary>
-    /// Whether a transport is bound.
+    /// Whether a transport is bound, and how many outbound messages are buffered waiting for one. Both are
+    /// read under the same lock, so the pair always describes one instant.
     /// </summary>
-    public bool IsBound
+    public (bool IsBound, int PendingOutboundCount) GetTransportState()
     {
-        get
+        lock (_gate)
         {
-            lock (_gate)
-            {
-                return _boundChannel is not null;
-            }
-        }
-    }
-
-    /// <summary>
-    /// The number of outbound messages buffered while no transport is bound.
-    /// </summary>
-    public int PendingOutboundCount
-    {
-        get
-        {
-            lock (_gate)
-            {
-                return _pendingOutbound.Count;
-            }
+            return (_boundChannel is not null, _pendingOutbound.Count);
         }
     }
 

--- a/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
@@ -182,26 +182,28 @@ public static class MacOSWebViewInterop
     /// side's owning reference while managed code keeps the raw handle; a later reattach or message then
     /// crashes on the freed view. Pinning the view turns those touches into calls on a live object. The
     /// WebContent renderer is still reclaimed by CloseNativeWebView, so what leaks is the view shell only.
+    /// Returns the background page activity preferences applied to a newly pinned view, or null when the
+    /// view was already pinned.
     /// </summary>
     // UNO-BUG: MacOSNativeElement disposes the native view on Unloaded while the handle stays in use.
-    public static void RetainNativeWebView(IntPtr webView)
+    public static IReadOnlyList<string>? RetainNativeWebView(IntPtr webView)
     {
         if (webView == IntPtr.Zero)
         {
-            return;
+            return null;
         }
 
         lock (_pinnedWebViews)
         {
             if (!_pinnedWebViews.Add(webView))
             {
-                return;
+                return null;
             }
         }
 
         SendMessage(webView, GetSelector("retain"));
 
-        EnableBackgroundPageActivity(webView);
+        return EnableBackgroundPageActivity(webView);
     }
 
     /// <summary>

--- a/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/MacOSWebViewInterop.cs
@@ -182,8 +182,8 @@ public static class MacOSWebViewInterop
     /// side's owning reference while managed code keeps the raw handle; a later reattach or message then
     /// crashes on the freed view. Pinning the view turns those touches into calls on a live object. The
     /// WebContent renderer is still reclaimed by CloseNativeWebView, so what leaks is the view shell only.
-    /// Returns the background page activity preferences applied to a newly pinned view, or null when the
-    /// view was already pinned.
+    /// Returns the background page activity preferences applied to a newly pinned view, or null when
+    /// nothing was pinned.
     /// </summary>
     // UNO-BUG: MacOSNativeElement disposes the native view on Unloaded while the handle stays in use.
     public static IReadOnlyList<string>? RetainNativeWebView(IntPtr webView)
@@ -240,7 +240,7 @@ public static class MacOSWebViewInterop
     /// preferences that were applied, for diagnostics. Private SPI, each guarded by respondsToSelector: so an
     /// OS that drops one degrades rather than crashing.
     /// </summary>
-    public static IReadOnlyList<string> EnableBackgroundPageActivity(IntPtr webView)
+    private static IReadOnlyList<string> EnableBackgroundPageActivity(IntPtr webView)
     {
         var applied = new List<string>();
 

--- a/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
@@ -22,6 +22,23 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
     private bool _checkedInactiveSelection;
     private bool _reportedRemoteInspection;
 
+    // Live hosted web views and when each was last woken. Touched from the UI thread only.
+    private readonly List<KeepAliveEntry> _keepAliveWebViews = new();
+    private DispatcherTimer? _keepAliveTimer;
+
+    private sealed class KeepAliveEntry
+    {
+        public KeepAliveEntry(CoreWebView2 webView)
+        {
+            WebView = webView;
+            LastWokenUtc = DateTime.UtcNow;
+        }
+
+        public CoreWebView2 WebView { get; }
+
+        public DateTime LastWokenUtc { get; set; }
+    }
+
     // The find methods receive only a CoreWebView2, so sessions are keyed by it to recover per-find state.
     private readonly Dictionary<CoreWebView2, FindSession> _findSessions = new();
 
@@ -73,16 +90,15 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
 
             // Pin the native WKWebView for the process lifetime and keep it schedulable while hidden. Uno's
             // native element disposes the view on every Unloaded and later touches the stale handle, which is
-            // a use-after-free. The handle may not be resolvable yet at this point, so the other adapter entry
-            // points that resolve it also pin (RetainNativeWebView is idempotent).
+            // a use-after-free.
             if (OperatingSystem.IsMacOS() && webView.CoreWebView2 is not null)
             {
                 if (MacOSWebViewInterop.TryGetNativeWebViewHandle(webView.CoreWebView2, out var nativeWebViewHandle, out var detail))
                 {
-                    MacOSWebViewInterop.RetainNativeWebView(nativeWebViewHandle);
-                    CheckBackgroundPageActivityOnce(nativeWebViewHandle);
+                    PinNativeWebView(nativeWebViewHandle);
                     KeepSelectionWhileUnfocused(nativeWebViewHandle);
                     ApplyInitialViewportSize(nativeWebViewHandle);
+                    RegisterForKeepAlive(webView.CoreWebView2);
                 }
                 else
                 {
@@ -90,10 +106,9 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
                 }
 
                 // UNO-BUG: the script message handler is registered on every Loaded and never removed.
-                // Uno registers its script message handler on every Loaded and never removes it, so the
-                // second load of a control aborts the process inside WebKit. This control sees a second
-                // load as soon as it leaves the init host for its real container, so drop the handler on
-                // every Unloaded and let Uno's next Loaded register it again.
+                // The second load of a control then aborts the process inside WebKit. This control sees a
+                // second load as soon as it leaves the init host for its real container, so drop the handler
+                // on every Unloaded and let Uno's next Loaded register it again.
                 webView.Unloaded -= WebView_Unloaded;
                 webView.Unloaded += WebView_Unloaded;
             }
@@ -127,12 +142,133 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
     private const double MinimumViewportWidth = 1024;
     private const double MinimumViewportHeight = 768;
 
+    // How long a hosted page may go without being woken. A hidden page's event loop stops entirely after
+    // roughly seven minutes.
+    private const int KeepAliveIntervalSeconds = 180;
+
+    // How often the rotation looks for an overdue page.
+    private const int KeepAliveTickSeconds = 5;
+
+    // Wakes this hosted web view on a rotation. WebKit stops a hidden page's event loop after a few minutes,
+    // so it services no host RPC until the user activates it, and evaluating a trivial script restarts it.
+    private void RegisterForKeepAlive(CoreWebView2 coreWebView2)
+    {
+        if (FindKeepAliveEntry(coreWebView2) is not null)
+        {
+            return;
+        }
+
+        _keepAliveWebViews.Add(new KeepAliveEntry(coreWebView2));
+        StartKeepAliveTimer();
+    }
+
+    private void UnregisterFromKeepAlive(CoreWebView2 coreWebView2)
+    {
+        var entry = FindKeepAliveEntry(coreWebView2);
+        if (entry is null)
+        {
+            return;
+        }
+
+        _keepAliveWebViews.Remove(entry);
+
+        if (_keepAliveWebViews.Count == 0)
+        {
+            _keepAliveTimer?.Stop();
+        }
+    }
+
+    private KeepAliveEntry? FindKeepAliveEntry(CoreWebView2 coreWebView2)
+    {
+        foreach (var entry in _keepAliveWebViews)
+        {
+            if (entry.WebView == coreWebView2)
+            {
+                return entry;
+            }
+        }
+
+        return null;
+    }
+
+    // The tick never changes and a running timer is left alone, so a burst of document opens and closes
+    // cannot keep restarting the countdown and starve the wake.
+    private void StartKeepAliveTimer()
+    {
+        if (_keepAliveTimer is null)
+        {
+            _keepAliveTimer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(KeepAliveTickSeconds)
+            };
+            _keepAliveTimer.Tick += OnKeepAliveTick;
+
+            _logger.LogDebug(
+                "Waking each hosted page every {Seconds}s so hidden pages keep running",
+                KeepAliveIntervalSeconds);
+        }
+
+        if (!_keepAliveTimer.IsEnabled)
+        {
+            _keepAliveTimer.Start();
+        }
+    }
+
+    // At most one view is woken per tick, so the web content processes never resume together.
+    private void OnKeepAliveTick(object? sender, object e)
+    {
+        if (_keepAliveWebViews.Count == 0)
+        {
+            _keepAliveTimer?.Stop();
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var dueAfter = TimeSpan.FromSeconds(KeepAliveIntervalSeconds);
+
+        KeepAliveEntry? mostOverdue = null;
+        foreach (var entry in _keepAliveWebViews)
+        {
+            if (now - entry.LastWokenUtc < dueAfter)
+            {
+                continue;
+            }
+
+            if (mostOverdue is null
+                || entry.LastWokenUtc < mostOverdue.LastWokenUtc)
+            {
+                mostOverdue = entry;
+            }
+        }
+
+        if (mostOverdue is null)
+        {
+            return;
+        }
+
+        mostOverdue.LastWokenUtc = now;
+
+        _ = WakePageAsync(mostOverdue.WebView);
+    }
+
+    // A view torn down between the tick and this call throws here, which is not an error.
+    private async Task WakePageAsync(CoreWebView2 coreWebView2)
+    {
+        try
+        {
+            await EvalAsync(coreWebView2, "0");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not wake a hosted page");
+        }
+    }
+
     // UNO-BUG: the native frame is arranged only while the control is in the visual tree.
-    // Gives the native view a usable frame before anything loads into it. Uno arranges the frame only while
-    // the control is in the visual tree, so a surface that loads while it is not (a document restored into a
-    // background tab, a utility running from project load) reports a zero-sized window to its page: layout
-    // collapses, and a page that derives geometry from the viewport at startup divides by zero and stays
-    // broken even after the real arrange arrives.
+    // A surface that loads while it is not (a document restored into a background tab, a utility running
+    // from project load) reports a zero-sized window to its page: layout collapses, and a page that derives
+    // geometry from the viewport at startup divides by zero and stays broken even after the real arrange
+    // arrives.
     private void ApplyInitialViewportSize(IntPtr nativeWebViewHandle)
     {
         var userInterfaceService = ServiceLocator.AcquireService<IUserInterfaceService>();
@@ -151,10 +287,23 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
     }
 
     // WebKit suspends a hidden page's process, which stalls host-to-editor RPC for a background document
-    // tab until the tab is shown again. RetainNativeWebView turns that suppression off through private SPI,
-    // so this reports once per session whether the SPI still exists: losing it silently brings the stall back.
-    private void CheckBackgroundPageActivityOnce(IntPtr nativeWebViewHandle)
+    // tab until the tab is shown again.
+    private void PinNativeWebView(IntPtr nativeWebViewHandle)
     {
+        var applied = MacOSWebViewInterop.RetainNativeWebView(nativeWebViewHandle);
+        if (applied is null)
+        {
+            return;
+        }
+
+        if (applied.Count < MacOSWebViewInterop.BackgroundPageActivityPreferenceCount)
+        {
+            _logger.LogWarning(
+                "WebKit did not accept every background page activity preference for this web view, so its document may stop servicing host RPC while it is a background tab. Applied: {Applied}",
+                applied.Count == 0 ? "none" : string.Join(", ", applied));
+            return;
+        }
+
         if (_checkedBackgroundActivity)
         {
             return;
@@ -162,16 +311,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
 
         _checkedBackgroundActivity = true;
 
-        var applied = MacOSWebViewInterop.EnableBackgroundPageActivity(nativeWebViewHandle);
-        if (applied.Count == MacOSWebViewInterop.BackgroundPageActivityPreferenceCount)
-        {
-            _logger.LogDebug("Background page activity preferences applied: {Applied}", string.Join(", ", applied));
-            return;
-        }
-
-        _logger.LogWarning(
-            "WebKit no longer exposes every background page activity preference, so background documents may stop servicing host RPC. Applied: {Applied}",
-            applied.Count == 0 ? "none" : string.Join(", ", applied));
+        _logger.LogDebug("Background page activity preferences applied: {Applied}", string.Join(", ", applied));
     }
 
     // Managed focus moves resign the web view's first responder status, and WebKit discards the page's
@@ -214,6 +354,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
         if (webView.CoreWebView2 is not null)
         {
             _findSessions.Remove(webView.CoreWebView2);
+            UnregisterFromKeepAlive(webView.CoreWebView2);
         }
 
         container?.Children.Remove(webView);
@@ -237,7 +378,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
         {
             if (MacOSWebViewInterop.TryGetNativeWebViewHandle(webView.CoreWebView2, out var nativeHandle, out var detail))
             {
-                MacOSWebViewInterop.RetainNativeWebView(nativeHandle);
+                PinNativeWebView(nativeHandle);
                 MacOSWebViewInterop.MakeWebViewFirstResponder(nativeHandle);
             }
             else
@@ -351,10 +492,10 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
     public void PostMessageToWeb(CoreWebView2 coreWebView2, string json)
     {
         // UNO-BUG: PostWebMessageAsString is unimplemented on the Skia WebView2.
-        // PostWebMessageAsString does not deliver on the Uno Skia WebView2 (the C#->JS half of web messaging is
-        // unimplemented). Push the message by invoking a JS dispatch function via ExecuteScriptAsync, which the
-        // client transport registers. The JS->C# direction (chrome.webview.postMessage -> WebMessageReceived)
-        // works and is unchanged. Serializing the JSON yields a safely-escaped JS string literal.
+        // The C#->JS half of web messaging never delivers, so push the message by invoking a JS dispatch
+        // function via ExecuteScriptAsync, which the client transport registers. The JS->C# direction
+        // (chrome.webview.postMessage -> WebMessageReceived) works. Serializing the JSON yields a
+        // safely-escaped JS string literal.
         var encodedJson = JsonSerializer.Serialize(json);
         var script = $"window.__hostReceiveMessage && window.__hostReceiveMessage({encodedJson});";
 
@@ -384,7 +525,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
         if (OperatingSystem.IsMacOS()
             && MacOSWebViewInterop.TryGetNativeWebViewHandle(coreWebView2, out var nativeHandle, out _))
         {
-            MacOSWebViewInterop.RetainNativeWebView(nativeHandle);
+            PinNativeWebView(nativeHandle);
             MacOSWebViewInterop.AddUserScriptAtDocumentStart(nativeHandle, script);
         }
 
@@ -424,7 +565,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
             return;
         }
 
-        MacOSWebViewInterop.RetainNativeWebView(nativeHandle);
+        PinNativeWebView(nativeHandle);
 
         _safariVersion ??= ResolveSafariVersion();
 
@@ -474,7 +615,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
             return;
         }
 
-        MacOSWebViewInterop.RetainNativeWebView(nativeHandle);
+        PinNativeWebView(nativeHandle);
 
         var inspectable = MacOSWebViewInterop.SetInspectable(nativeHandle, enabled);
 
@@ -533,7 +674,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
                 $"Could not reach the native WKWebView handle to load HTML: {detail}");
         }
 
-        MacOSWebViewInterop.RetainNativeWebView(nativeHandle);
+        PinNativeWebView(nativeHandle);
         MacOSWebViewInterop.LoadHtmlString(nativeHandle, html, baseUrl);
     }
 
@@ -561,7 +702,7 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
             return;
         }
 
-        MacOSWebViewInterop.RetainNativeWebView(nativeHandle);
+        PinNativeWebView(nativeHandle);
 
         var session = new FindSession(term, options.CaseSensitive, options.OnMatchStateChanged);
         _findSessions[coreWebView2] = session;

--- a/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
+++ b/Source/Core/Celbridge.WebHost/Platform/SkiaWebViewAdapter.cs
@@ -22,22 +22,8 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
     private bool _checkedInactiveSelection;
     private bool _reportedRemoteInspection;
 
-    // Live hosted web views and when each was last woken. Touched from the UI thread only.
-    private readonly List<KeepAliveEntry> _keepAliveWebViews = new();
-    private DispatcherTimer? _keepAliveTimer;
-
-    private sealed class KeepAliveEntry
-    {
-        public KeepAliveEntry(CoreWebView2 webView)
-        {
-            WebView = webView;
-            LastWokenUtc = DateTime.UtcNow;
-        }
-
-        public CoreWebView2 WebView { get; }
-
-        public DateTime LastWokenUtc { get; set; }
-    }
+    // The wake loop running for each live hosted web view, keyed by the view it wakes.
+    private readonly Dictionary<CoreWebView2, CancellationTokenSource> _keepAliveLoops = new();
 
     // The find methods receive only a CoreWebView2, so sessions are keyed by it to recover per-find state.
     private readonly Dictionary<CoreWebView2, FindSession> _findSessions = new();
@@ -98,12 +84,13 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
                     PinNativeWebView(nativeWebViewHandle);
                     KeepSelectionWhileUnfocused(nativeWebViewHandle);
                     ApplyInitialViewportSize(nativeWebViewHandle);
-                    RegisterForKeepAlive(webView.CoreWebView2);
                 }
                 else
                 {
                     _logger.LogDebug("Native WKWebView handle not resolvable after init ({Detail}); pinning deferred to first resolution", detail);
                 }
+
+                RegisterForKeepAlive(webView.CoreWebView2);
 
                 // UNO-BUG: the script message handler is registered on every Loaded and never removed.
                 // The second load of a control then aborts the process inside WebKit. This control sees a
@@ -143,124 +130,76 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
     private const double MinimumViewportHeight = 768;
 
     // How long a hosted page may go without being woken. A hidden page's event loop stops entirely after
-    // roughly seven minutes.
-    private const int KeepAliveIntervalSeconds = 180;
+    // roughly seven minutes, so a page that has gone quiet is running again well inside the timeouts that
+    // wait on it.
+    private const int KeepAliveIntervalSeconds = 30;
 
-    // How often the rotation looks for an overdue page.
-    private const int KeepAliveTickSeconds = 5;
+    // Spread added to every wake, so pages registered together do not settle into waking in the same instant.
+    private const int KeepAliveJitterSeconds = 5;
 
-    // Wakes this hosted web view on a rotation. WebKit stops a hidden page's event loop after a few minutes,
-    // so it services no host RPC until the user activates it, and evaluating a trivial script restarts it.
+    // Wakes this hosted web view until it is closed. WebKit stops a hidden page's event loop after a few
+    // minutes, so it services no host RPC until the user activates it, and evaluating a trivial script
+    // restarts it.
     private void RegisterForKeepAlive(CoreWebView2 coreWebView2)
     {
-        if (FindKeepAliveEntry(coreWebView2) is not null)
+        CancellationTokenSource cancellationTokenSource;
+
+        lock (_keepAliveLoops)
         {
-            return;
+            if (_keepAliveLoops.ContainsKey(coreWebView2))
+            {
+                return;
+            }
+
+            cancellationTokenSource = new CancellationTokenSource();
+            _keepAliveLoops.Add(coreWebView2, cancellationTokenSource);
         }
 
-        _keepAliveWebViews.Add(new KeepAliveEntry(coreWebView2));
-        StartKeepAliveTimer();
+        _ = KeepPageAwakeAsync(coreWebView2, cancellationTokenSource.Token);
     }
 
     private void UnregisterFromKeepAlive(CoreWebView2 coreWebView2)
     {
-        var entry = FindKeepAliveEntry(coreWebView2);
-        if (entry is null)
-        {
-            return;
-        }
+        CancellationTokenSource? cancellationTokenSource;
 
-        _keepAliveWebViews.Remove(entry);
-
-        if (_keepAliveWebViews.Count == 0)
+        lock (_keepAliveLoops)
         {
-            _keepAliveTimer?.Stop();
-        }
-    }
-
-    private KeepAliveEntry? FindKeepAliveEntry(CoreWebView2 coreWebView2)
-    {
-        foreach (var entry in _keepAliveWebViews)
-        {
-            if (entry.WebView == coreWebView2)
+            if (!_keepAliveLoops.Remove(coreWebView2, out cancellationTokenSource))
             {
-                return entry;
+                return;
             }
         }
 
-        return null;
+        cancellationTokenSource.Cancel();
+        cancellationTokenSource.Dispose();
     }
 
-    // The tick never changes and a running timer is left alone, so a burst of document opens and closes
-    // cannot keep restarting the countdown and starve the wake.
-    private void StartKeepAliveTimer()
+    // The delay must resume on the UI thread, where the script evaluation has to run, so the awaits here
+    // are never configured away from the dispatcher.
+    private async Task KeepPageAwakeAsync(CoreWebView2 coreWebView2, CancellationToken cancellationToken)
     {
-        if (_keepAliveTimer is null)
+        while (true)
         {
-            _keepAliveTimer = new DispatcherTimer
+            try
             {
-                Interval = TimeSpan.FromSeconds(KeepAliveTickSeconds)
-            };
-            _keepAliveTimer.Tick += OnKeepAliveTick;
+                var jitter = TimeSpan.FromMilliseconds(Random.Shared.Next(0, KeepAliveJitterSeconds * 1000));
+                await Task.Delay(TimeSpan.FromSeconds(KeepAliveIntervalSeconds) + jitter, cancellationToken);
 
-            _logger.LogDebug(
-                "Waking each hosted page every {Seconds}s so hidden pages keep running",
-                KeepAliveIntervalSeconds);
-        }
-
-        if (!_keepAliveTimer.IsEnabled)
-        {
-            _keepAliveTimer.Start();
-        }
-    }
-
-    // At most one view is woken per tick, so the web content processes never resume together.
-    private void OnKeepAliveTick(object? sender, object e)
-    {
-        if (_keepAliveWebViews.Count == 0)
-        {
-            _keepAliveTimer?.Stop();
-            return;
-        }
-
-        var now = DateTime.UtcNow;
-        var dueAfter = TimeSpan.FromSeconds(KeepAliveIntervalSeconds);
-
-        KeepAliveEntry? mostOverdue = null;
-        foreach (var entry in _keepAliveWebViews)
-        {
-            if (now - entry.LastWokenUtc < dueAfter)
-            {
-                continue;
+                await EvalAsync(coreWebView2, "0");
             }
-
-            if (mostOverdue is null
-                || entry.LastWokenUtc < mostOverdue.LastWokenUtc)
+            catch (OperationCanceledException)
             {
-                mostOverdue = entry;
+                return;
             }
-        }
-
-        if (mostOverdue is null)
-        {
-            return;
-        }
-
-        mostOverdue.LastWokenUtc = now;
-
-        _ = WakePageAsync(mostOverdue.WebView);
-    }
-
-    // A view torn down between the tick and this call throws here, which is not an error.
-    private async Task WakePageAsync(CoreWebView2 coreWebView2)
-    {
-        try
-        {
-            await EvalAsync(coreWebView2, "0");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Could not wake a hosted page");
+            catch (ObjectDisposedException)
+            {
+                // The view was torn down without reaching CloseWebView, so there is nothing left to wake.
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Could not wake a hosted page");
+            }
         }
     }
 
@@ -290,6 +229,12 @@ public sealed class SkiaWebViewAdapter : IWebViewAdapter
     // tab until the tab is shown again.
     private void PinNativeWebView(IntPtr nativeWebViewHandle)
     {
+        if (nativeWebViewHandle == IntPtr.Zero)
+        {
+            _logger.LogWarning("Cannot pin a null native WKWebView handle, so this web view keeps neither its native view nor its background page activity");
+            return;
+        }
+
         var applied = MacOSWebViewInterop.RetainNativeWebView(nativeWebViewHandle);
         if (applied is null)
         {

--- a/Source/Core/Celbridge.WebHost/Services/WebViewFactory.cs
+++ b/Source/Core/Celbridge.WebHost/Services/WebViewFactory.cs
@@ -223,14 +223,16 @@ public class WebViewFactory : IWebViewFactory, IDisposable
         _logger.LogDebug("WebViewFactory shutdown complete");
     }
 
-    private static void CloseWebView(WebView2? webView)
+    // Closed through the adapter rather than WebView2.Close, which reaches neither the macOS native
+    // teardown nor the per-view state the adapter holds while a view is alive.
+    private void CloseWebView(WebView2? webView)
     {
         if (webView == null)
             return;
 
         try
         {
-            webView.Close();
+            _webViewAdapter.CloseWebView(webView, container: null);
         }
         catch
         {

--- a/Source/Core/Celbridge.WebHost/Web/celbridge-client/api/log-api.js
+++ b/Source/Core/Celbridge.WebHost/Web/celbridge-client/api/log-api.js
@@ -48,7 +48,27 @@ export class LogAPI {
      * @param {Error} [error] - Appended with its stack when supplied.
      */
     error(message, error = null) {
-        const detail = error && error.stack ? `${message}: ${error.stack}` : message;
+        if (error === null || error === undefined) {
+            this.#write('error', message);
+            return;
+        }
+
+        // WebKit's Error.stack carries only the frames, so an error reported through the stack alone reaches
+        // the log without the one line that says what went wrong. V8 prefixes the stack with the same text,
+        // which is why it is only added when the stack does not already open with it.
+        const name = error.name ?? 'Error';
+        const reason = error.message ? `${name}: ${error.message}` : name;
+        const stack = error.stack ?? '';
+
+        let detail;
+        if (!stack) {
+            detail = `${message}: ${reason}`;
+        } else if (stack.startsWith(name)) {
+            detail = `${message}: ${stack}`;
+        } else {
+            detail = `${message}: ${reason}\n${stack}`;
+        }
+
         this.#write('error', detail);
     }
 

--- a/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
+++ b/Source/Modules/Celbridge.Spreadsheet/Package/spreadsheet.js
@@ -280,9 +280,16 @@ function initializeSpreadsheet() {
     } catch (e) {
         const container = document.getElementById('gc-designer-container');
         // The container size is logged because a WebView that loads while unarranged reports a zero viewport.
+        // The rest is state nothing else can recover: this package blocks DevTools and the webview_* tools to
+        // keep the license keys out of reach, so the log is the only account of a failure here. The keys
+        // themselves are never reported, only that the constructor was reached with them applied.
         client.log.error('[Spreadsheet] Designer construction failed'
             + ' (container ' + (container ? container.clientWidth + 'x' + container.clientHeight : 'missing')
-            + ', viewport ' + window.innerWidth + 'x' + window.innerHeight + ')', e);
+            + ', viewport ' + window.innerWidth + 'x' + window.innerHeight
+            + ', readyState ' + document.readyState
+            + ', stylesheets ' + document.styleSheets.length
+            + ', spreadjs ' + (GC?.Spread?.Sheets?.version ?? 'unknown')
+            + ', designer ' + typeof GC?.Spread?.Sheets?.Designer?.Designer + ')', e);
         return false;
     }
 }

--- a/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
@@ -1012,7 +1012,17 @@ public sealed class CustomEditorController : IHostInput, IHostContext, IEditTarg
 
         if (completedTask != requestStateTask)
         {
-            _logger.LogWarning("Editor did not return state within {Seconds}s; closing without preserving editor state.", EditorStateRequestTimeoutSeconds);
+            // A bound channel with nothing pending means the page received the request and did not service it.
+            var channelState = "direct transport";
+            if (_proxyChannel is not null)
+            {
+                channelState = $"bound {_proxyChannel.IsBound}, pending outbound {_proxyChannel.PendingOutboundCount}";
+            }
+
+            _logger.LogWarning(
+                "Editor did not return state within {Seconds}s; closing without preserving editor state. File: {File}, channel {ChannelState}",
+                EditorStateRequestTimeoutSeconds, _viewModel.FilePath, channelState);
+
             ObserveAbandonedRequest(requestStateTask);
             return null;
         }

--- a/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
@@ -1012,16 +1012,18 @@ public sealed class CustomEditorController : IHostInput, IHostContext, IEditTarg
 
         if (completedTask != requestStateTask)
         {
-            // A bound channel with nothing pending means the page received the request and did not service it.
-            var channelState = "direct transport";
-            if (_proxyChannel is not null)
-            {
-                channelState = $"bound {_proxyChannel.IsBound}, pending outbound {_proxyChannel.PendingOutboundCount}";
-            }
+            // Outbound messages are buffered only while no transport is bound, so a bound channel always
+            // reports nothing pending.
+            var proxyChannel = _proxyChannel;
+            var transportState = proxyChannel?.GetTransportState();
 
             _logger.LogWarning(
-                "Editor did not return state within {Seconds}s; closing without preserving editor state. File: {File}, channel {ChannelState}",
-                EditorStateRequestTimeoutSeconds, _viewModel.FilePath, channelState);
+                "Editor did not return state within {Seconds}s; closing without preserving editor state. File: {File}, proxy channel {HasProxyChannel}, transport bound {IsBound}, pending outbound {PendingOutbound}",
+                EditorStateRequestTimeoutSeconds,
+                _viewModel.FilePath,
+                proxyChannel is not null,
+                transportState?.IsBound,
+                transportState?.PendingOutboundCount);
 
             ObserveAbandonedRequest(requestStateTask);
             return null;


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the host and webview layers, focusing on reliability, diagnostics, and background activity for hosted web views, especially on macOS. The most significant changes include the introduction of a keep-alive mechanism for macOS WebViews to prevent background suspension, improved error logging for better diagnostics, and refactoring of how native views are pinned and managed. Additionally, adapter shutdown now properly tears down per-view state, and spreadsheet diagnostics are enhanced.

**WebView keep-alive and background activity (macOS):**
- Added a keep-alive system (`RegisterForKeepAlive`, `UnregisterFromKeepAlive`, and `KeepPageAwakeAsync`) in `SkiaWebViewAdapter` to periodically wake hidden macOS WebViews, preventing their event loops from being suspended in the background. This includes jitter to avoid synchronized wakeups.
- Refactored and centralized the logic for pinning native WebViews and applying background page activity preferences into a new `PinNativeWebView` method, replacing direct calls to `RetainNativeWebView` throughout the adapter. The method now logs if not all preferences are applied, improving diagnostics when WebKit behavior changes. [[1]](diffhunk://#diff-81a41f07468d8c448e6ed65bb190a3d8cf549418621bfc7fcbe51d4fcfbcf7b0L154-R259) [[2]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dR185-R206) [[3]](diffhunk://#diff-f31591fe34160fa193923b193c07812ffba05e473ebcb48850005e56ed52410dL241-R243)

**Diagnostics and error reporting:**
- Enhanced JavaScript error logging in `LogAPI.error` to always include the error name and message, even when `Error.stack` is incomplete (as on WebKit), ensuring the root cause is visible in logs.
- Improved spreadsheet initialization diagnostics by logging additional state (document readiness, stylesheet count, SpreadJS/designer version) when designer construction fails, aiding in debugging issues that are otherwise inaccessible due to restricted DevTools access.

**Resource management and shutdown:**
- Modified `WebViewFactory` to close WebViews through the adapter, ensuring proper teardown of native resources and per-view state, rather than calling `WebView2.Close` directly.
- On WebView close, the keep-alive loop is now unregistered to prevent resource leaks.

**API and code cleanup:**
- Changed `EnableBackgroundPageActivity` to be private, as it's now only used internally via `PinNativeWebView`.
- Added a new `GetTransportState` method to `ProxyHostChannel` for thread-safe reporting of transport binding and outbound buffer state.