### PR TITLE
Refactor workspace item handling and improve save failure management

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -213,11 +213,21 @@
   <data name="ProjectFile_CannotChangeExtension" xml:space="preserve">
     <value>The project file must keep its {0} extension.</value>
   </data>
-  <data name="Toast_SaveFailed_Single" xml:space="preserve">
-    <value>Could not save '{0}': {1}</value>
+  <data name="Toast_SaveDiscarded" xml:space="preserve">
+    <value>Unsaved changes to '{0}' were discarded</value>
   </data>
-  <data name="Toast_SaveFailed_Multiple" xml:space="preserve">
+  <data name="SaveStatus_Failed_Single" xml:space="preserve">
+    <value>Could not save '{0}'</value>
+  </data>
+  <data name="SaveStatus_Failed_Multiple" xml:space="preserve">
     <value>Could not save {0} files</value>
+  </data>
+  <data name="DocumentTab_Tooltip_WithEditor" xml:space="preserve">
+    <value>{0} - {1}</value>
+  </data>
+  <data name="DocumentTab_Tooltip_SaveFailed" xml:space="preserve">
+    <value>{0}
+This file could not be saved</value>
   </data>
   <data name="Toast_OperationFailed_Delete_Single" xml:space="preserve">
     <value>Could not delete '{0}': {1}</value>

--- a/Source/Core/Celbridge.Commands/Services/CommandService.cs
+++ b/Source/Core/Celbridge.Commands/Services/CommandService.cs
@@ -223,10 +223,18 @@ public class CommandService : ICommandService
 
             // To avoid race conditions, application and workspace state is updated while there are no
             // executing commands. This ensures that no commands run until pending saves complete.
-            var updateResult = await ExecuteWithWatchdogAsync(UpdateApplicationAsync(), "Application update");
-            if (updateResult.IsFailure)
+            try
             {
-                _logger.LogError(updateResult, "Failed to update application");
+                var updateResult = await ExecuteWithWatchdogAsync(UpdateApplicationAsync(), "Application update");
+                if (updateResult.IsFailure)
+                {
+                    _logger.LogError(updateResult, "Failed to update application");
+                }
+            }
+            catch (Exception ex)
+            {
+                // The loop task is not awaited, so an exception that escapes here is never observed.
+                _logger.LogError(ex, "An exception occurred while updating the application.");
             }
 
             // An open dialog is the user being asked a question, so the queue waits for the answer. Only

--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentView.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentView.cs
@@ -5,7 +5,7 @@ namespace Celbridge.Documents;
 /// <summary>
 /// Interface for interacting with a document view.
 /// </summary>
-public interface IDocumentView : ISaveableWorkspaceItem
+public interface IDocumentView : IWorkspaceItem
 {
     /// <summary>
     /// Id of the factory that produced this view. Immutable for the view's lifetime.

--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentsPanel.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentsPanel.cs
@@ -104,9 +104,9 @@ public interface IDocumentsPanel
     Task<Result> CloseDocument(ResourceKey fileResource, CloseDocumentOptions? options = null);
 
     /// <summary>
-    /// The open documents as saveable workspace items. A utility docked into a document tab is not included.
+    /// The open documents as workspace items. A utility docked into a document tab is not included.
     /// </summary>
-    IReadOnlyList<ISaveableWorkspaceItem> GetSaveableItems();
+    IReadOnlyList<IWorkspaceItem> GetWorkspaceItems();
 
     /// <summary>
     /// Activates an opened document in the documents panel, making it the active tab.

--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentsService.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentsService.cs
@@ -100,7 +100,7 @@ public interface IDocumentsService
 
     /// <summary>
     /// Writes the content of every open document that still holds unsaved changes. A document that cannot
-    /// be written is logged and skipped, so the flush always completes.
+    /// be written is skipped.
     /// </summary>
     Task FlushModifiedDocumentsAsync();
 

--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentsService.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentsService.cs
@@ -99,12 +99,6 @@ public interface IDocumentsService
     IReadOnlyList<IWorkspaceItem> GetWorkspaceItems();
 
     /// <summary>
-    /// Writes the content of every open document that still holds unsaved changes. A document that cannot
-    /// be written is skipped.
-    /// </summary>
-    Task FlushModifiedDocumentsAsync();
-
-    /// <summary>
     /// Returns a snapshot of all open documents with their addresses and editor IDs.
     /// This is a cached snapshot that is safe to read from any thread.
     /// </summary>

--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentsService.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentsService.cs
@@ -94,9 +94,9 @@ public interface IDocumentsService
     IReadOnlyList<DocumentSection> VisibleSections { get; }
 
     /// <summary>
-    /// The open documents as saveable workspace items. A utility docked into a document tab is not included.
+    /// The open documents as workspace items. A utility docked into a document tab is not included.
     /// </summary>
-    IReadOnlyList<ISaveableWorkspaceItem> GetSaveableItems();
+    IReadOnlyList<IWorkspaceItem> GetWorkspaceItems();
 
     /// <summary>
     /// Returns a snapshot of all open documents with their addresses and editor IDs.

--- a/Source/Core/Celbridge.Foundation/Documents/IDocumentsService.cs
+++ b/Source/Core/Celbridge.Foundation/Documents/IDocumentsService.cs
@@ -99,6 +99,12 @@ public interface IDocumentsService
     IReadOnlyList<IWorkspaceItem> GetWorkspaceItems();
 
     /// <summary>
+    /// Writes the content of every open document that still holds unsaved changes. A document that cannot
+    /// be written is logged and skipped, so the flush always completes.
+    /// </summary>
+    Task FlushModifiedDocumentsAsync();
+
+    /// <summary>
     /// Returns a snapshot of all open documents with their addresses and editor IDs.
     /// This is a cached snapshot that is safe to read from any thread.
     /// </summary>

--- a/Source/Core/Celbridge.Foundation/Workspace/IUtilityService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IUtilityService.cs
@@ -63,9 +63,9 @@ public interface IUtilityService
     EditorId? GetDockedUtilityId(ResourceKey resource);
 
     /// <summary>
-    /// The utilities as saveable workspace items. A utility docked into a document tab is included.
+    /// The utilities as workspace items. A utility docked into a document tab is included.
     /// </summary>
-    IReadOnlyList<ISaveableWorkspaceItem> GetSaveableItems();
+    IReadOnlyList<IWorkspaceItem> GetWorkspaceItems();
 
     /// <summary>
     /// Saves any pending changes in the utilities and releases them. Called on workspace unload.

--- a/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceItem.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceItem.cs
@@ -1,8 +1,7 @@
 namespace Celbridge.Workspace;
 
 /// <summary>
-/// A document or utility open in the workspace. An item holding unsaved changes is written to its file
-/// resource when its save timer expires.
+/// A document or utility open in the workspace.
 /// </summary>
 public interface IWorkspaceItem
 {
@@ -13,7 +12,7 @@ public interface IWorkspaceItem
 
     /// <summary>
     /// Whether the item holds edits that have not been written to its file resource yet. Stays true when a
-    /// write fails, so the content is attempted again.
+    /// write fails.
     /// </summary>
     bool HasUnsavedChanges { get; }
 

--- a/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceItem.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceItem.cs
@@ -12,7 +12,8 @@ public interface IWorkspaceItem
     ResourceKey FileResource { get; }
 
     /// <summary>
-    /// Whether the item holds edits that have not been written to its file resource yet.
+    /// Whether the item holds edits that have not been written to its file resource yet. Stays true when a
+    /// write fails, so the content is attempted again.
     /// </summary>
     bool HasUnsavedChanges { get; }
 

--- a/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceItem.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceItem.cs
@@ -1,9 +1,10 @@
 namespace Celbridge.Workspace;
 
 /// <summary>
-/// A workspace item that buffers edits and writes them to its file resource when its save timer expires.
+/// A document or utility open in the workspace. An item holding unsaved changes is written to its file
+/// resource when its save timer expires.
 /// </summary>
-public interface ISaveableWorkspaceItem
+public interface IWorkspaceItem
 {
     /// <summary>
     /// The file resource the item's content is stored in.

--- a/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceService.cs
@@ -90,7 +90,7 @@ public interface IWorkspaceService
     Task<Result> UpdateWorkspaceAsync(double deltaTime);
 
     /// <summary>
-    /// The resources that cannot be written, for a caller that starts observing after they were reported.
+    /// The resources that cannot be written.
     /// </summary>
     IReadOnlyList<ResourceKey> GetFailingSaveResources();
 }

--- a/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceService.cs
@@ -88,4 +88,9 @@ public interface IWorkspaceService
     /// Update the workspace state, for example by saving any pending workspace or document changes to disk.
     /// </summary>
     Task<Result> UpdateWorkspaceAsync(double deltaTime);
+
+    /// <summary>
+    /// The resources that cannot be written, for a caller that starts observing after they were reported.
+    /// </summary>
+    IReadOnlyList<ResourceKey> GetFailingSaveResources();
 }

--- a/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceService.cs
@@ -90,6 +90,12 @@ public interface IWorkspaceService
     Task<Result> UpdateWorkspaceAsync(double deltaTime);
 
     /// <summary>
+    /// Writes the content of every open workspace item that still holds unsaved changes. An item that does
+    /// not write within the flush timeout is abandoned and its content is discarded.
+    /// </summary>
+    Task FlushModifiedItemsAsync();
+
+    /// <summary>
     /// The resources that cannot be written.
     /// </summary>
     IReadOnlyList<ResourceKey> GetFailingSaveResources();

--- a/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceService.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/IWorkspaceService.cs
@@ -96,7 +96,7 @@ public interface IWorkspaceService
     Task FlushModifiedItemsAsync();
 
     /// <summary>
-    /// The resources that cannot be written.
+    /// Every resource whose last write failed and is waiting to be attempted again.
     /// </summary>
-    IReadOnlyList<ResourceKey> GetFailingSaveResources();
+    IReadOnlyList<ResourceKey> GetRetryingResources();
 }

--- a/Source/Core/Celbridge.Foundation/Workspace/SaveConstants.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/SaveConstants.cs
@@ -11,8 +11,7 @@ public static class SaveConstants
     public const double SaveDelay = 1.0;
 
     /// <summary>
-    /// How often the save pass runs. Item save delays are measured in seconds, so this is the precision a
-    /// save lands with.
+    /// How often the save pass runs.
     /// </summary>
     public const double SavePassInterval = 0.1;
 
@@ -23,14 +22,13 @@ public static class SaveConstants
 
     /// <summary>
     /// The longest a failed save waits before it is attempted again. The wait doubles with each failure up
-    /// to this value, so an item that cannot be written settles into one attempt every fifteen seconds.
+    /// to this value.
     /// </summary>
     public const double MaximumRetryDelay = 15.0;
 
     /// <summary>
     /// How long each item is given to write while the workspace closes. An item that has not written by
-    /// then is abandoned and its unsaved content is lost, so that one editor cannot hold the workspace
-    /// open. Long enough that only an editor which has stopped answering reaches it.
+    /// then is abandoned and its unsaved content is lost.
     /// </summary>
     public const double UnloadFlushTimeout = 5.0;
 }

--- a/Source/Core/Celbridge.Foundation/Workspace/SaveConstants.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/SaveConstants.cs
@@ -1,0 +1,36 @@
+namespace Celbridge.Workspace;
+
+/// <summary>
+/// Timings for the workspace save model, in seconds.
+/// </summary>
+public static class SaveConstants
+{
+    /// <summary>
+    /// How long an item waits after its most recent change before its content is written.
+    /// </summary>
+    public const double SaveDelay = 1.0;
+
+    /// <summary>
+    /// How often the save pass runs. Item save delays are measured in seconds, so this is the precision a
+    /// save lands with.
+    /// </summary>
+    public const double SavePassInterval = 0.1;
+
+    /// <summary>
+    /// How long a failed save waits before it is attempted again.
+    /// </summary>
+    public const double InitialRetryDelay = 1.0;
+
+    /// <summary>
+    /// The longest a failed save waits before it is attempted again. The wait doubles with each failure up
+    /// to this value, so an item that cannot be written settles into one attempt every fifteen seconds.
+    /// </summary>
+    public const double MaximumRetryDelay = 15.0;
+
+    /// <summary>
+    /// How long each item is given to write while the workspace closes. An item that has not written by
+    /// then is abandoned and its unsaved content is lost, so that one editor cannot hold the workspace
+    /// open. Long enough that only an editor which has stopped answering reaches it.
+    /// </summary>
+    public const double UnloadFlushTimeout = 5.0;
+}

--- a/Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.cs
@@ -7,15 +7,13 @@ public record PendingSaveCountMessage(int Count);
 
 /// <summary>
 /// Sent when the set of workspace items that cannot be written changes, carrying every resource currently
-/// in that state. An empty list means every item is writing again. The reason a write failed is developer
-/// text, so it is logged rather than carried here.
+/// in that state. An empty list means every item is writing again.
 /// </summary>
 public record WorkspaceItemSaveFailuresChangedMessage(IReadOnlyList<ResourceKey> FailingResources);
 
 /// <summary>
 /// Sent when a workspace item closed while holding content that could not be written, so that content
-/// was discarded. The reason the write reported is developer text, so it is logged rather than carried
-/// here.
+/// was discarded.
 /// </summary>
 public record WorkspaceItemSaveDiscardedMessage(ResourceKey Resource);
 

--- a/Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.cs
@@ -6,10 +6,10 @@ namespace Celbridge.Workspace;
 public record PendingSaveCountMessage(int Count);
 
 /// <summary>
-/// Sent when the set of workspace items that cannot be written changes, carrying every resource currently
-/// in that state. An empty list means every item is writing again.
+/// Sent when the set of workspace items waiting to be written again changes, carrying every resource
+/// currently in that state. An empty list means every item is writing again.
 /// </summary>
-public record WorkspaceItemSaveFailuresChangedMessage(IReadOnlyList<ResourceKey> FailingResources);
+public record WorkspaceItemSaveRetriesChangedMessage(IReadOnlyList<ResourceKey> RetryingResources);
 
 /// <summary>
 /// Sent when a workspace item closed while holding content that could not be written, so that content

--- a/Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.cs
+++ b/Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.cs
@@ -6,10 +6,18 @@ namespace Celbridge.Workspace;
 public record PendingSaveCountMessage(int Count);
 
 /// <summary>
-/// Sent when the save tick could not write one or more workspace items, each with the reason its save
-/// reported.
+/// Sent when the set of workspace items that cannot be written changes, carrying every resource currently
+/// in that state. An empty list means every item is writing again. The reason a write failed is developer
+/// text, so it is logged rather than carried here.
 /// </summary>
-public record WorkspaceItemSaveFailedMessage(IReadOnlyList<FailedResource> FailedItems);
+public record WorkspaceItemSaveFailuresChangedMessage(IReadOnlyList<ResourceKey> FailingResources);
+
+/// <summary>
+/// Sent when a workspace item closed while holding content that could not be written, so that content
+/// was discarded. The reason the write reported is developer text, so it is logged rather than carried
+/// here.
+/// </summary>
+public record WorkspaceItemSaveDiscardedMessage(ResourceKey Resource);
 
 /// <summary>
 /// Sent when the workspace service has been created.

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Controls/TitleBarViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Controls/TitleBarViewModel.cs
@@ -74,8 +74,6 @@ public partial class TitleBarViewModel : ObservableObject
         SaveFailureMessage = ComposeSaveFailureMessage(failingResources);
     }
 
-    // One failing resource is named, which is all the user needs to find it. Several are a count, since the
-    // names do not fit a tooltip.
     private string ComposeSaveFailureMessage(IReadOnlyList<ResourceKey> failingResources)
     {
         if (failingResources.Count == 0)

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Controls/TitleBarViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Controls/TitleBarViewModel.cs
@@ -19,10 +19,10 @@ public partial class TitleBarViewModel : ObservableObject
     private bool _isWorkspaceLoaded;
 
     [ObservableProperty]
-    private bool _hasSaveFailures;
+    private bool _hasSaveRetries;
 
     [ObservableProperty]
-    private string _saveFailureMessage = string.Empty;
+    private string _saveRetryMessage = string.Empty;
 
     public TitleBarViewModel(
         IMessengerService messengerService,
@@ -39,7 +39,7 @@ public partial class TitleBarViewModel : ObservableObject
         _messengerService.Register<WorkspaceLoadedMessage>(this, OnWorkspaceLoaded);
         _messengerService.Register<WorkspaceUnloadedMessage>(this, OnWorkspaceUnloaded);
         _messengerService.Register<PendingSaveCountMessage>(this, OnPendingSaveCount);
-        _messengerService.Register<WorkspaceItemSaveFailuresChangedMessage>(this, OnSaveFailuresChanged);
+        _messengerService.Register<WorkspaceItemSaveRetriesChangedMessage>(this, OnSaveRetriesChanged);
 
         IsWorkspaceLoaded = _workspaceWrapper.IsWorkspaceLoaded;
     }
@@ -60,33 +60,33 @@ public partial class TitleBarViewModel : ObservableObject
 
         // The save state belonged to the workspace that is going away.
         IsSaving = false;
-        ApplySaveFailures(Array.Empty<ResourceKey>());
+        ApplySaveRetries(Array.Empty<ResourceKey>());
     }
 
-    private void OnSaveFailuresChanged(object recipient, WorkspaceItemSaveFailuresChangedMessage message)
+    private void OnSaveRetriesChanged(object recipient, WorkspaceItemSaveRetriesChangedMessage message)
     {
-        ApplySaveFailures(message.FailingResources);
+        ApplySaveRetries(message.RetryingResources);
     }
 
-    private void ApplySaveFailures(IReadOnlyList<ResourceKey> failingResources)
+    private void ApplySaveRetries(IReadOnlyList<ResourceKey> retryingResources)
     {
-        HasSaveFailures = failingResources.Count > 0;
-        SaveFailureMessage = ComposeSaveFailureMessage(failingResources);
+        HasSaveRetries = retryingResources.Count > 0;
+        SaveRetryMessage = ComposeSaveRetryMessage(retryingResources);
     }
 
-    private string ComposeSaveFailureMessage(IReadOnlyList<ResourceKey> failingResources)
+    private string ComposeSaveRetryMessage(IReadOnlyList<ResourceKey> retryingResources)
     {
-        if (failingResources.Count == 0)
+        if (retryingResources.Count == 0)
         {
             return string.Empty;
         }
 
-        if (failingResources.Count == 1)
+        if (retryingResources.Count == 1)
         {
-            return _stringLocalizer.GetString("SaveStatus_Failed_Single", failingResources[0].ResourceName);
+            return _stringLocalizer.GetString("SaveStatus_Failed_Single", retryingResources[0].ResourceName);
         }
 
-        return _stringLocalizer.GetString("SaveStatus_Failed_Multiple", failingResources.Count);
+        return _stringLocalizer.GetString("SaveStatus_Failed_Multiple", retryingResources.Count);
     }
 
     private void OnPendingSaveCount(object recipient, PendingSaveCountMessage message)

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Controls/TitleBarViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Controls/TitleBarViewModel.cs
@@ -11,7 +11,6 @@ public partial class TitleBarViewModel : ObservableObject
     private readonly IMessengerService _messengerService;
     private readonly IWorkspaceWrapper _workspaceWrapper;
     private readonly IStringLocalizer _stringLocalizer;
-    private readonly IDispatcher _dispatcher;
 
     [ObservableProperty]
     private bool _isSaving;
@@ -28,13 +27,11 @@ public partial class TitleBarViewModel : ObservableObject
     public TitleBarViewModel(
         IMessengerService messengerService,
         IWorkspaceWrapper workspaceWrapper,
-        IStringLocalizer stringLocalizer,
-        IDispatcher dispatcher)
+        IStringLocalizer stringLocalizer)
     {
         _messengerService = messengerService;
         _workspaceWrapper = workspaceWrapper;
         _stringLocalizer = stringLocalizer;
-        _dispatcher = dispatcher;
     }
 
     public void OnLoaded()
@@ -61,26 +58,24 @@ public partial class TitleBarViewModel : ObservableObject
     {
         IsWorkspaceLoaded = false;
 
-        // The failures belonged to the workspace that is going away.
-        HasSaveFailures = false;
-        SaveFailureMessage = string.Empty;
+        // The save state belonged to the workspace that is going away.
+        IsSaving = false;
+        ApplySaveFailures(Array.Empty<ResourceKey>());
     }
 
     private void OnSaveFailuresChanged(object recipient, WorkspaceItemSaveFailuresChangedMessage message)
     {
-        var failingResources = message.FailingResources;
-        var failureMessage = ComposeSaveFailureMessage(failingResources);
-
-        // Raised from the workspace update loop, which does not run on the UI thread.
-        _dispatcher.TryEnqueue(() =>
-        {
-            HasSaveFailures = failingResources.Count > 0;
-            SaveFailureMessage = failureMessage;
-        });
+        ApplySaveFailures(message.FailingResources);
     }
 
-    // One failing resource is named, which is all the user needs to find it. Several are a count, since
-    // the names do not fit a tooltip and each one carries its own marker on its tab.
+    private void ApplySaveFailures(IReadOnlyList<ResourceKey> failingResources)
+    {
+        HasSaveFailures = failingResources.Count > 0;
+        SaveFailureMessage = ComposeSaveFailureMessage(failingResources);
+    }
+
+    // One failing resource is named, which is all the user needs to find it. Several are a count, since the
+    // names do not fit a tooltip.
     private string ComposeSaveFailureMessage(IReadOnlyList<ResourceKey> failingResources)
     {
         if (failingResources.Count == 0)
@@ -98,8 +93,7 @@ public partial class TitleBarViewModel : ObservableObject
 
     private void OnPendingSaveCount(object recipient, PendingSaveCountMessage message)
     {
-        // Raised from the workspace update loop, which does not run on the UI thread.
-        _dispatcher.TryEnqueue(() => IsSaving = message.Count > 0);
+        IsSaving = message.Count > 0;
     }
 }
 

--- a/Source/Core/Celbridge.UserInterface/ViewModels/Controls/TitleBarViewModel.cs
+++ b/Source/Core/Celbridge.UserInterface/ViewModels/Controls/TitleBarViewModel.cs
@@ -1,4 +1,5 @@
 using Celbridge.Workspace;
+using Microsoft.Extensions.Localization;
 
 namespace Celbridge.UserInterface.ViewModels.Controls;
 
@@ -9,6 +10,8 @@ public partial class TitleBarViewModel : ObservableObject
 {
     private readonly IMessengerService _messengerService;
     private readonly IWorkspaceWrapper _workspaceWrapper;
+    private readonly IStringLocalizer _stringLocalizer;
+    private readonly IDispatcher _dispatcher;
 
     [ObservableProperty]
     private bool _isSaving;
@@ -16,12 +19,22 @@ public partial class TitleBarViewModel : ObservableObject
     [ObservableProperty]
     private bool _isWorkspaceLoaded;
 
+    [ObservableProperty]
+    private bool _hasSaveFailures;
+
+    [ObservableProperty]
+    private string _saveFailureMessage = string.Empty;
+
     public TitleBarViewModel(
         IMessengerService messengerService,
-        IWorkspaceWrapper workspaceWrapper)
+        IWorkspaceWrapper workspaceWrapper,
+        IStringLocalizer stringLocalizer,
+        IDispatcher dispatcher)
     {
         _messengerService = messengerService;
         _workspaceWrapper = workspaceWrapper;
+        _stringLocalizer = stringLocalizer;
+        _dispatcher = dispatcher;
     }
 
     public void OnLoaded()
@@ -29,6 +42,7 @@ public partial class TitleBarViewModel : ObservableObject
         _messengerService.Register<WorkspaceLoadedMessage>(this, OnWorkspaceLoaded);
         _messengerService.Register<WorkspaceUnloadedMessage>(this, OnWorkspaceUnloaded);
         _messengerService.Register<PendingSaveCountMessage>(this, OnPendingSaveCount);
+        _messengerService.Register<WorkspaceItemSaveFailuresChangedMessage>(this, OnSaveFailuresChanged);
 
         IsWorkspaceLoaded = _workspaceWrapper.IsWorkspaceLoaded;
     }
@@ -46,11 +60,46 @@ public partial class TitleBarViewModel : ObservableObject
     private void OnWorkspaceUnloaded(object recipient, WorkspaceUnloadedMessage message)
     {
         IsWorkspaceLoaded = false;
+
+        // The failures belonged to the workspace that is going away.
+        HasSaveFailures = false;
+        SaveFailureMessage = string.Empty;
+    }
+
+    private void OnSaveFailuresChanged(object recipient, WorkspaceItemSaveFailuresChangedMessage message)
+    {
+        var failingResources = message.FailingResources;
+        var failureMessage = ComposeSaveFailureMessage(failingResources);
+
+        // Raised from the workspace update loop, which does not run on the UI thread.
+        _dispatcher.TryEnqueue(() =>
+        {
+            HasSaveFailures = failingResources.Count > 0;
+            SaveFailureMessage = failureMessage;
+        });
+    }
+
+    // One failing resource is named, which is all the user needs to find it. Several are a count, since
+    // the names do not fit a tooltip and each one carries its own marker on its tab.
+    private string ComposeSaveFailureMessage(IReadOnlyList<ResourceKey> failingResources)
+    {
+        if (failingResources.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        if (failingResources.Count == 1)
+        {
+            return _stringLocalizer.GetString("SaveStatus_Failed_Single", failingResources[0].ResourceName);
+        }
+
+        return _stringLocalizer.GetString("SaveStatus_Failed_Multiple", failingResources.Count);
     }
 
     private void OnPendingSaveCount(object recipient, PendingSaveCountMessage message)
     {
-        IsSaving = message.Count > 0;
+        // Raised from the workspace update loop, which does not run on the UI thread.
+        _dispatcher.TryEnqueue(() => IsSaving = message.Count > 0);
     }
 }
 

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml
@@ -44,16 +44,30 @@
         <local:ProjectToolbar x:Name="ProjectToolbar"
                                  Grid.Column="1"/>
 
-        <!-- Save Icon - positioned to the left of layout toolbar -->
-        <controls:Icon x:Name="SaveIcon"
-                       Grid.Column="3"
-                       Visibility="{x:Bind ViewModel.IsWorkspaceLoaded, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
-                       HorizontalAlignment="Right"
-                       VerticalAlignment="Center"
-                       Margin="0,0,16,0"
-                       Opacity="{x:Bind ViewModel.IsSaving, Mode=OneWay, Converter={StaticResource BoolToOpacityConverter}}"
-                       FontSize="{StaticResource IconSizeMedium}"
-                       Symbol="Save"/>
+        <!-- Save status - positioned to the left of layout toolbar. The warning stays up for as long as
+             anything is failing to save, while the save glyph only marks a write in progress. -->
+        <StackPanel Grid.Column="3"
+                    Orientation="Horizontal"
+                    Visibility="{x:Bind ViewModel.IsWorkspaceLoaded, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Margin="0,0,16,0">
+
+            <controls:Icon x:Name="SaveFailureIcon"
+                           Visibility="{x:Bind ViewModel.HasSaveFailures, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                           ToolTipService.ToolTip="{x:Bind ViewModel.SaveFailureMessage, Mode=OneWay}"
+                           VerticalAlignment="Center"
+                           Margin="0,0,8,0"
+                           FontSize="{StaticResource IconSizeMedium}"
+                           Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                           Symbol="Warning"/>
+
+            <controls:Icon x:Name="SaveIcon"
+                           VerticalAlignment="Center"
+                           Opacity="{x:Bind ViewModel.IsSaving, Mode=OneWay, Converter={StaticResource BoolToOpacityConverter}}"
+                           FontSize="{StaticResource IconSizeMedium}"
+                           Symbol="Save"/>
+        </StackPanel>
 
         <!-- Layout Toolbar - positioned on the right side of the toolbar -->
         <local:LayoutToolbar x:Name="LayoutToolbar"

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml
@@ -44,8 +44,7 @@
         <local:ProjectToolbar x:Name="ProjectToolbar"
                                  Grid.Column="1"/>
 
-        <!-- Save status - positioned to the left of layout toolbar. The warning stays up for as long as
-             anything is failing to save, while the save glyph only marks a write in progress. -->
+        <!-- Save status - positioned to the left of layout toolbar -->
         <StackPanel Grid.Column="3"
                     Orientation="Horizontal"
                     Visibility="{x:Bind ViewModel.IsWorkspaceLoaded, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"

--- a/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml
+++ b/Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xaml
@@ -52,9 +52,9 @@
                     VerticalAlignment="Center"
                     Margin="0,0,16,0">
 
-            <controls:Icon x:Name="SaveFailureIcon"
-                           Visibility="{x:Bind ViewModel.HasSaveFailures, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
-                           ToolTipService.ToolTip="{x:Bind ViewModel.SaveFailureMessage, Mode=OneWay}"
+            <controls:Icon x:Name="SaveRetryIcon"
+                           Visibility="{x:Bind ViewModel.HasSaveRetries, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                           ToolTipService.ToolTip="{x:Bind ViewModel.SaveRetryMessage, Mode=OneWay}"
                            VerticalAlignment="Center"
                            Margin="0,0,8,0"
                            FontSize="{StaticResource IconSizeMedium}"

--- a/Source/Modules/Celbridge.WebView/ViewModels/WebViewDocumentViewModel.cs
+++ b/Source/Modules/Celbridge.WebView/ViewModels/WebViewDocumentViewModel.cs
@@ -493,8 +493,7 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
 
     public async Task<Result> SaveDocumentContent()
     {
-        // Cleared before the write so an edit made while it is in flight is not counted as written. The
-        // save timer goes with it, and the saver's backoff decides when a failed write is tried again.
+        // Cleared before the write so an edit made while it is in flight is not counted as written.
         HasUnsavedChanges = false;
         SaveTimer = 0;
 
@@ -511,7 +510,6 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
         var saveResult = await SaveTextToFileAsync(content.ToToml());
         if (saveResult.IsFailure)
         {
-            // The content is still held only in the view, so the item is due to be written again.
             HasUnsavedChanges = true;
         }
 

--- a/Source/Modules/Celbridge.WebView/ViewModels/WebViewDocumentViewModel.cs
+++ b/Source/Modules/Celbridge.WebView/ViewModels/WebViewDocumentViewModel.cs
@@ -493,7 +493,8 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
 
     public async Task<Result> SaveDocumentContent()
     {
-        // Don't immediately try to save again if the save fails.
+        // Cleared before the write so an edit made while it is in flight is not counted as written. The
+        // save timer goes with it, and the saver's backoff decides when a failed write is tried again.
         HasUnsavedChanges = false;
         SaveTimer = 0;
 
@@ -507,7 +508,14 @@ public partial class WebViewDocumentViewModel : DocumentViewModel
             Bookmarks = bookmarks
         };
 
-        return await SaveTextToFileAsync(content.ToToml());
+        var saveResult = await SaveTextToFileAsync(content.ToToml());
+        if (saveResult.IsFailure)
+        {
+            // The content is still held only in the view, so the item is due to be written again.
+            HasUnsavedChanges = true;
+        }
+
+        return saveResult;
     }
 
     /// <summary>

--- a/Source/Tests/Documents/DocumentTabViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentTabViewModelTests.cs
@@ -4,6 +4,7 @@ using Celbridge.Messaging;
 using Celbridge.Messaging.Services;
 using Celbridge.Resources;
 using Celbridge.Workspace;
+using Microsoft.Extensions.Localization;
 
 namespace Celbridge.Tests.Documents;
 
@@ -23,6 +24,8 @@ public class DocumentTabViewModelTests
     private IResourceOperationService _resourceOperations = null!;
     private IResourceService _resourceService = null!;
     private IWorkspaceWrapper _workspaceWrapper = null!;
+    private IStringLocalizer _stringLocalizer = null!;
+    private IDispatcher _dispatcher = null!;
     private readonly List<DocumentTabViewModel> _createdViewModels = new();
 
     [SetUp]
@@ -56,6 +59,18 @@ public class DocumentTabViewModelTests
 
         _workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
         _workspaceWrapper.WorkspaceService.Returns(workspaceService);
+
+        _stringLocalizer = Substitute.For<IStringLocalizer>();
+        _stringLocalizer[Arg.Any<string>(), Arg.Any<object[]>()].Returns(call =>
+            new LocalizedString(call.Arg<string>(), call.Arg<string>()));
+
+        // The view model marshals onto the UI thread; run inline so the assertions see the result.
+        _dispatcher = Substitute.For<IDispatcher>();
+        _dispatcher.TryEnqueue(Arg.Any<Action>()).Returns(call =>
+        {
+            call.Arg<Action>().Invoke();
+            return true;
+        });
     }
 
     [TearDown]
@@ -73,7 +88,13 @@ public class DocumentTabViewModelTests
 
     private DocumentTabViewModel CreateViewModel(ResourceKey fileResource, IDocumentView? documentView = null)
     {
-        var viewModel = new DocumentTabViewModel(_messengerService, _commandService, _logger, _workspaceWrapper)
+        var viewModel = new DocumentTabViewModel(
+            _messengerService,
+            _commandService,
+            _logger,
+            _workspaceWrapper,
+            _stringLocalizer,
+            _dispatcher)
         {
             FileResource = fileResource,
             DocumentView = documentView!,

--- a/Source/Tests/Documents/DocumentTabViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentTabViewModelTests.cs
@@ -56,7 +56,7 @@ public class DocumentTabViewModelTests
 
         _workspaceService = Substitute.For<IWorkspaceService>();
         _workspaceService.ResourceService.Returns(_resourceService);
-        _workspaceService.GetFailingSaveResources().Returns(Array.Empty<ResourceKey>());
+        _workspaceService.GetRetryingResources().Returns(Array.Empty<ResourceKey>());
 
         _workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
         _workspaceWrapper.WorkspaceService.Returns(_workspaceService);
@@ -275,15 +275,15 @@ public class DocumentTabViewModelTests
     }
 
     [Test]
-    public void NewTab_ShowsASaveFailure_WhenTheResourceIsAlreadyFailing()
+    public void NewTab_ShowsTheWarning_WhenTheResourceIsAlreadyRetrying()
     {
         var fileResource = new ResourceKey("locked.md");
         _workspaceWrapper.IsWorkspaceLoaded.Returns(true);
-        _workspaceService.GetFailingSaveResources().Returns(new[] { fileResource });
+        _workspaceService.GetRetryingResources().Returns(new[] { fileResource });
 
         var viewModel = CreateViewModel(fileResource);
 
-        viewModel.HasSaveFailure.Should().BeTrue("the failing set is only sent when it changes");
+        viewModel.IsSaveRetrying.Should().BeTrue("the failing set is only sent when it changes");
     }
 
     [Test]
@@ -291,7 +291,7 @@ public class DocumentTabViewModelTests
     {
         var fileResource = new ResourceKey("locked.md");
         _workspaceWrapper.IsWorkspaceLoaded.Returns(true);
-        _workspaceService.GetFailingSaveResources().Returns(new[] { fileResource });
+        _workspaceService.GetRetryingResources().Returns(new[] { fileResource });
 
         var viewModel = CreateViewModel(fileResource);
         viewModel.FilePath = "C:/project/locked.md";

--- a/Source/Tests/Documents/DocumentTabViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentTabViewModelTests.cs
@@ -25,7 +25,7 @@ public class DocumentTabViewModelTests
     private IResourceService _resourceService = null!;
     private IWorkspaceWrapper _workspaceWrapper = null!;
     private IStringLocalizer _stringLocalizer = null!;
-    private IDispatcher _dispatcher = null!;
+    private IWorkspaceService _workspaceService = null!;
     private readonly List<DocumentTabViewModel> _createdViewModels = new();
 
     [SetUp]
@@ -54,22 +54,20 @@ public class DocumentTabViewModelTests
         _resourceService.FileSystem.Returns(_resourceFileSystem);
         _resourceService.Operations.Returns(_resourceOperations);
 
-        var workspaceService = Substitute.For<IWorkspaceService>();
-        workspaceService.ResourceService.Returns(_resourceService);
+        _workspaceService = Substitute.For<IWorkspaceService>();
+        _workspaceService.ResourceService.Returns(_resourceService);
+        _workspaceService.GetFailingSaveResources().Returns(Array.Empty<ResourceKey>());
 
         _workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
-        _workspaceWrapper.WorkspaceService.Returns(workspaceService);
+        _workspaceWrapper.WorkspaceService.Returns(_workspaceService);
 
+        // The composed value carries the arguments, so a test can tell which values reached the template.
         _stringLocalizer = Substitute.For<IStringLocalizer>();
         _stringLocalizer[Arg.Any<string>(), Arg.Any<object[]>()].Returns(call =>
-            new LocalizedString(call.Arg<string>(), call.Arg<string>()));
-
-        // The view model marshals onto the UI thread; run inline so the assertions see the result.
-        _dispatcher = Substitute.For<IDispatcher>();
-        _dispatcher.TryEnqueue(Arg.Any<Action>()).Returns(call =>
         {
-            call.Arg<Action>().Invoke();
-            return true;
+            var name = call.Arg<string>();
+            var arguments = call.Arg<object[]>();
+            return new LocalizedString(name, $"{name}({string.Join(", ", arguments)})");
         });
     }
 
@@ -93,8 +91,7 @@ public class DocumentTabViewModelTests
             _commandService,
             _logger,
             _workspaceWrapper,
-            _stringLocalizer,
-            _dispatcher)
+            _stringLocalizer)
         {
             FileResource = fileResource,
             DocumentView = documentView!,
@@ -244,5 +241,86 @@ public class DocumentTabViewModelTests
         _messengerService.Send(new ResourceRegistryUpdatedMessage());
 
         documentView.DidNotReceive().SetWritableState(Arg.Any<WritableState>());
+    }
+
+    [Test]
+    public async Task CloseDocument_AnnouncesDiscardedEdits_WhenSaveFails()
+    {
+        var fileResource = new ResourceKey("locked.md");
+        var viewModel = CreateViewModel(fileResource, CreateUnwritableDocumentView());
+
+        var discardedResources = RecordDiscardedResources(out var probe);
+
+        await viewModel.CloseDocument(forceClose: false);
+
+        _messengerService.UnregisterAll(probe);
+
+        discardedResources.Should().Equal(new[] { fileResource },
+            "the edits went with the view, so this is the last chance to say so");
+    }
+
+    [Test]
+    public async Task CloseDocument_DoesNotAnnounceDiscardedEdits_ForADockedUtility()
+    {
+        var viewModel = CreateViewModel(new ResourceKey("locked.md"), CreateUnwritableDocumentView());
+        viewModel.IsDockedUtility = true;
+
+        var discardedResources = RecordDiscardedResources(out var probe);
+
+        await viewModel.CloseDocument(forceClose: false);
+
+        _messengerService.UnregisterAll(probe);
+
+        discardedResources.Should().BeEmpty("a docked utility keeps its view and its content when the tab closes");
+    }
+
+    [Test]
+    public void NewTab_ShowsASaveFailure_WhenTheResourceIsAlreadyFailing()
+    {
+        var fileResource = new ResourceKey("locked.md");
+        _workspaceWrapper.IsWorkspaceLoaded.Returns(true);
+        _workspaceService.GetFailingSaveResources().Returns(new[] { fileResource });
+
+        var viewModel = CreateViewModel(fileResource);
+
+        viewModel.HasSaveFailure.Should().BeTrue("the failing set is only sent when it changes");
+    }
+
+    [Test]
+    public void TabTooltip_SaysTheFileCouldNotBeSaved_WhenTheResourceIsFailing()
+    {
+        var fileResource = new ResourceKey("locked.md");
+        _workspaceWrapper.IsWorkspaceLoaded.Returns(true);
+        _workspaceService.GetFailingSaveResources().Returns(new[] { fileResource });
+
+        var viewModel = CreateViewModel(fileResource);
+        viewModel.FilePath = "C:/project/locked.md";
+
+        viewModel.TabTooltip.Should()
+            .StartWith("DocumentTab_Tooltip_SaveFailed(")
+            .And.Contain("C:/project/locked.md");
+    }
+
+    private static IDocumentView CreateUnwritableDocumentView()
+    {
+        var documentView = Substitute.For<IDocumentView>();
+        documentView.CanClose().Returns(Task.FromResult(true));
+        documentView.HasUnsavedChanges.Returns(true);
+        documentView.SaveAsync().Returns(Task.FromResult<Result>(Result.Fail("simulated save failure")));
+        documentView.WritableState.Returns(WritableState.Locked);
+
+        return documentView;
+    }
+
+    private List<ResourceKey> RecordDiscardedResources(out object probe)
+    {
+        var discardedResources = new List<ResourceKey>();
+
+        probe = new object();
+        _messengerService.Register<WorkspaceItemSaveDiscardedMessage>(
+            probe,
+            (object _, WorkspaceItemSaveDiscardedMessage message) => discardedResources.Add(message.Resource));
+
+        return discardedResources;
     }
 }

--- a/Source/Tests/Documents/DocumentViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentViewModelTests.cs
@@ -355,15 +355,24 @@ public class DocumentViewModelTests
 
         public async Task<Result> SaveDocumentContent(string text)
         {
+            // Cleared before the write so an edit made while it is in flight is not counted as written,
+            // and restored when the write fails, as the real editors do.
             HasUnsavedChanges = false;
             SaveTimer = 0;
-            return await SaveTextToFileAsync(text);
+
+            var saveResult = await SaveTextToFileAsync(text);
+            if (saveResult.IsFailure)
+            {
+                HasUnsavedChanges = true;
+            }
+
+            return saveResult;
         }
 
         public void OnTextChanged()
         {
             HasUnsavedChanges = true;
-            SaveTimer = SaveDelay;
+            SaveTimer = SaveConstants.SaveDelay;
         }
 
         protected override IResourceFileSystem GetFileSystem() => _resourceFileSystem;

--- a/Source/Tests/Documents/DocumentViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentViewModelTests.cs
@@ -186,6 +186,43 @@ public class DocumentViewModelTests
     }
 
     [Test]
+    public void UpdateSaveTimer_ReportsNoSaveIsDue_BeforeTheDelayElapses()
+    {
+        _vm.OnTextChanged();
+
+        var result = _vm.UpdateSaveTimer(0.5);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+    }
+
+    [Test]
+    public void UpdateSaveTimer_ComesDueAgain_WhenTheContentIsStillUnwritten()
+    {
+        _vm.OnTextChanged();
+
+        var firstResult = _vm.UpdateSaveTimer(1.0);
+
+        firstResult.Value.Should().BeTrue();
+        _vm.SaveTimer.Should().Be(1.0);
+
+        // The save did not clear the unsaved changes, so the document comes due again on the next delay.
+        var secondResult = _vm.UpdateSaveTimer(1.0);
+
+        secondResult.Value.Should().BeTrue();
+    }
+
+    [Test]
+    public void UpdateSaveTimer_Fails_WhenTheDocumentHasNoUnsavedChanges()
+    {
+        _vm.HasUnsavedChanges = false;
+
+        var result = _vm.UpdateSaveTimer(1.0);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Test]
     public void ResourceChanged_TriggersReload_WhenFileChangedExternally()
     {
         // With no prior load/save the hash is null, so any change is treated as external

--- a/Source/Tests/Documents/DocumentViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentViewModelTests.cs
@@ -355,8 +355,8 @@ public class DocumentViewModelTests
 
         public async Task<Result> SaveDocumentContent(string text)
         {
-            // Cleared before the write so an edit made while it is in flight is not counted as written,
-            // and restored when the write fails, as the real editors do.
+            // Cleared before the write so an edit made while it is in flight is not counted as written, as
+            // the real editors do.
             HasUnsavedChanges = false;
             SaveTimer = 0;
 

--- a/Source/Tests/UserInterface/TitleBarViewModelTests.cs
+++ b/Source/Tests/UserInterface/TitleBarViewModelTests.cs
@@ -19,7 +19,7 @@ public class TitleBarViewModelTests
     private MessageHandler<object, WorkspaceLoadedMessage>? _workspaceLoadedHandler;
     private MessageHandler<object, WorkspaceUnloadedMessage>? _workspaceUnloadedHandler;
     private MessageHandler<object, PendingSaveCountMessage>? _pendingSaveCountHandler;
-    private MessageHandler<object, WorkspaceItemSaveFailuresChangedMessage>? _saveFailuresHandler;
+    private MessageHandler<object, WorkspaceItemSaveRetriesChangedMessage>? _saveRetriesHandler;
 
     private TitleBarViewModel _viewModel = null!;
 
@@ -50,8 +50,8 @@ public class TitleBarViewModelTests
         _messengerService
             .When(service => service.Register(
                 Arg.Any<object>(),
-                Arg.Any<MessageHandler<object, WorkspaceItemSaveFailuresChangedMessage>>()))
-            .Do(call => _saveFailuresHandler = call.Arg<MessageHandler<object, WorkspaceItemSaveFailuresChangedMessage>>());
+                Arg.Any<MessageHandler<object, WorkspaceItemSaveRetriesChangedMessage>>()))
+            .Do(call => _saveRetriesHandler = call.Arg<MessageHandler<object, WorkspaceItemSaveRetriesChangedMessage>>());
 
         _workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
 
@@ -68,38 +68,38 @@ public class TitleBarViewModelTests
     }
 
     [Test]
-    public void SaveFailures_NameTheResource_WhenOneItemIsFailing()
+    public void SaveRetries_NameTheResource_WhenOneItemIsRetrying()
     {
         _viewModel.OnLoaded();
 
-        SendFailingResources(new ResourceKey("project:notes.txt"));
+        SendRetryingResources(new ResourceKey("project:notes.txt"));
 
-        _viewModel.HasSaveFailures.Should().BeTrue();
-        _viewModel.SaveFailureMessage.Should().Be("SaveStatus_Failed_Single(notes.txt)");
+        _viewModel.HasSaveRetries.Should().BeTrue();
+        _viewModel.SaveRetryMessage.Should().Be("SaveStatus_Failed_Single(notes.txt)");
     }
 
     [Test]
-    public void SaveFailures_ShowTheCount_WhenSeveralItemsAreFailing()
+    public void SaveRetries_ShowTheCount_WhenSeveralItemsAreRetrying()
     {
         _viewModel.OnLoaded();
 
-        SendFailingResources(new ResourceKey("project:notes.txt"), new ResourceKey("project:data.json"));
+        SendRetryingResources(new ResourceKey("project:notes.txt"), new ResourceKey("project:data.json"));
 
-        _viewModel.HasSaveFailures.Should().BeTrue();
-        _viewModel.SaveFailureMessage.Should().Be("SaveStatus_Failed_Multiple(2)",
+        _viewModel.HasSaveRetries.Should().BeTrue();
+        _viewModel.SaveRetryMessage.Should().Be("SaveStatus_Failed_Multiple(2)",
             "the names do not fit a tooltip");
     }
 
     [Test]
-    public void SaveFailures_Clear_WhenTheFailingSetEmpties()
+    public void SaveRetries_Clear_WhenTheRetryingSetEmpties()
     {
         _viewModel.OnLoaded();
 
-        SendFailingResources(new ResourceKey("project:notes.txt"));
-        SendFailingResources();
+        SendRetryingResources(new ResourceKey("project:notes.txt"));
+        SendRetryingResources();
 
-        _viewModel.HasSaveFailures.Should().BeFalse();
-        _viewModel.SaveFailureMessage.Should().BeEmpty();
+        _viewModel.HasSaveRetries.Should().BeFalse();
+        _viewModel.SaveRetryMessage.Should().BeEmpty();
     }
 
     [Test]
@@ -107,14 +107,14 @@ public class TitleBarViewModelTests
     {
         _viewModel.OnLoaded();
 
-        SendFailingResources(new ResourceKey("project:notes.txt"));
+        SendRetryingResources(new ResourceKey("project:notes.txt"));
         _pendingSaveCountHandler!.Invoke(this, new PendingSaveCountMessage(1));
 
         _workspaceUnloadedHandler!.Invoke(this, new WorkspaceUnloadedMessage());
 
         _viewModel.IsSaving.Should().BeFalse("the save state belonged to the workspace that went away");
-        _viewModel.HasSaveFailures.Should().BeFalse();
-        _viewModel.SaveFailureMessage.Should().BeEmpty();
+        _viewModel.HasSaveRetries.Should().BeFalse();
+        _viewModel.SaveRetryMessage.Should().BeEmpty();
     }
 
     [Test]
@@ -122,17 +122,17 @@ public class TitleBarViewModelTests
     {
         _viewModel.OnLoaded();
 
-        SendFailingResources(new ResourceKey("project:notes.txt"));
+        SendRetryingResources(new ResourceKey("project:notes.txt"));
         _workspaceUnloadedHandler!.Invoke(this, new WorkspaceUnloadedMessage());
 
         _workspaceLoadedHandler!.Invoke(this, new WorkspaceLoadedMessage());
 
-        _viewModel.HasSaveFailures.Should().BeFalse();
-        _viewModel.SaveFailureMessage.Should().BeEmpty();
+        _viewModel.HasSaveRetries.Should().BeFalse();
+        _viewModel.SaveRetryMessage.Should().BeEmpty();
     }
 
-    private void SendFailingResources(params ResourceKey[] failingResources)
+    private void SendRetryingResources(params ResourceKey[] retryingResources)
     {
-        _saveFailuresHandler!.Invoke(this, new WorkspaceItemSaveFailuresChangedMessage(failingResources));
+        _saveRetriesHandler!.Invoke(this, new WorkspaceItemSaveRetriesChangedMessage(retryingResources));
     }
 }

--- a/Source/Tests/UserInterface/TitleBarViewModelTests.cs
+++ b/Source/Tests/UserInterface/TitleBarViewModelTests.cs
@@ -7,8 +7,7 @@ using Microsoft.Extensions.Localization;
 namespace Celbridge.Tests.UserInterface;
 
 /// <summary>
-/// Tests for the save indicators in the application toolbar. One failing resource is named so the user can
-/// find it, several are a count, and the state belongs to the workspace that reported it.
+/// Tests for the save indicators in the application toolbar.
 /// </summary>
 [TestFixture]
 public class TitleBarViewModelTests

--- a/Source/Tests/UserInterface/TitleBarViewModelTests.cs
+++ b/Source/Tests/UserInterface/TitleBarViewModelTests.cs
@@ -1,0 +1,139 @@
+using Celbridge.Messaging;
+using Celbridge.Resources;
+using Celbridge.UserInterface.ViewModels.Controls;
+using Celbridge.Workspace;
+using Microsoft.Extensions.Localization;
+
+namespace Celbridge.Tests.UserInterface;
+
+/// <summary>
+/// Tests for the save indicators in the application toolbar. One failing resource is named so the user can
+/// find it, several are a count, and the state belongs to the workspace that reported it.
+/// </summary>
+[TestFixture]
+public class TitleBarViewModelTests
+{
+    private IMessengerService _messengerService = null!;
+    private IWorkspaceWrapper _workspaceWrapper = null!;
+    private IStringLocalizer _stringLocalizer = null!;
+
+    private MessageHandler<object, WorkspaceLoadedMessage>? _workspaceLoadedHandler;
+    private MessageHandler<object, WorkspaceUnloadedMessage>? _workspaceUnloadedHandler;
+    private MessageHandler<object, PendingSaveCountMessage>? _pendingSaveCountHandler;
+    private MessageHandler<object, WorkspaceItemSaveFailuresChangedMessage>? _saveFailuresHandler;
+
+    private TitleBarViewModel _viewModel = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _messengerService = Substitute.For<IMessengerService>();
+
+        // Capture the handlers so a test can deliver a message without a live messenger.
+        _messengerService
+            .When(service => service.Register(
+                Arg.Any<object>(),
+                Arg.Any<MessageHandler<object, WorkspaceLoadedMessage>>()))
+            .Do(call => _workspaceLoadedHandler = call.Arg<MessageHandler<object, WorkspaceLoadedMessage>>());
+
+        _messengerService
+            .When(service => service.Register(
+                Arg.Any<object>(),
+                Arg.Any<MessageHandler<object, WorkspaceUnloadedMessage>>()))
+            .Do(call => _workspaceUnloadedHandler = call.Arg<MessageHandler<object, WorkspaceUnloadedMessage>>());
+
+        _messengerService
+            .When(service => service.Register(
+                Arg.Any<object>(),
+                Arg.Any<MessageHandler<object, PendingSaveCountMessage>>()))
+            .Do(call => _pendingSaveCountHandler = call.Arg<MessageHandler<object, PendingSaveCountMessage>>());
+
+        _messengerService
+            .When(service => service.Register(
+                Arg.Any<object>(),
+                Arg.Any<MessageHandler<object, WorkspaceItemSaveFailuresChangedMessage>>()))
+            .Do(call => _saveFailuresHandler = call.Arg<MessageHandler<object, WorkspaceItemSaveFailuresChangedMessage>>());
+
+        _workspaceWrapper = Substitute.For<IWorkspaceWrapper>();
+
+        // The composed value carries the arguments, so a test can tell which values reached the template.
+        _stringLocalizer = Substitute.For<IStringLocalizer>();
+        _stringLocalizer[Arg.Any<string>(), Arg.Any<object[]>()].Returns(call =>
+        {
+            var name = call.Arg<string>();
+            var arguments = call.Arg<object[]>();
+            return new LocalizedString(name, $"{name}({string.Join(", ", arguments)})");
+        });
+
+        _viewModel = new TitleBarViewModel(_messengerService, _workspaceWrapper, _stringLocalizer);
+    }
+
+    [Test]
+    public void SaveFailures_NameTheResource_WhenOneItemIsFailing()
+    {
+        _viewModel.OnLoaded();
+
+        SendFailingResources(new ResourceKey("project:notes.txt"));
+
+        _viewModel.HasSaveFailures.Should().BeTrue();
+        _viewModel.SaveFailureMessage.Should().Be("SaveStatus_Failed_Single(notes.txt)");
+    }
+
+    [Test]
+    public void SaveFailures_ShowTheCount_WhenSeveralItemsAreFailing()
+    {
+        _viewModel.OnLoaded();
+
+        SendFailingResources(new ResourceKey("project:notes.txt"), new ResourceKey("project:data.json"));
+
+        _viewModel.HasSaveFailures.Should().BeTrue();
+        _viewModel.SaveFailureMessage.Should().Be("SaveStatus_Failed_Multiple(2)",
+            "the names do not fit a tooltip");
+    }
+
+    [Test]
+    public void SaveFailures_Clear_WhenTheFailingSetEmpties()
+    {
+        _viewModel.OnLoaded();
+
+        SendFailingResources(new ResourceKey("project:notes.txt"));
+        SendFailingResources();
+
+        _viewModel.HasSaveFailures.Should().BeFalse();
+        _viewModel.SaveFailureMessage.Should().BeEmpty();
+    }
+
+    [Test]
+    public void WorkspaceUnloaded_ClearsTheSaveState()
+    {
+        _viewModel.OnLoaded();
+
+        SendFailingResources(new ResourceKey("project:notes.txt"));
+        _pendingSaveCountHandler!.Invoke(this, new PendingSaveCountMessage(1));
+
+        _workspaceUnloadedHandler!.Invoke(this, new WorkspaceUnloadedMessage());
+
+        _viewModel.IsSaving.Should().BeFalse("the save state belonged to the workspace that went away");
+        _viewModel.HasSaveFailures.Should().BeFalse();
+        _viewModel.SaveFailureMessage.Should().BeEmpty();
+    }
+
+    [Test]
+    public void WorkspaceLoaded_DoesNotCarryFailuresOverFromThePreviousWorkspace()
+    {
+        _viewModel.OnLoaded();
+
+        SendFailingResources(new ResourceKey("project:notes.txt"));
+        _workspaceUnloadedHandler!.Invoke(this, new WorkspaceUnloadedMessage());
+
+        _workspaceLoadedHandler!.Invoke(this, new WorkspaceLoadedMessage());
+
+        _viewModel.HasSaveFailures.Should().BeFalse();
+        _viewModel.SaveFailureMessage.Should().BeEmpty();
+    }
+
+    private void SendFailingResources(params ResourceKey[] failingResources)
+    {
+        _saveFailuresHandler!.Invoke(this, new WorkspaceItemSaveFailuresChangedMessage(failingResources));
+    }
+}

--- a/Source/Tests/WorkspaceUI/SaveRetryTrackerTests.cs
+++ b/Source/Tests/WorkspaceUI/SaveRetryTrackerTests.cs
@@ -1,0 +1,141 @@
+using Celbridge.Resources;
+using Celbridge.Workspace;
+using Celbridge.WorkspaceUI.Services;
+
+namespace Celbridge.Tests.WorkspaceUI;
+
+/// <summary>
+/// Tests for the backoff and reporting held against each resource that is waiting to be written again.
+/// </summary>
+[TestFixture]
+public class SaveRetryTrackerTests
+{
+    private static readonly ResourceKey Resource = new("project:notes.txt");
+
+    private SaveRetryTracker _tracker = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _tracker = new SaveRetryTracker();
+    }
+
+    [Test]
+    public void Schedule_StartsTheResourceWaiting()
+    {
+        _tracker.Schedule(Resource, "locked");
+
+        _tracker.IsRetrying(Resource).Should().BeTrue();
+        _tracker.IsWaiting(Resource).Should().BeTrue();
+    }
+
+    [Test]
+    public void Schedule_DoublesTheWaitAfterEachFailure()
+    {
+        _tracker.Schedule(Resource, "locked");
+        _tracker.UpdateTimers(SaveConstants.InitialRetryDelay);
+        _tracker.IsWaiting(Resource).Should().BeFalse("the first wait is the initial delay");
+
+        _tracker.Schedule(Resource, "locked");
+        _tracker.UpdateTimers(SaveConstants.InitialRetryDelay);
+        _tracker.IsWaiting(Resource).Should().BeTrue("the second wait is twice the first");
+    }
+
+    [Test]
+    public void Schedule_CapsTheWaitAtTheMaximum()
+    {
+        // Ten failures would run to hundreds of seconds if the wait were left to double unchecked.
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            _tracker.Schedule(Resource, "locked");
+        }
+
+        _tracker.UpdateTimers(SaveConstants.MaximumRetryDelay);
+
+        _tracker.IsWaiting(Resource).Should().BeFalse();
+    }
+
+    [Test]
+    public void Schedule_ReportsWhetherTheReasonChanged()
+    {
+        _tracker.Schedule(Resource, "locked").Should().BeTrue("the first attempt has no previous reason");
+        _tracker.Schedule(Resource, "locked").Should().BeFalse();
+        _tracker.Schedule(Resource, "read-only").Should().BeTrue();
+    }
+
+    [Test]
+    public void Schedule_KeepsTheResourceReported()
+    {
+        _tracker.Schedule(Resource, "locked");
+        _tracker.StartReporting(Resource);
+
+        _tracker.Schedule(Resource, "locked");
+
+        _tracker.GetReported().Should().Equal(new[] { Resource });
+    }
+
+    [Test]
+    public void StartReporting_ReturnsFalse_WhenTheResourceIsAlreadyReported()
+    {
+        _tracker.Schedule(Resource, "locked");
+
+        _tracker.StartReporting(Resource).Should().BeTrue();
+        _tracker.StartReporting(Resource).Should().BeFalse();
+    }
+
+    [Test]
+    public void StopReporting_LeavesTheResourceBackingOff()
+    {
+        _tracker.Schedule(Resource, "locked");
+        _tracker.StartReporting(Resource);
+
+        _tracker.StopReporting(Resource);
+
+        _tracker.GetReported().Should().BeEmpty();
+        _tracker.IsRetrying(Resource).Should().BeTrue("a resource that is not reported still backs off");
+        _tracker.IsWaiting(Resource).Should().BeTrue();
+    }
+
+    [Test]
+    public void Forget_DropsEverythingHeldAboutTheResource()
+    {
+        _tracker.Schedule(Resource, "locked");
+        _tracker.StartReporting(Resource);
+
+        _tracker.Forget(Resource);
+
+        _tracker.IsRetrying(Resource).Should().BeFalse();
+        _tracker.IsWaiting(Resource).Should().BeFalse();
+        _tracker.GetReported().Should().BeEmpty();
+    }
+
+    [Test]
+    public void ForgetAllExcept_DropsTheResourcesThatAreGone()
+    {
+        var closedResource = new ResourceKey("project:closed.txt");
+        _tracker.Schedule(Resource, "locked");
+        _tracker.Schedule(closedResource, "locked");
+
+        _tracker.ForgetAllExcept(new HashSet<ResourceKey> { Resource });
+
+        _tracker.IsRetrying(Resource).Should().BeTrue();
+        _tracker.IsRetrying(closedResource).Should().BeFalse();
+    }
+
+    [Test]
+    public void ReportedChanges_AreFlaggedOnlyWhenTheReportedResourcesMove()
+    {
+        _tracker.Schedule(Resource, "locked");
+        _tracker.HasReportedChanges.Should().BeFalse("a scheduled wait reports nothing on its own");
+
+        _tracker.StartReporting(Resource);
+        _tracker.HasReportedChanges.Should().BeTrue();
+
+        _tracker.ClearReportedChanges();
+        _tracker.StartReporting(Resource);
+        _tracker.HasReportedChanges.Should().BeFalse("the resource was already reported");
+
+        _tracker.Forget(Resource);
+        _tracker.HasReportedChanges.Should().BeTrue();
+    }
+}

--- a/Source/Tests/WorkspaceUI/SaveRetryTrackerTests.cs
+++ b/Source/Tests/WorkspaceUI/SaveRetryTrackerTests.cs
@@ -5,7 +5,7 @@ using Celbridge.WorkspaceUI.Services;
 namespace Celbridge.Tests.WorkspaceUI;
 
 /// <summary>
-/// Tests for the backoff and reporting held against each resource that is waiting to be written again.
+/// Tests for the backoff held against each resource that is waiting to be written again.
 /// </summary>
 [TestFixture]
 public class SaveRetryTrackerTests
@@ -64,49 +64,14 @@ public class SaveRetryTrackerTests
     }
 
     [Test]
-    public void Schedule_KeepsTheResourceReported()
-    {
-        _tracker.Schedule(Resource, "locked");
-        _tracker.StartReporting(Resource);
-
-        _tracker.Schedule(Resource, "locked");
-
-        _tracker.GetReported().Should().Equal(new[] { Resource });
-    }
-
-    [Test]
-    public void StartReporting_ReturnsFalse_WhenTheResourceIsAlreadyReported()
-    {
-        _tracker.Schedule(Resource, "locked");
-
-        _tracker.StartReporting(Resource).Should().BeTrue();
-        _tracker.StartReporting(Resource).Should().BeFalse();
-    }
-
-    [Test]
-    public void StopReporting_LeavesTheResourceBackingOff()
-    {
-        _tracker.Schedule(Resource, "locked");
-        _tracker.StartReporting(Resource);
-
-        _tracker.StopReporting(Resource);
-
-        _tracker.GetReported().Should().BeEmpty();
-        _tracker.IsRetrying(Resource).Should().BeTrue("a resource that is not reported still backs off");
-        _tracker.IsWaiting(Resource).Should().BeTrue();
-    }
-
-    [Test]
     public void Forget_DropsEverythingHeldAboutTheResource()
     {
         _tracker.Schedule(Resource, "locked");
-        _tracker.StartReporting(Resource);
 
         _tracker.Forget(Resource);
 
         _tracker.IsRetrying(Resource).Should().BeFalse();
         _tracker.IsWaiting(Resource).Should().BeFalse();
-        _tracker.GetReported().Should().BeEmpty();
     }
 
     [Test]
@@ -120,22 +85,5 @@ public class SaveRetryTrackerTests
 
         _tracker.IsRetrying(Resource).Should().BeTrue();
         _tracker.IsRetrying(closedResource).Should().BeFalse();
-    }
-
-    [Test]
-    public void ReportedChanges_AreFlaggedOnlyWhenTheReportedResourcesMove()
-    {
-        _tracker.Schedule(Resource, "locked");
-        _tracker.HasReportedChanges.Should().BeFalse("a scheduled wait reports nothing on its own");
-
-        _tracker.StartReporting(Resource);
-        _tracker.HasReportedChanges.Should().BeTrue();
-
-        _tracker.ClearReportedChanges();
-        _tracker.StartReporting(Resource);
-        _tracker.HasReportedChanges.Should().BeFalse("the resource was already reported");
-
-        _tracker.Forget(Resource);
-        _tracker.HasReportedChanges.Should().BeTrue();
     }
 }

--- a/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
+++ b/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
@@ -7,9 +7,7 @@ using Celbridge.WorkspaceUI.Services;
 namespace Celbridge.Tests.WorkspaceUI;
 
 /// <summary>
-/// The save pass runs against every open document and utility. These tests pin what it reports and how it
-/// retries: an item waiting for its timer is reported as saving while one that cannot be written is
-/// reported as failing, the failing set is sent only when it changes, and the attempts back off.
+/// Tests for the save pass that runs against every open document and utility.
 /// </summary>
 [TestFixture]
 public class WorkspaceItemSaverTests
@@ -287,8 +285,6 @@ public class WorkspaceItemSaverTests
     [Test]
     public async Task SaveModifiedItems_GoesOnRequestingAResourceUpdate_WhileASaveKeepsFailing()
     {
-        // The writable cache is what turns the warning into a read-only editor, so one rebuild that misses
-        // the change must not be the only attempt.
         var item = new FakeWorkspaceItem { SaveSucceeds = false };
         var items = new[] { item };
 
@@ -342,7 +338,7 @@ public class WorkspaceItemSaverTests
         public bool IsDueToSave { get; set; } = true;
 
         // The cadence the item comes due on, re-arming after each due pass as a document does. Left at
-        // zero, IsDueToSave decides instead, which keeps the reporting tests independent of timing.
+        // zero, IsDueToSave decides instead.
         public double SaveDelay { get; init; }
 
         public bool SaveSucceeds { get; set; }

--- a/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
+++ b/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
@@ -287,6 +287,24 @@ public class WorkspaceItemSaverTests
     }
 
     [Test]
+    public async Task SaveModifiedItems_WithdrawsTheFailure_WhenTheItemTurnsNonWritableWhileWaitingToRetry()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+        var items = new[] { item };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        // The wait from the first failure has not elapsed, so no second attempt is made.
+        item.WritableState = WritableState.Locked;
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        item.SaveCount.Should().Be(1);
+        _retryReports.Select(report => report.Count).Should().Equal(
+            new[] { 1, 0 },
+            "the report follows the item's current writable state, not the state at its last attempt");
+    }
+
+    [Test]
     public async Task SaveModifiedItems_GoesOnRequestingAResourceUpdate_WhileASaveKeepsFailing()
     {
         var item = new FakeWorkspaceItem { SaveSucceeds = false };

--- a/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
+++ b/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
@@ -1,0 +1,278 @@
+using Celbridge.Commands;
+using Celbridge.Messaging;
+using Celbridge.Resources;
+using Celbridge.Workspace;
+using Celbridge.WorkspaceUI.Services;
+
+namespace Celbridge.Tests.WorkspaceUI;
+
+/// <summary>
+/// The save tick runs about sixty times a second against every open document and utility. These tests pin
+/// what it reports and how it retries: an item waiting for its timer is reported as saving while one that
+/// cannot be written is reported as failing, the failing set is sent only when it changes, and the
+/// attempts back off.
+/// </summary>
+[TestFixture]
+public class WorkspaceItemSaverTests
+{
+    private const double TickDelta = 0.016;
+
+    // Longer than the one second wait a first failure schedules, so a tick of this length retries.
+    private const double PastFirstRetryDelta = 1.5;
+
+    private IMessengerService _messengerService = null!;
+    private ICommandService _commandService = null!;
+    private WorkspaceItemSaver _workspaceItemSaver = null!;
+
+    private List<int> _pendingSaveCounts = null!;
+    private List<IReadOnlyList<ResourceKey>> _failureReports = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _messengerService = Substitute.For<IMessengerService>();
+        _commandService = Substitute.For<ICommandService>();
+
+        _pendingSaveCounts = new List<int>();
+        _failureReports = new List<IReadOnlyList<ResourceKey>>();
+
+        // Capture the messages so a test can read what the tick reported.
+        _messengerService
+            .When(service => service.Send(Arg.Any<PendingSaveCountMessage>()))
+            .Do(call => _pendingSaveCounts.Add(call.Arg<PendingSaveCountMessage>().Count));
+
+        _messengerService
+            .When(service => service.Send(Arg.Any<WorkspaceItemSaveFailuresChangedMessage>()))
+            .Do(call => _failureReports.Add(call.Arg<WorkspaceItemSaveFailuresChangedMessage>().FailingResources));
+
+        _workspaceItemSaver = new WorkspaceItemSaver(
+            Substitute.For<ILogger<WorkspaceItemSaver>>(),
+            _commandService,
+            _messengerService);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_ReportsAWrittenItemAsNoLongerPending()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = true };
+
+        var result = await _workspaceItemSaver.SaveModifiedItemsAsync(new[] { item }, TickDelta);
+
+        result.IsSuccess.Should().BeTrue();
+        item.SaveCount.Should().Be(1);
+        _pendingSaveCounts.Should().Equal(0);
+        _failureReports.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_CountsAnItemWaitingForItsTimerAsPending()
+    {
+        var item = new FakeWorkspaceItem { IsDueToSave = false };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(new[] { item }, TickDelta);
+
+        item.SaveCount.Should().Be(0);
+        _pendingSaveCounts.Should().Equal(1);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_ReportsAFailingItemAsFailingRatherThanSaving()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+
+        var result = await _workspaceItemSaver.SaveModifiedItemsAsync(new[] { item }, TickDelta);
+
+        result.IsFailure.Should().BeTrue();
+        _pendingSaveCounts.Should().Equal(
+            new[] { 0 },
+            "an item that cannot be written is not in the middle of being saved");
+
+        _failureReports.Should().HaveCount(1);
+        _failureReports[0].Should().ContainSingle()
+            .Which.Should().Be(item.FileResource);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_GoesOnReportingAHealthyItemAsSaving_WhileAnotherIsBlocked()
+    {
+        var healthyItem = new FakeWorkspaceItem
+        {
+            FileResource = new ResourceKey("healthy.md"),
+            IsDueToSave = false
+        };
+
+        var blockedItem = new FakeWorkspaceItem
+        {
+            FileResource = new ResourceKey("blocked.md"),
+            SaveSucceeds = false
+        };
+
+        var items = new[] { healthyItem, blockedItem };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        _pendingSaveCounts.Should().Equal(
+            new[] { 1, 1 },
+            "a document that cannot be written must not stop the workspace reporting that another one is saving");
+
+        _failureReports.Should().HaveCount(1);
+        _failureReports[0].Should().ContainSingle()
+            .Which.Should().Be(blockedItem.FileResource);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_ReportsTheFailingSetOnlyWhenItChanges()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+        var items = new[] { item };
+
+        var firstResult = await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+        var secondResult = await _workspaceItemSaver.SaveModifiedItemsAsync(items, PastFirstRetryDelta);
+
+        firstResult.IsFailure.Should().BeTrue();
+        secondResult.IsSuccess.Should().BeTrue("the failure has already been reported");
+        item.SaveCount.Should().Be(2, "a failed save is attempted again");
+        _failureReports.Should().HaveCount(1);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_WaitsBeforeRetryingAFailedSave()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+        var items = new[] { item };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        item.SaveCount.Should().Be(1, "the item is due on every tick, but the retry wait has not elapsed");
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_LengthensTheWaitAfterEachFailure()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+        var items = new[] { item };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, PastFirstRetryDelta);
+
+        item.SaveCount.Should().Be(2);
+
+        // The second failure doubles the wait to two seconds, so the same tick no longer reaches it.
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, PastFirstRetryDelta);
+
+        item.SaveCount.Should().Be(2);
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, PastFirstRetryDelta);
+
+        item.SaveCount.Should().Be(3);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_ClearsTheFailingSet_WhenASaveSucceeds()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+        var items = new[] { item };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        item.SaveSucceeds = true;
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, PastFirstRetryDelta);
+
+        item.HasUnsavedChanges = true;
+        item.SaveSucceeds = false;
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        _failureReports.Select(report => report.Count).Should().Equal(1, 0, 1);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_ClearsTheFailingSet_WhenTheItemIsClosed()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(new[] { item }, TickDelta);
+        await _workspaceItemSaver.SaveModifiedItemsAsync(Array.Empty<IWorkspaceItem>(), TickDelta);
+        await _workspaceItemSaver.SaveModifiedItemsAsync(new[] { item }, TickDelta);
+
+        _failureReports.Select(report => report.Count).Should().Equal(1, 0, 1);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_ClearsTheFailingSet_WhenAReloadClearsTheItem()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+        var items = new[] { item };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        // An external change reloads the buffer, which clears the unsaved changes without a save.
+        item.HasUnsavedChanges = false;
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        item.HasUnsavedChanges = true;
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        item.SaveCount.Should().Be(2, "the retry wait went with the failure");
+        _failureReports.Select(report => report.Count).Should().Equal(1, 0, 1);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_DoesNotReportANonWritableItem()
+    {
+        var item = new FakeWorkspaceItem
+        {
+            SaveSucceeds = false,
+            WritableState = WritableState.Locked
+        };
+
+        var result = await _workspaceItemSaver.SaveModifiedItemsAsync(new[] { item }, TickDelta);
+
+        result.IsSuccess.Should().BeTrue();
+        _failureReports.Should().BeEmpty("the editor already shows a read-only file as read-only");
+        _pendingSaveCounts.Should().Equal(0);
+    }
+
+    private sealed class FakeWorkspaceItem : IWorkspaceItem
+    {
+        public ResourceKey FileResource { get; init; } = new ResourceKey("test.md");
+
+        public bool HasUnsavedChanges { get; set; } = true;
+
+        public WritableState WritableState { get; set; } = WritableState.Writable;
+
+        // Whether the tick finds the item due to be written.
+        public bool IsDueToSave { get; set; } = true;
+
+        public bool SaveSucceeds { get; set; }
+
+        public int SaveCount { get; private set; }
+
+        public Result<bool> UpdateSaveTimer(double deltaTime)
+        {
+            if (!HasUnsavedChanges)
+            {
+                return Result<bool>.Fail("The item has no unsaved changes.");
+            }
+
+            return IsDueToSave;
+        }
+
+        public async Task<Result> SaveAsync()
+        {
+            await Task.CompletedTask;
+
+            SaveCount++;
+
+            if (!SaveSucceeds)
+            {
+                return Result.Fail("Simulated save failure");
+            }
+
+            HasUnsavedChanges = false;
+
+            return Result.Ok();
+        }
+    }
+}

--- a/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
+++ b/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
@@ -7,10 +7,9 @@ using Celbridge.WorkspaceUI.Services;
 namespace Celbridge.Tests.WorkspaceUI;
 
 /// <summary>
-/// The save tick runs about sixty times a second against every open document and utility. These tests pin
-/// what it reports and how it retries: an item waiting for its timer is reported as saving while one that
-/// cannot be written is reported as failing, the failing set is sent only when it changes, and the
-/// attempts back off.
+/// The save pass runs against every open document and utility. These tests pin what it reports and how it
+/// retries: an item waiting for its timer is reported as saving while one that cannot be written is
+/// reported as failing, the failing set is sent only when it changes, and the attempts back off.
 /// </summary>
 [TestFixture]
 public class WorkspaceItemSaverTests
@@ -234,18 +233,121 @@ public class WorkspaceItemSaverTests
         _pendingSaveCounts.Should().Equal(0);
     }
 
+    [Test]
+    public async Task SaveModifiedItems_DoesNotCountABlockedItemAsPending_WhileItWaitsToRetry()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+        var items = new[] { item };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        // The failure scheduled a wait, and the item is no longer due, so it is neither saving nor retrying.
+        item.IsDueToSave = false;
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        _pendingSaveCounts.Should().Equal(new[] { 0, 0 }, "a blocked item is reported as failing, not as saving");
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_BacksOffANonWritableItem()
+    {
+        var item = new FakeWorkspaceItem
+        {
+            SaveSucceeds = false,
+            WritableState = WritableState.Locked
+        };
+        var items = new[] { item };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        item.SaveCount.Should().Be(1, "a locked file waits rather than being written on every pass");
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, PastFirstRetryDelta);
+
+        item.SaveCount.Should().Be(2);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_WithdrawsTheFailure_WhenTheItemTurnsNonWritable()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+        var items = new[] { item };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        // The resource update the first failure asked for reports the file as read-only.
+        item.WritableState = WritableState.Locked;
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, PastFirstRetryDelta);
+
+        _failureReports.Select(report => report.Count).Should().Equal(new[] { 1, 0 },
+            "a file that turns read-only ends up reported the same way as one that was read-only all along");
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_GoesOnRequestingAResourceUpdate_WhileASaveKeepsFailing()
+    {
+        // The writable cache is what turns the warning into a read-only editor, so one rebuild that misses
+        // the change must not be the only attempt.
+        var item = new FakeWorkspaceItem { SaveSucceeds = false };
+        var items = new[] { item };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, PastFirstRetryDelta);
+
+        _commandService.ReceivedWithAnyArgs(2).Execute<IUpdateResourcesCommand>();
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_ReportsAFailure_WhenTheSaveThrows()
+    {
+        var item = new FakeWorkspaceItem { SaveThrows = true };
+        var items = new[] { item };
+
+        var result = await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+
+        result.IsFailure.Should().BeTrue("an editor that throws is a failed save, not a stopped pass");
+        _failureReports.Select(report => report.Count).Should().Equal(1);
+    }
+
+    [Test]
+    public async Task SaveModifiedItems_RetriesOnTheItemsOwnCadence_WhenItIsNotDueOnEveryPass()
+    {
+        var item = new FakeWorkspaceItem { SaveSucceeds = false, SaveDelay = 1.0 };
+        var items = new[] { item };
+
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
+        item.SaveCount.Should().Be(1);
+
+        // Half a second on, neither the item's timer nor the wait has expired.
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, 0.5);
+        item.SaveCount.Should().Be(1);
+
+        // A second later both have, so the item is written again.
+        await _workspaceItemSaver.SaveModifiedItemsAsync(items, 1.0);
+        item.SaveCount.Should().Be(2);
+    }
+
     private sealed class FakeWorkspaceItem : IWorkspaceItem
     {
+        private double _saveTimer;
+
         public ResourceKey FileResource { get; init; } = new ResourceKey("test.md");
 
         public bool HasUnsavedChanges { get; set; } = true;
 
         public WritableState WritableState { get; set; } = WritableState.Writable;
 
-        // Whether the tick finds the item due to be written.
+        // Whether the pass finds the item due to be written. Ignored once SaveDelay is set.
         public bool IsDueToSave { get; set; } = true;
 
+        // The cadence the item comes due on, re-arming after each due pass as a document does. Left at
+        // zero, IsDueToSave decides instead, which keeps the reporting tests independent of timing.
+        public double SaveDelay { get; init; }
+
         public bool SaveSucceeds { get; set; }
+
+        public bool SaveThrows { get; set; }
 
         public int SaveCount { get; private set; }
 
@@ -256,7 +358,20 @@ public class WorkspaceItemSaverTests
                 return Result<bool>.Fail("The item has no unsaved changes.");
             }
 
-            return IsDueToSave;
+            if (SaveDelay <= 0)
+            {
+                return IsDueToSave;
+            }
+
+            _saveTimer -= deltaTime;
+            if (_saveTimer > 0)
+            {
+                return false;
+            }
+
+            _saveTimer = SaveDelay;
+
+            return true;
         }
 
         public async Task<Result> SaveAsync()
@@ -264,6 +379,11 @@ public class WorkspaceItemSaverTests
             await Task.CompletedTask;
 
             SaveCount++;
+
+            if (SaveThrows)
+            {
+                throw new InvalidOperationException("Simulated save exception");
+            }
 
             if (!SaveSucceeds)
             {

--- a/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
+++ b/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
@@ -25,7 +25,7 @@ public class WorkspaceItemSaverTests
     private WorkspaceItemSaver _workspaceItemSaver = null!;
 
     private List<int> _pendingSaveCounts = null!;
-    private List<IReadOnlyList<ResourceKey>> _failureReports = null!;
+    private List<IReadOnlyList<ResourceKey>> _retryReports = null!;
 
     [SetUp]
     public void Setup()
@@ -34,7 +34,7 @@ public class WorkspaceItemSaverTests
         _commandService = Substitute.For<ICommandService>();
 
         _pendingSaveCounts = new List<int>();
-        _failureReports = new List<IReadOnlyList<ResourceKey>>();
+        _retryReports = new List<IReadOnlyList<ResourceKey>>();
 
         // Capture the messages so a test can read what the tick reported.
         _messengerService
@@ -42,13 +42,14 @@ public class WorkspaceItemSaverTests
             .Do(call => _pendingSaveCounts.Add(call.Arg<PendingSaveCountMessage>().Count));
 
         _messengerService
-            .When(service => service.Send(Arg.Any<WorkspaceItemSaveFailuresChangedMessage>()))
-            .Do(call => _failureReports.Add(call.Arg<WorkspaceItemSaveFailuresChangedMessage>().FailingResources));
+            .When(service => service.Send(Arg.Any<WorkspaceItemSaveRetriesChangedMessage>()))
+            .Do(call => _retryReports.Add(call.Arg<WorkspaceItemSaveRetriesChangedMessage>().RetryingResources));
 
         _workspaceItemSaver = new WorkspaceItemSaver(
             Substitute.For<ILogger<WorkspaceItemSaver>>(),
             _commandService,
-            _messengerService);
+            _messengerService,
+            new SaveRetryTracker());
     }
 
     [Test]
@@ -61,7 +62,7 @@ public class WorkspaceItemSaverTests
         result.IsSuccess.Should().BeTrue();
         item.SaveCount.Should().Be(1);
         _pendingSaveCounts.Should().Equal(0);
-        _failureReports.Should().BeEmpty();
+        _retryReports.Should().BeEmpty();
     }
 
     [Test]
@@ -76,7 +77,7 @@ public class WorkspaceItemSaverTests
     }
 
     [Test]
-    public async Task SaveModifiedItems_ReportsAFailingItemAsFailingRatherThanSaving()
+    public async Task SaveModifiedItems_ReportsARetryingItemAsRetryingRatherThanSaving()
     {
         var item = new FakeWorkspaceItem { SaveSucceeds = false };
 
@@ -87,8 +88,8 @@ public class WorkspaceItemSaverTests
             new[] { 0 },
             "an item that cannot be written is not in the middle of being saved");
 
-        _failureReports.Should().HaveCount(1);
-        _failureReports[0].Should().ContainSingle()
+        _retryReports.Should().HaveCount(1);
+        _retryReports[0].Should().ContainSingle()
             .Which.Should().Be(item.FileResource);
     }
 
@@ -116,13 +117,13 @@ public class WorkspaceItemSaverTests
             new[] { 1, 1 },
             "a document that cannot be written must not stop the workspace reporting that another one is saving");
 
-        _failureReports.Should().HaveCount(1);
-        _failureReports[0].Should().ContainSingle()
+        _retryReports.Should().HaveCount(1);
+        _retryReports[0].Should().ContainSingle()
             .Which.Should().Be(blockedItem.FileResource);
     }
 
     [Test]
-    public async Task SaveModifiedItems_ReportsTheFailingSetOnlyWhenItChanges()
+    public async Task SaveModifiedItems_ReportsTheRetryingSetOnlyWhenItChanges()
     {
         var item = new FakeWorkspaceItem { SaveSucceeds = false };
         var items = new[] { item };
@@ -133,7 +134,7 @@ public class WorkspaceItemSaverTests
         firstResult.IsFailure.Should().BeTrue();
         secondResult.IsSuccess.Should().BeTrue("the failure has already been reported");
         item.SaveCount.Should().Be(2, "a failed save is attempted again");
-        _failureReports.Should().HaveCount(1);
+        _retryReports.Should().HaveCount(1);
     }
 
     [Test]
@@ -170,7 +171,7 @@ public class WorkspaceItemSaverTests
     }
 
     [Test]
-    public async Task SaveModifiedItems_ClearsTheFailingSet_WhenASaveSucceeds()
+    public async Task SaveModifiedItems_ClearsTheRetryingSet_WhenASaveSucceeds()
     {
         var item = new FakeWorkspaceItem { SaveSucceeds = false };
         var items = new[] { item };
@@ -184,11 +185,11 @@ public class WorkspaceItemSaverTests
         item.SaveSucceeds = false;
         await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
 
-        _failureReports.Select(report => report.Count).Should().Equal(1, 0, 1);
+        _retryReports.Select(report => report.Count).Should().Equal(1, 0, 1);
     }
 
     [Test]
-    public async Task SaveModifiedItems_ClearsTheFailingSet_WhenTheItemIsClosed()
+    public async Task SaveModifiedItems_ClearsTheRetryingSet_WhenTheItemIsClosed()
     {
         var item = new FakeWorkspaceItem { SaveSucceeds = false };
 
@@ -196,11 +197,11 @@ public class WorkspaceItemSaverTests
         await _workspaceItemSaver.SaveModifiedItemsAsync(Array.Empty<IWorkspaceItem>(), TickDelta);
         await _workspaceItemSaver.SaveModifiedItemsAsync(new[] { item }, TickDelta);
 
-        _failureReports.Select(report => report.Count).Should().Equal(1, 0, 1);
+        _retryReports.Select(report => report.Count).Should().Equal(1, 0, 1);
     }
 
     [Test]
-    public async Task SaveModifiedItems_ClearsTheFailingSet_WhenAReloadClearsTheItem()
+    public async Task SaveModifiedItems_ClearsTheRetryingSet_WhenAReloadClearsTheItem()
     {
         var item = new FakeWorkspaceItem { SaveSucceeds = false };
         var items = new[] { item };
@@ -215,7 +216,7 @@ public class WorkspaceItemSaverTests
         await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
 
         item.SaveCount.Should().Be(2, "the retry wait went with the failure");
-        _failureReports.Select(report => report.Count).Should().Equal(1, 0, 1);
+        _retryReports.Select(report => report.Count).Should().Equal(1, 0, 1);
     }
 
     [Test]
@@ -230,7 +231,7 @@ public class WorkspaceItemSaverTests
         var result = await _workspaceItemSaver.SaveModifiedItemsAsync(new[] { item }, TickDelta);
 
         result.IsSuccess.Should().BeTrue();
-        _failureReports.Should().BeEmpty("the editor already shows a read-only file as read-only");
+        _retryReports.Should().BeEmpty("the editor already shows a read-only file as read-only");
         _pendingSaveCounts.Should().Equal(0);
     }
 
@@ -281,7 +282,7 @@ public class WorkspaceItemSaverTests
         item.WritableState = WritableState.Locked;
         await _workspaceItemSaver.SaveModifiedItemsAsync(items, PastFirstRetryDelta);
 
-        _failureReports.Select(report => report.Count).Should().Equal(new[] { 1, 0 },
+        _retryReports.Select(report => report.Count).Should().Equal(new[] { 1, 0 },
             "a file that turns read-only ends up reported the same way as one that was read-only all along");
     }
 
@@ -306,7 +307,7 @@ public class WorkspaceItemSaverTests
         var result = await _workspaceItemSaver.SaveModifiedItemsAsync(items, TickDelta);
 
         result.IsFailure.Should().BeTrue("an editor that throws is a failed save, not a stopped pass");
-        _failureReports.Select(report => report.Count).Should().Equal(1);
+        _retryReports.Select(report => report.Count).Should().Equal(1);
     }
 
     [Test]

--- a/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
+++ b/Source/Tests/WorkspaceUI/WorkspaceItemSaverTests.cs
@@ -17,6 +17,9 @@ public class WorkspaceItemSaverTests
     // Longer than the one second wait a first failure schedules, so a tick of this length retries.
     private const double PastFirstRetryDelta = 1.5;
 
+    // Short enough that a stalled write does not slow the suite.
+    private const double FlushTimeout = 0.1;
+
     private IMessengerService _messengerService = null!;
     private ICommandService _commandService = null!;
     private WorkspaceItemSaver _workspaceItemSaver = null!;
@@ -324,6 +327,61 @@ public class WorkspaceItemSaverTests
         item.SaveCount.Should().Be(2);
     }
 
+    [Test]
+    public async Task FlushModifiedItems_WritesEveryItemHoldingUnsavedChanges()
+    {
+        var document = new FakeWorkspaceItem { FileResource = new ResourceKey("project:notes.txt"), SaveSucceeds = true };
+        var utility = new FakeWorkspaceItem { FileResource = new ResourceKey("project:panel.toml"), SaveSucceeds = true };
+
+        await _workspaceItemSaver.FlushModifiedItemsAsync(new[] { document, utility }, FlushTimeout);
+
+        document.SaveCount.Should().Be(1);
+        utility.SaveCount.Should().Be(1, "a utility is written by the same flush as a document");
+    }
+
+    [Test]
+    public async Task FlushModifiedItems_SkipsAnItemWithNothingUnwritten()
+    {
+        var item = new FakeWorkspaceItem { HasUnsavedChanges = false, SaveSucceeds = true };
+
+        await _workspaceItemSaver.FlushModifiedItemsAsync(new[] { item }, FlushTimeout);
+
+        item.SaveCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task FlushModifiedItems_AbandonsAnItemThatDoesNotWriteInTime()
+    {
+        var stalledItem = new FakeWorkspaceItem { FileResource = new ResourceKey("project:stalled.txt"), SaveHangs = true };
+        var nextItem = new FakeWorkspaceItem { FileResource = new ResourceKey("project:notes.txt"), SaveSucceeds = true };
+
+        await _workspaceItemSaver.FlushModifiedItemsAsync(new[] { stalledItem, nextItem }, FlushTimeout);
+
+        nextItem.SaveCount.Should().Be(1, "one editor that never answers must not hold the workspace open");
+    }
+
+    [Test]
+    public async Task FlushModifiedItems_ContinuesAfterAnItemThrows()
+    {
+        var throwingItem = new FakeWorkspaceItem { FileResource = new ResourceKey("project:throws.txt"), SaveThrows = true };
+        var nextItem = new FakeWorkspaceItem { FileResource = new ResourceKey("project:notes.txt"), SaveSucceeds = true };
+
+        await _workspaceItemSaver.FlushModifiedItemsAsync(new[] { throwingItem, nextItem }, FlushTimeout);
+
+        nextItem.SaveCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task FlushModifiedItems_ContinuesAfterAFailedWrite()
+    {
+        var failingItem = new FakeWorkspaceItem { FileResource = new ResourceKey("project:locked.txt"), SaveSucceeds = false };
+        var nextItem = new FakeWorkspaceItem { FileResource = new ResourceKey("project:notes.txt"), SaveSucceeds = true };
+
+        await _workspaceItemSaver.FlushModifiedItemsAsync(new[] { failingItem, nextItem }, FlushTimeout);
+
+        nextItem.SaveCount.Should().Be(1);
+    }
+
     private sealed class FakeWorkspaceItem : IWorkspaceItem
     {
         private double _saveTimer;
@@ -344,6 +402,9 @@ public class WorkspaceItemSaverTests
         public bool SaveSucceeds { get; set; }
 
         public bool SaveThrows { get; set; }
+
+        // Whether the write never completes, as an editor that has stopped answering does.
+        public bool SaveHangs { get; init; }
 
         public int SaveCount { get; private set; }
 
@@ -375,6 +436,11 @@ public class WorkspaceItemSaverTests
             await Task.CompletedTask;
 
             SaveCount++;
+
+            if (SaveHangs)
+            {
+                await Task.Delay(Timeout.Infinite);
+            }
 
             if (SaveThrows)
             {

--- a/Source/Tests/WorkspaceUI/WorkspaceToastViewModelTests.cs
+++ b/Source/Tests/WorkspaceUI/WorkspaceToastViewModelTests.cs
@@ -27,7 +27,7 @@ public class WorkspaceToastViewModelTests
     private MessageHandler<object, ProjectLoadNotificationMessage>? _loadHandler;
     private MessageHandler<object, ResourceOperationFailedMessage>? _operationHandler;
     private MessageHandler<object, EditorNotificationMessage>? _editorHandler;
-    private MessageHandler<object, WorkspaceItemSaveFailedMessage>? _saveFailureHandler;
+    private MessageHandler<object, WorkspaceItemSaveDiscardedMessage>? _saveDiscardedHandler;
 
     private WorkspaceToastViewModel _viewModel = null!;
 
@@ -61,8 +61,8 @@ public class WorkspaceToastViewModelTests
         _messengerService
             .When(service => service.Register(
                 Arg.Any<object>(),
-                Arg.Any<MessageHandler<object, WorkspaceItemSaveFailedMessage>>()))
-            .Do(call => _saveFailureHandler = call.Arg<MessageHandler<object, WorkspaceItemSaveFailedMessage>>());
+                Arg.Any<MessageHandler<object, WorkspaceItemSaveDiscardedMessage>>()))
+            .Do(call => _saveDiscardedHandler = call.Arg<MessageHandler<object, WorkspaceItemSaveDiscardedMessage>>());
 
         // The view model marshals onto the UI thread; run inline so the assertions see the result.
         _dispatcher.TryEnqueue(Arg.Any<Action>()).Returns(call =>
@@ -313,31 +313,15 @@ public class WorkspaceToastViewModelTests
     }
 
     [Test]
-    public void AOneItemSaveFailure_NamesItAndItsReasonWithNoReportAction()
+    public void DiscardedEditsOnClose_NameTheFileAsAnError()
     {
-        SendSaveFailure(new FailedResource(new ResourceKey("project:notes.txt"), "the file is locked"));
+        var message = new WorkspaceItemSaveDiscardedMessage(new ResourceKey("project:notes.txt"));
 
-        _viewModel.ToastSeverity.Should().Be(InfoBarSeverity.Error);
+        _saveDiscardedHandler!.Invoke(this, message);
+
+        _viewModel.ToastMessage.Should().Contain("Toast_SaveDiscarded");
         _viewModel.ToastMessage.Should().Contain("notes.txt");
-        _viewModel.ToastMessage.Should().Contain("the file is locked");
-        _viewModel.IsActionVisible.Should().BeFalse();
-    }
-
-    [Test]
-    public void SeveralItemSaveFailures_CountThemWithNoReportAction()
-    {
-        SendSaveFailure(
-            new FailedResource(new ResourceKey("project:notes.txt"), "the file is locked"),
-            new FailedResource(new ResourceKey("project:data.json"), "the file is locked"));
-
-        _viewModel.ToastMessage.Should().Contain("Toast_SaveFailed_Multiple");
-        _viewModel.ToastMessage.Should().Contain("2");
-        _viewModel.IsActionVisible.Should().BeFalse();
-    }
-
-    private void SendSaveFailure(params FailedResource[] failedItems)
-    {
-        _saveFailureHandler!.Invoke(this, new WorkspaceItemSaveFailedMessage(failedItems));
+        _viewModel.ToastSeverity.Should().Be(InfoBarSeverity.Error);
     }
 
     private void SendOperationFailure(ResourceOperationType operationType, params string[] failedItems)

--- a/Source/Tests/WorkspaceUI/WorkspaceToastViewModelTests.cs
+++ b/Source/Tests/WorkspaceUI/WorkspaceToastViewModelTests.cs
@@ -322,6 +322,7 @@ public class WorkspaceToastViewModelTests
         _viewModel.ToastMessage.Should().Contain("Toast_SaveDiscarded");
         _viewModel.ToastMessage.Should().Contain("notes.txt");
         _viewModel.ToastSeverity.Should().Be(InfoBarSeverity.Error);
+        _viewModel.IsActionVisible.Should().BeFalse("there is no report to open for a discarded save");
     }
 
     private void SendOperationFailure(ResourceOperationType operationType, params string[] failedItems)

--- a/Source/Workspace/Celbridge.Documents/Helpers/AbandonedTaskObserver.cs
+++ b/Source/Workspace/Celbridge.Documents/Helpers/AbandonedTaskObserver.cs
@@ -1,0 +1,20 @@
+namespace Celbridge.Documents.Helpers;
+
+/// <summary>
+/// Observes the faults of tasks that are no longer awaited.
+/// </summary>
+public static class AbandonedTaskObserver
+{
+    /// <summary>
+    /// Swallows the eventual fault of an abandoned task, which faults when the work behind it is torn
+    /// down. Reading Exception marks it observed, so it does not surface as an unobserved task exception.
+    /// </summary>
+    public static void Observe(Task task)
+    {
+        _ = task.ContinueWith(
+            static abandonedTask => { _ = abandonedTask.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+    }
+}

--- a/Source/Workspace/Celbridge.Documents/Helpers/AbandonedTaskObserver.cs
+++ b/Source/Workspace/Celbridge.Documents/Helpers/AbandonedTaskObserver.cs
@@ -6,8 +6,8 @@ namespace Celbridge.Documents.Helpers;
 public static class AbandonedTaskObserver
 {
     /// <summary>
-    /// Swallows the eventual fault of an abandoned task, which faults when the work behind it is torn
-    /// down. Reading Exception marks it observed, so it does not surface as an unobserved task exception.
+    /// Swallows the eventual fault of an abandoned task. Reading Exception marks it observed, so it does
+    /// not surface as an unobserved task exception.
     /// </summary>
     public static void Observe(Task task)
     {

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -40,41 +40,6 @@ public class DocumentsService : IDocumentsService, IDisposable
     // Reads TabView-backed state, so callers must be on the UI thread.
     public IReadOnlyList<IWorkspaceItem> GetWorkspaceItems() => DocumentsPanel.GetWorkspaceItems();
 
-    public async Task FlushModifiedDocumentsAsync()
-    {
-        foreach (var workspaceItem in GetWorkspaceItems())
-        {
-            if (!workspaceItem.HasUnsavedChanges)
-            {
-                continue;
-            }
-
-            try
-            {
-                var saveTask = workspaceItem.SaveAsync();
-                var timeoutTask = Task.Delay(TimeSpan.FromSeconds(SaveConstants.UnloadFlushTimeout));
-                var completedTask = await Task.WhenAny(saveTask, timeoutTask);
-
-                if (completedTask != saveTask)
-                {
-                    _logger.LogError($"Document did not write within {SaveConstants.UnloadFlushTimeout}s, so its unsaved content was discarded: '{workspaceItem.FileResource}'");
-                    AbandonedTaskObserver.Observe(saveTask);
-                    continue;
-                }
-
-                var saveResult = await saveTask;
-                if (saveResult.IsFailure)
-                {
-                    _logger.LogError($"Failed to write unsaved content, so it was discarded: '{workspaceItem.FileResource}'. {saveResult.DiagnosticReport}");
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"An exception occurred while writing unsaved content, so it was discarded: '{workspaceItem.FileResource}'");
-            }
-        }
-    }
-
     public IReadOnlyList<OpenDocumentInfo> GetOpenDocuments() => DocumentsPanel.GetOpenDocuments();
 
     public OpenDocumentInfo? FindOpenDocument(ResourceKey fileResource)

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -51,8 +51,6 @@ public class DocumentsService : IDocumentsService, IDisposable
 
             try
             {
-                // Race the write against a hard timeout and abandon it on timeout, so an editor that
-                // never answers cannot hold the workspace open.
                 var saveTask = workspaceItem.SaveAsync();
                 var timeoutTask = Task.Delay(TimeSpan.FromSeconds(SaveConstants.UnloadFlushTimeout));
                 var completedTask = await Task.WhenAny(saveTask, timeoutTask);

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -40,6 +40,30 @@ public class DocumentsService : IDocumentsService, IDisposable
     // Reads TabView-backed state, so callers must be on the UI thread.
     public IReadOnlyList<IWorkspaceItem> GetWorkspaceItems() => DocumentsPanel.GetWorkspaceItems();
 
+    public async Task FlushModifiedDocumentsAsync()
+    {
+        foreach (var workspaceItem in GetWorkspaceItems())
+        {
+            if (!workspaceItem.HasUnsavedChanges)
+            {
+                continue;
+            }
+
+            try
+            {
+                var saveResult = await workspaceItem.SaveAsync();
+                if (saveResult.IsFailure)
+                {
+                    _logger.LogError($"Failed to write unsaved content for document: '{workspaceItem.FileResource}'. {saveResult.DiagnosticReport}");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"An exception occurred while writing unsaved content for document: '{workspaceItem.FileResource}'");
+            }
+        }
+    }
+
     public IReadOnlyList<OpenDocumentInfo> GetOpenDocuments() => DocumentsPanel.GetOpenDocuments();
 
     public OpenDocumentInfo? FindOpenDocument(ResourceKey fileResource)

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -38,7 +38,7 @@ public class DocumentsService : IDocumentsService, IDisposable
             : ResourceKey.Empty;
 
     // Reads TabView-backed state, so callers must be on the UI thread.
-    public IReadOnlyList<ISaveableWorkspaceItem> GetSaveableItems() => DocumentsPanel.GetSaveableItems();
+    public IReadOnlyList<IWorkspaceItem> GetWorkspaceItems() => DocumentsPanel.GetWorkspaceItems();
 
     public IReadOnlyList<OpenDocumentInfo> GetOpenDocuments() => DocumentsPanel.GetOpenDocuments();
 

--- a/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/DocumentsService.cs
@@ -51,15 +51,28 @@ public class DocumentsService : IDocumentsService, IDisposable
 
             try
             {
-                var saveResult = await workspaceItem.SaveAsync();
+                // Race the write against a hard timeout and abandon it on timeout, so an editor that
+                // never answers cannot hold the workspace open.
+                var saveTask = workspaceItem.SaveAsync();
+                var timeoutTask = Task.Delay(TimeSpan.FromSeconds(SaveConstants.UnloadFlushTimeout));
+                var completedTask = await Task.WhenAny(saveTask, timeoutTask);
+
+                if (completedTask != saveTask)
+                {
+                    _logger.LogError($"Document did not write within {SaveConstants.UnloadFlushTimeout}s, so its unsaved content was discarded: '{workspaceItem.FileResource}'");
+                    AbandonedTaskObserver.Observe(saveTask);
+                    continue;
+                }
+
+                var saveResult = await saveTask;
                 if (saveResult.IsFailure)
                 {
-                    _logger.LogError($"Failed to write unsaved content for document: '{workspaceItem.FileResource}'. {saveResult.DiagnosticReport}");
+                    _logger.LogError($"Failed to write unsaved content, so it was discarded: '{workspaceItem.FileResource}'. {saveResult.DiagnosticReport}");
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"An exception occurred while writing unsaved content for document: '{workspaceItem.FileResource}'");
+                _logger.LogError(ex, $"An exception occurred while writing unsaved content, so it was discarded: '{workspaceItem.FileResource}'");
             }
         }
     }

--- a/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
@@ -520,26 +520,16 @@ public class UtilityService : IUtilityService, IDisposable
         return new List<IWorkspaceItem>(_utilities);
     }
 
-    public async Task TeardownUtilitiesAsync()
+    public Task TeardownUtilitiesAsync()
     {
         foreach (var utility in _utilities)
         {
-            try
-            {
-                if (utility.HasUnsavedChanges)
-                {
-                    await utility.SaveAsync();
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to flush utility during teardown");
-            }
-
             utility.Teardown();
         }
 
         _utilities.Clear();
+
+        return Task.CompletedTask;
     }
 
     public void Dispose()

--- a/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
@@ -515,9 +515,9 @@ public class UtilityService : IUtilityService, IDisposable
         _messengerService.Send(new FlashDocumentMessage(fileResource));
     }
 
-    public IReadOnlyList<ISaveableWorkspaceItem> GetSaveableItems()
+    public IReadOnlyList<IWorkspaceItem> GetWorkspaceItems()
     {
-        return new List<ISaveableWorkspaceItem>(_utilities);
+        return new List<IWorkspaceItem>(_utilities);
     }
 
     public async Task TeardownUtilitiesAsync()

--- a/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
+++ b/Source/Workspace/Celbridge.Documents/Services/UtilityService.cs
@@ -1,4 +1,5 @@
 using Celbridge.Commands;
+using Celbridge.Community;
 using Celbridge.Documents.Views;
 using Celbridge.Logging;
 using Celbridge.Messaging;
@@ -6,7 +7,6 @@ using Celbridge.Packages;
 using Celbridge.Projects;
 using Celbridge.UserInterface;
 using Celbridge.UserInterface.Helpers;
-using Celbridge.Community;
 using Celbridge.Workspace;
 using Microsoft.Extensions.Localization;
 
@@ -520,7 +520,7 @@ public class UtilityService : IUtilityService, IDisposable
         return new List<IWorkspaceItem>(_utilities);
     }
 
-    public Task TeardownUtilitiesAsync()
+    public async Task TeardownUtilitiesAsync()
     {
         foreach (var utility in _utilities)
         {
@@ -529,7 +529,9 @@ public class UtilityService : IUtilityService, IDisposable
 
         _utilities.Clear();
 
-        return Task.CompletedTask;
+        await Task.CompletedTask;
+
+        return;
     }
 
     public void Dispose()

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
@@ -46,7 +46,7 @@ public partial class DocumentTabViewModel : ObservableObject
     private string _editorDisplayName = string.Empty;
 
     [ObservableProperty]
-    private bool _hasSaveFailure;
+    private bool _isSaveRetrying;
 
     /// <summary>
     /// True when this tab borrows a utility's live view rather than holding a document of its own. Such a
@@ -107,7 +107,7 @@ public partial class DocumentTabViewModel : ObservableObject
         {
             var description = ComposeTabDescription();
 
-            if (!HasSaveFailure)
+            if (!IsSaveRetrying)
             {
                 return description;
             }
@@ -160,7 +160,7 @@ public partial class DocumentTabViewModel : ObservableObject
     {
         OnPropertyChanged(nameof(FileName));
 
-        RefreshSaveFailure();
+        RefreshSaveState();
     }
 
     public IDocumentView? DocumentView { get; set; }
@@ -189,28 +189,28 @@ public partial class DocumentTabViewModel : ObservableObject
 
         _messengerService.Register<ResourceRegistryUpdatedMessage>(this, OnResourceRegistryUpdatedMessage);
         _messengerService.Register<ResourceKeyChangedMessage>(this, OnResourceKeyChangedMessage);
-        _messengerService.Register<WorkspaceItemSaveFailuresChangedMessage>(this, OnSaveFailuresChanged);
+        _messengerService.Register<WorkspaceItemSaveRetriesChangedMessage>(this, OnSaveRetriesChanged);
     }
 
-    private void OnSaveFailuresChanged(object recipient, WorkspaceItemSaveFailuresChangedMessage message)
+    private void OnSaveRetriesChanged(object recipient, WorkspaceItemSaveRetriesChangedMessage message)
     {
-        HasSaveFailure = message.FailingResources.Contains(FileResource);
+        IsSaveRetrying = message.RetryingResources.Contains(FileResource);
     }
 
-    // The failing set is only sent when it changes, so a tab opened onto an already-failing resource
-    // must read the current state.
-    private void RefreshSaveFailure()
+    private void RefreshSaveState()
     {
         if (!_workspaceWrapper.IsWorkspaceLoaded)
         {
             return;
         }
 
-        var failingResources = _workspaceWrapper.WorkspaceService.GetFailingSaveResources();
-        HasSaveFailure = failingResources.Contains(FileResource);
+        // The retrying set is only sent when it changes, so a tab that appears later has missed it and
+        // reads the current set instead.
+        var retryingResources = _workspaceWrapper.WorkspaceService.GetRetryingResources();
+        IsSaveRetrying = retryingResources.Contains(FileResource);
     }
 
-    partial void OnHasSaveFailureChanged(bool value)
+    partial void OnIsSaveRetryingChanged(bool value)
     {
         OnPropertyChanged(nameof(TabTooltip));
     }

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
@@ -197,8 +197,8 @@ public partial class DocumentTabViewModel : ObservableObject
         HasSaveFailure = message.FailingResources.Contains(FileResource);
     }
 
-    // The failing set is only sent when it changes, so a tab opened onto a resource that is already failing
-    // never receives that message and has to read the current state instead.
+    // The failing set is only sent when it changes, so a tab opened onto an already-failing resource
+    // must read the current state.
     private void RefreshSaveFailure()
     {
         if (!_workspaceWrapper.IsWorkspaceLoaded)
@@ -345,9 +345,8 @@ public partial class DocumentTabViewModel : ObservableObject
                 // Discard the unsaved edits and proceed to teardown.
                 _logger.LogWarning(saveResult, $"Saving document failed during close. Discarding unsaved edits for file resource: '{FileResource}'");
 
-                // The edits go with the view, and this is the last point the user can be told they are
-                // gone. A docked utility keeps its view and its content when the tab closes, so it has
-                // lost nothing to report.
+                // A docked utility keeps its view and its content when the tab closes, so nothing is
+                // discarded.
                 if (!IsDockedUtility)
                 {
                     var discardedMessage = new WorkspaceItemSaveDiscardedMessage(FileResource);

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
@@ -3,6 +3,7 @@ using Celbridge.Logging;
 using Celbridge.Messaging;
 using Celbridge.Workspace;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.Localization;
 
 namespace Celbridge.Documents.ViewModels;
 
@@ -30,6 +31,8 @@ public partial class DocumentTabViewModel : ObservableObject
     private readonly ICommandService _commandService;
     private readonly ILogger<DocumentTabViewModel> _logger;
     private readonly IResourceRegistry _resourceRegistry;
+    private readonly IStringLocalizer _stringLocalizer;
+    private readonly IDispatcher _dispatcher;
 
     [ObservableProperty]
     private ResourceKey _fileResource;
@@ -42,6 +45,9 @@ public partial class DocumentTabViewModel : ObservableObject
 
     [ObservableProperty]
     private string _editorDisplayName = string.Empty;
+
+    [ObservableProperty]
+    private bool _hasSaveFailure;
 
     /// <summary>
     /// True when this tab borrows a utility's live view rather than holding a document of its own. Such a
@@ -94,24 +100,36 @@ public partial class DocumentTabViewModel : ObservableObject
     /// <summary>
     /// Tooltip text for the tab. A utility tab shows its manifest description, falling back to its title
     /// when none is declared. An ordinary tab shows its file path plus the editor name when multiple
-    /// editors are available.
+    /// editors are available. A tab whose file cannot be written says so below that.
     /// </summary>
     public string TabTooltip
     {
         get
         {
-            if (IsUtilityEditor)
+            var description = ComposeTabDescription();
+
+            if (!HasSaveFailure)
             {
-                return string.IsNullOrEmpty(UtilityTooltip) ? DocumentName : UtilityTooltip;
+                return description;
             }
 
-            if (string.IsNullOrEmpty(EditorDisplayName))
-            {
-                return FilePath;
-            }
-
-            return $"{FilePath} - {EditorDisplayName}";
+            return _stringLocalizer.GetString("DocumentTab_Tooltip_SaveFailed", description);
         }
+    }
+
+    private string ComposeTabDescription()
+    {
+        if (IsUtilityEditor)
+        {
+            return string.IsNullOrEmpty(UtilityTooltip) ? DocumentName : UtilityTooltip;
+        }
+
+        if (string.IsNullOrEmpty(EditorDisplayName))
+        {
+            return FilePath;
+        }
+
+        return _stringLocalizer.GetString("DocumentTab_Tooltip_WithEditor", FilePath, EditorDisplayName);
     }
 
     partial void OnFilePathChanged(string? oldValue, string newValue)
@@ -153,12 +171,16 @@ public partial class DocumentTabViewModel : ObservableObject
         IMessengerService messengerService,
         ICommandService commandService,
         ILogger<DocumentTabViewModel> logger,
-        IWorkspaceWrapper workspaceWrapper)
+        IWorkspaceWrapper workspaceWrapper,
+        IStringLocalizer stringLocalizer,
+        IDispatcher dispatcher)
     {
         _messengerService = messengerService;
         _commandService = commandService;
         _logger = logger;
         _workspaceWrapper = workspaceWrapper;
+        _stringLocalizer = stringLocalizer;
+        _dispatcher = dispatcher;
         _resourceRegistry = workspaceWrapper.WorkspaceService.ResourceService.Registry;
 
         // Reordering a TabViewItem adds it in the new position before removing it from the old, so Unloaded
@@ -168,6 +190,28 @@ public partial class DocumentTabViewModel : ObservableObject
 
         _messengerService.Register<ResourceRegistryUpdatedMessage>(this, OnResourceRegistryUpdatedMessage);
         _messengerService.Register<ResourceKeyChangedMessage>(this, OnResourceKeyChangedMessage);
+        _messengerService.Register<WorkspaceItemSaveFailuresChangedMessage>(this, OnSaveFailuresChanged);
+    }
+
+    private void OnSaveFailuresChanged(object recipient, WorkspaceItemSaveFailuresChangedMessage message)
+    {
+        var isFailing = false;
+        foreach (var failingResource in message.FailingResources)
+        {
+            if (failingResource == FileResource)
+            {
+                isFailing = true;
+                break;
+            }
+        }
+
+        // Raised from the workspace update loop, which does not run on the UI thread.
+        _dispatcher.TryEnqueue(() => HasSaveFailure = isFailing);
+    }
+
+    partial void OnHasSaveFailureChanged(bool value)
+    {
+        OnPropertyChanged(nameof(TabTooltip));
     }
 
     /// <summary>
@@ -299,6 +343,11 @@ public partial class DocumentTabViewModel : ObservableObject
                 // permanently-refused save would otherwise jam the close path forever.
                 // Discard the unsaved edits and proceed to teardown.
                 _logger.LogWarning(saveResult, $"Saving document failed during close. Discarding unsaved edits for file resource: '{FileResource}'");
+
+                // The edits go with the view, and this is the last point the user can be told they are
+                // gone. The auto-save notification they saw earlier said only that a write had failed.
+                var discardedMessage = new WorkspaceItemSaveDiscardedMessage(FileResource);
+                _messengerService.Send(discardedMessage);
 
                 // If the cached writable state still reads Writable, an external attribute change
                 // probably slipped past the watcher. Schedule a resource update so the cache catches

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
@@ -32,7 +32,6 @@ public partial class DocumentTabViewModel : ObservableObject
     private readonly ILogger<DocumentTabViewModel> _logger;
     private readonly IResourceRegistry _resourceRegistry;
     private readonly IStringLocalizer _stringLocalizer;
-    private readonly IDispatcher _dispatcher;
 
     [ObservableProperty]
     private ResourceKey _fileResource;
@@ -160,6 +159,8 @@ public partial class DocumentTabViewModel : ObservableObject
     partial void OnFileResourceChanged(ResourceKey oldValue, ResourceKey newValue)
     {
         OnPropertyChanged(nameof(FileName));
+
+        RefreshSaveFailure();
     }
 
     public IDocumentView? DocumentView { get; set; }
@@ -172,15 +173,13 @@ public partial class DocumentTabViewModel : ObservableObject
         ICommandService commandService,
         ILogger<DocumentTabViewModel> logger,
         IWorkspaceWrapper workspaceWrapper,
-        IStringLocalizer stringLocalizer,
-        IDispatcher dispatcher)
+        IStringLocalizer stringLocalizer)
     {
         _messengerService = messengerService;
         _commandService = commandService;
         _logger = logger;
         _workspaceWrapper = workspaceWrapper;
         _stringLocalizer = stringLocalizer;
-        _dispatcher = dispatcher;
         _resourceRegistry = workspaceWrapper.WorkspaceService.ResourceService.Registry;
 
         // Reordering a TabViewItem adds it in the new position before removing it from the old, so Unloaded
@@ -195,18 +194,20 @@ public partial class DocumentTabViewModel : ObservableObject
 
     private void OnSaveFailuresChanged(object recipient, WorkspaceItemSaveFailuresChangedMessage message)
     {
-        var isFailing = false;
-        foreach (var failingResource in message.FailingResources)
+        HasSaveFailure = message.FailingResources.Contains(FileResource);
+    }
+
+    // The failing set is only sent when it changes, so a tab opened onto a resource that is already failing
+    // never receives that message and has to read the current state instead.
+    private void RefreshSaveFailure()
+    {
+        if (!_workspaceWrapper.IsWorkspaceLoaded)
         {
-            if (failingResource == FileResource)
-            {
-                isFailing = true;
-                break;
-            }
+            return;
         }
 
-        // Raised from the workspace update loop, which does not run on the UI thread.
-        _dispatcher.TryEnqueue(() => HasSaveFailure = isFailing);
+        var failingResources = _workspaceWrapper.WorkspaceService.GetFailingSaveResources();
+        HasSaveFailure = failingResources.Contains(FileResource);
     }
 
     partial void OnHasSaveFailureChanged(bool value)
@@ -345,9 +346,13 @@ public partial class DocumentTabViewModel : ObservableObject
                 _logger.LogWarning(saveResult, $"Saving document failed during close. Discarding unsaved edits for file resource: '{FileResource}'");
 
                 // The edits go with the view, and this is the last point the user can be told they are
-                // gone. The auto-save notification they saw earlier said only that a write had failed.
-                var discardedMessage = new WorkspaceItemSaveDiscardedMessage(FileResource);
-                _messengerService.Send(discardedMessage);
+                // gone. A docked utility keeps its view and its content when the tab closes, so it has
+                // lost nothing to report.
+                if (!IsDockedUtility)
+                {
+                    var discardedMessage = new WorkspaceItemSaveDiscardedMessage(FileResource);
+                    _messengerService.Send(discardedMessage);
+                }
 
                 // If the cached writable state still reads Writable, an external attribute change
                 // probably slipped past the watcher. Schedule a resource update so the cache catches

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentViewModel.cs
@@ -59,8 +59,7 @@ public abstract partial class DocumentViewModel : ObservableObject
             return false;
         }
 
-        // Restarted so content that is still unwritten comes due again after another delay. A save that
-        // succeeds clears HasUnsavedChanges, which ends the cycle at the guard above.
+        // Restarted so content that is still unwritten comes due again after another delay.
         SaveTimer = SaveConstants.SaveDelay;
 
         return true;

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentViewModel.cs
@@ -8,9 +8,6 @@ namespace Celbridge.Documents.ViewModels;
 
 public abstract partial class DocumentViewModel : ObservableObject
 {
-    // Delay before saving the document after the most recent change
-    protected const double SaveDelay = 1.0; // Seconds
-
     private IMessengerService? _messengerService;
     private ILogger<DocumentViewModel>? _logger;
 
@@ -43,7 +40,7 @@ public abstract partial class DocumentViewModel : ObservableObject
     public virtual void OnDataChanged()
     {
         HasUnsavedChanges = true;
-        SaveTimer = SaveDelay;
+        SaveTimer = SaveConstants.SaveDelay;
     }
 
     /// <summary>
@@ -64,7 +61,7 @@ public abstract partial class DocumentViewModel : ObservableObject
 
         // Restarted so content that is still unwritten comes due again after another delay. A save that
         // succeeds clears HasUnsavedChanges, which ends the cycle at the guard above.
-        SaveTimer = SaveDelay;
+        SaveTimer = SaveConstants.SaveDelay;
 
         return true;
     }
@@ -150,7 +147,7 @@ public abstract partial class DocumentViewModel : ObservableObject
 
     /// <summary>
     /// Saves text content as UTF-8 (no BOM) to the file at FilePath.
-    /// Callers are responsible for managing HasUnsavedChanges and SaveTimer.
+    /// Callers are responsible for clearing HasUnsavedChanges once the write has succeeded.
     /// </summary>
     protected async Task<Result> SaveTextToFileAsync(string text)
     {
@@ -160,7 +157,7 @@ public abstract partial class DocumentViewModel : ObservableObject
 
     /// <summary>
     /// Decodes base64 content and saves the raw bytes to the file at FilePath.
-    /// Callers are responsible for managing HasUnsavedChanges and SaveTimer.
+    /// Callers are responsible for clearing HasUnsavedChanges once the write has succeeded.
     /// Returns failure if the content is not valid base64.
     /// </summary>
     protected async Task<Result> SaveBinaryToFileAsync(string base64Content)

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentViewModel.cs
@@ -56,17 +56,17 @@ public abstract partial class DocumentViewModel : ObservableObject
             return Result<bool>.Fail($"Document does not have unsaved changes: {FileResource}");
         }
 
+        SaveTimer -= deltaTime;
         if (SaveTimer > 0)
         {
-            SaveTimer -= deltaTime;
-            if (SaveTimer <= 0)
-            {
-                SaveTimer = 0;
-                return true;
-            }
+            return false;
         }
 
-        return false;
+        // Restarted so content that is still unwritten comes due again after another delay. A save that
+        // succeeds clears HasUnsavedChanges, which ends the cycle at the guard above.
+        SaveTimer = SaveDelay;
+
+        return true;
     }
 
     /// <summary>

--- a/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomEditorController.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Celbridge.Commands;
 using Celbridge.DataTransfer;
 using Celbridge.Dialog;
+using Celbridge.Documents.Helpers;
 using Celbridge.Documents.ViewModels;
 using Celbridge.Host;
 using Celbridge.Localization;
@@ -1018,7 +1019,7 @@ public sealed class CustomEditorController : IHostInput, IHostContext, IEditTarg
         if (completedTask != requestStateTask)
         {
             _logger.LogWarning("Editor did not return state within {Seconds}s; closing without preserving editor state.", EditorStateRequestTimeoutSeconds);
-            ObserveAbandonedRequest(requestStateTask);
+            AbandonedTaskObserver.Observe(requestStateTask);
             return null;
         }
 
@@ -1031,17 +1032,6 @@ public sealed class CustomEditorController : IHostInput, IHostContext, IEditTarg
             // Editor did not register a document/requestState handler.
             return null;
         }
-    }
-
-    // Swallows the eventual fault of an abandoned host->editor request (it faults when the WebView is
-    // torn down) so it does not surface as an unobserved task exception.
-    private static void ObserveAbandonedRequest(Task task)
-    {
-        _ = task.ContinueWith(
-            static abandonedTask => { _ = abandonedTask.Exception; },
-            CancellationToken.None,
-            TaskContinuationOptions.OnlyOnFaulted,
-            TaskScheduler.Default);
     }
 
     public async Task RestoreEditorStateAsync(string state)
@@ -1060,7 +1050,7 @@ public sealed class CustomEditorController : IHostInput, IHostContext, IEditTarg
         {
             // Best-effort restore. An unresponsive editor should not stall the caller. Abandon and move on.
             _logger.LogWarning("Editor did not acknowledge restoreState within {Seconds}s; continuing.", EditorStateRequestTimeoutSeconds);
-            ObserveAbandonedRequest(restoreStateTask);
+            AbandonedTaskObserver.Observe(restoreStateTask);
             return;
         }
 

--- a/Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/CustomUtilityView.xaml.cs
@@ -12,7 +12,7 @@ namespace Celbridge.Documents.Views;
 /// Hosts a custom utility in the Utility Panel, adapting the shared CustomEditorController to
 /// panel chrome.
 /// </summary>
-public sealed partial class CustomUtilityView : UserControl, ISaveableWorkspaceItem
+public sealed partial class CustomUtilityView : UserControl, IWorkspaceItem
 {
     private readonly IMessengerService _messengerService;
     private readonly IWorkspaceWrapper _workspaceWrapper;

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
@@ -61,7 +61,7 @@
                      file cannot be written. -->
                 <Grid>
                     <StackPanel Orientation="Horizontal"
-                                Visibility="{x:Bind ViewModel.HasSaveFailure, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Inverted}">
+                                Visibility="{x:Bind ViewModel.IsSaveRetrying, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Inverted}">
                         <!-- Ordinary document tabs show a file-type icon. A tab a utility editor opens
                              shows that editor's manifest glyph in the tab's own text colour. File-type
                              icons sit inside a luminance band that excludes that colour, so an untinted
@@ -81,9 +81,9 @@
                                        Visibility="{x:Bind ViewModel.IsUtilityEditor, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
                     </StackPanel>
 
-                    <controls:Icon x:Name="SaveFailureIcon"
+                    <controls:Icon x:Name="SaveRetryIcon"
                                    Symbol="Warning"
-                                   Visibility="{x:Bind ViewModel.HasSaveFailure, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                   Visibility="{x:Bind ViewModel.IsSaveRetrying, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                                    ToolTipService.ToolTip="{x:Bind ViewModel.TabTooltip, Mode=OneWay}"
                                    ToolTipService.Placement="Bottom"
                                    FontSize="16"

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
@@ -57,16 +57,15 @@
             <!-- Tab content -->
             <StackPanel Orientation="Horizontal"
                         VerticalAlignment="Center">
-                <!-- The identity glyph and the warning share one slot, so a file that cannot be written
-                     shows the warning in place of its icon and the tab keeps its width. The tooltip names
-                     the item either way. -->
+                <!-- The identity glyph and the warning share one slot, so the tab keeps its width when a
+                     file cannot be written. -->
                 <Grid>
                     <StackPanel Orientation="Horizontal"
                                 Visibility="{x:Bind ViewModel.HasSaveFailure, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Inverted}">
-                        <!-- Ordinary document tabs show a file-type icon. A tab a utility editor opens shows that
-                             editor's manifest glyph in the tab's own text colour. Every file-type icon is held
-                             inside a luminance band that excludes that colour, so an untinted glyph is what marks
-                             the tab as a utility. -->
+                        <!-- Ordinary document tabs show a file-type icon. A tab a utility editor opens
+                             shows that editor's manifest glyph in the tab's own text colour. File-type
+                             icons sit inside a luminance band that excludes that colour, so an untinted
+                             glyph marks the tab as a utility. -->
                         <controls:FileIcon x:Name="ResourceIcon"
                                            Source="{x:Bind ViewModel.FileName, Mode=OneWay}"
                                            Size="18"

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
@@ -57,23 +57,42 @@
             <!-- Tab content -->
             <StackPanel Orientation="Horizontal"
                         VerticalAlignment="Center">
-                <!-- Ordinary document tabs show a file-type icon. A tab a utility editor opens shows that
-                     editor's manifest glyph in the tab's own text colour. Every file-type icon is held
-                     inside a luminance band that excludes that colour, so an untinted glyph is what marks
-                     the tab as a utility. -->
-                <controls:FileIcon x:Name="ResourceIcon"
-                                   Source="{x:Bind ViewModel.FileName, Mode=OneWay}"
-                                   Size="18"
-                                   MinWidth="22"
-                                   Margin="0"
-                                   Visibility="{x:Bind ViewModel.IsUtilityEditor, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Inverted}" />
+                <!-- The identity glyph and the warning share one slot, so a file that cannot be written
+                     shows the warning in place of its icon and the tab keeps its width. The tooltip names
+                     the item either way. -->
+                <Grid>
+                    <StackPanel Orientation="Horizontal"
+                                Visibility="{x:Bind ViewModel.HasSaveFailure, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Inverted}">
+                        <!-- Ordinary document tabs show a file-type icon. A tab a utility editor opens shows that
+                             editor's manifest glyph in the tab's own text colour. Every file-type icon is held
+                             inside a luminance band that excludes that colour, so an untinted glyph is what marks
+                             the tab as a utility. -->
+                        <controls:FileIcon x:Name="ResourceIcon"
+                                           Source="{x:Bind ViewModel.FileName, Mode=OneWay}"
+                                           Size="18"
+                                           MinWidth="22"
+                                           Margin="0"
+                                           Visibility="{x:Bind ViewModel.IsUtilityEditor, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=Inverted}" />
 
-                <controls:Icon x:Name="UtilityIcon"
-                               IconName="{x:Bind ViewModel.UtilityIconName, Mode=OneWay}"
-                               FontSize="16"
-                               MinWidth="20"
-                               Margin="0"
-                               Visibility="{x:Bind ViewModel.IsUtilityEditor, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                        <controls:Icon x:Name="UtilityIcon"
+                                       IconName="{x:Bind ViewModel.UtilityIconName, Mode=OneWay}"
+                                       FontSize="16"
+                                       MinWidth="20"
+                                       Margin="0"
+                                       Visibility="{x:Bind ViewModel.IsUtilityEditor, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                    </StackPanel>
+
+                    <controls:Icon x:Name="SaveFailureIcon"
+                                   Symbol="Warning"
+                                   Visibility="{x:Bind ViewModel.HasSaveFailure, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                                   ToolTipService.ToolTip="{x:Bind ViewModel.TabTooltip, Mode=OneWay}"
+                                   ToolTipService.Placement="Bottom"
+                                   FontSize="16"
+                                   MinWidth="22"
+                                   VerticalAlignment="Center"
+                                   Margin="0"
+                                   Foreground="{ThemeResource SystemFillColorCautionBrush}" />
+                </Grid>
 
                 <!-- The hidden copy holds the label at the width it takes when the tab is selected and drawn
                      at the heavier weight, so selecting a tab does not widen it. -->

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.xaml.cs
@@ -1063,9 +1063,9 @@ public sealed partial class WorkspacePanel : UserControl, IDocumentsPanel
         }
     }
 
-    public IReadOnlyList<ISaveableWorkspaceItem> GetSaveableItems()
+    public IReadOnlyList<IWorkspaceItem> GetWorkspaceItems()
     {
-        var items = new List<ISaveableWorkspaceItem>();
+        var items = new List<IWorkspaceItem>();
 
         foreach (var sectionView in SectionContainer.GetAllSections())
         {

--- a/Source/Workspace/Celbridge.ProjectSettings/Views/ProjectSettingsEditorView.xaml.cs
+++ b/Source/Workspace/Celbridge.ProjectSettings/Views/ProjectSettingsEditorView.xaml.cs
@@ -17,13 +17,10 @@ namespace Celbridge.ProjectSettings.Views;
 /// </summary>
 public sealed partial class ProjectSettingsEditorView : UserControl, IDocumentView
 {
-    // Matches the delay the text document views use, so a burst of edits settles into one write.
-    private const double SaveDelay = 1.0;
-
     private readonly IStringLocalizer _stringLocalizer;
     private readonly ILogger<ProjectSettingsEditorView> _logger;
 
-    private double _saveTimer = SaveDelay;
+    private double _saveTimer = SaveConstants.SaveDelay;
 
     public ProjectSettingsEditorViewModel ViewModel { get; }
 
@@ -188,7 +185,7 @@ public sealed partial class ProjectSettingsEditorView : UserControl, IDocumentVi
             return false;
         }
 
-        _saveTimer = SaveDelay;
+        _saveTimer = SaveConstants.SaveDelay;
 
         return true;
     }

--- a/Source/Workspace/Celbridge.WorkspaceUI/ServiceConfiguration.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ServiceConfiguration.cs
@@ -33,6 +33,7 @@ public static class ServiceConfiguration
         services.AddTransient<IDataTransferService, DataTransferService>();
         services.AddTransient<WorkspaceLoader>();
         services.AddTransient<WorkspaceItemSaver>();
+        services.AddTransient<SaveRetryTracker>();
 
         //
         // Register panels

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/SaveRetryTracker.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/SaveRetryTracker.cs
@@ -4,26 +4,15 @@ namespace Celbridge.WorkspaceUI.Services;
 /// What is known about a resource that is waiting to be written again. Delay is the full wait before the
 /// next attempt, Remaining is how much of that wait is left.
 /// </summary>
-internal sealed record SaveRetry(double Delay, double Remaining, string Reason, bool IsReported);
+internal sealed record SaveRetry(double Delay, double Remaining, string Reason);
 
 /// <summary>
-/// The resources that are waiting to be written again, how long each one waits before the next attempt,
-/// and which of them are reported to the user.
+/// The resources that are waiting to be written again, and how long each one waits before the next
+/// attempt.
 /// </summary>
 public class SaveRetryTracker
 {
-    // A non-writable resource is held here so that it backs off like any other, but it is not reported.
     private readonly Dictionary<ResourceKey, SaveRetry> _saveRetries = new();
-
-    /// <summary>
-    /// Whether the reported resources have changed since they were last cleared.
-    /// </summary>
-    public bool HasReportedChanges { get; private set; }
-
-    public void ClearReportedChanges()
-    {
-        HasReportedChanges = false;
-    }
 
     /// <summary>
     /// Whether the resource is waiting to be written again.
@@ -54,16 +43,14 @@ public class SaveRetryTracker
     {
         var delay = SaveConstants.InitialRetryDelay;
         var reasonChanged = true;
-        var isReported = false;
 
         if (_saveRetries.TryGetValue(resource, out var previousRetry))
         {
             delay = Math.Min(previousRetry.Delay * 2, SaveConstants.MaximumRetryDelay);
             reasonChanged = previousRetry.Reason != reason;
-            isReported = previousRetry.IsReported;
         }
 
-        _saveRetries[resource] = new SaveRetry(delay, delay, reason, isReported);
+        _saveRetries[resource] = new SaveRetry(delay, delay, reason);
 
         return reasonChanged;
     }
@@ -86,47 +73,11 @@ public class SaveRetryTracker
     }
 
     /// <summary>
-    /// Starts reporting a resource to the user. Returns false when it is already reported.
-    /// </summary>
-    public bool StartReporting(ResourceKey resource)
-    {
-        var retry = _saveRetries[resource];
-        if (retry.IsReported)
-        {
-            return false;
-        }
-
-        _saveRetries[resource] = retry with { IsReported = true };
-        HasReportedChanges = true;
-
-        return true;
-    }
-
-    /// <summary>
-    /// Stops reporting a resource to the user, leaving its wait in place so it goes on backing off.
-    /// </summary>
-    public void StopReporting(ResourceKey resource)
-    {
-        if (!_saveRetries.TryGetValue(resource, out var retry) ||
-            !retry.IsReported)
-        {
-            return;
-        }
-
-        _saveRetries[resource] = retry with { IsReported = false };
-        HasReportedChanges = true;
-    }
-
-    /// <summary>
-    /// Drops everything held about a resource, so a later failure is reported and backs off afresh.
+    /// Drops everything held about a resource, so a later failure backs off afresh.
     /// </summary>
     public void Forget(ResourceKey resource)
     {
-        if (_saveRetries.Remove(resource, out var retry) &&
-            retry.IsReported)
-        {
-            HasReportedChanges = true;
-        }
+        _saveRetries.Remove(resource);
     }
 
     /// <summary>
@@ -146,23 +97,5 @@ public class SaveRetryTracker
                 Forget(resource);
             }
         }
-    }
-
-    /// <summary>
-    /// Every resource that is reported to the user.
-    /// </summary>
-    public IReadOnlyList<ResourceKey> GetReported()
-    {
-        var reportedResources = new List<ResourceKey>();
-
-        foreach (var saveRetry in _saveRetries)
-        {
-            if (saveRetry.Value.IsReported)
-            {
-                reportedResources.Add(saveRetry.Key);
-            }
-        }
-
-        return reportedResources;
     }
 }

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/SaveRetryTracker.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/SaveRetryTracker.cs
@@ -1,0 +1,168 @@
+namespace Celbridge.WorkspaceUI.Services;
+
+/// <summary>
+/// What is known about a resource that is waiting to be written again. Delay is the full wait before the
+/// next attempt, Remaining is how much of that wait is left.
+/// </summary>
+internal sealed record SaveRetry(double Delay, double Remaining, string Reason, bool IsReported);
+
+/// <summary>
+/// The resources that are waiting to be written again, how long each one waits before the next attempt,
+/// and which of them are reported to the user.
+/// </summary>
+public class SaveRetryTracker
+{
+    // A non-writable resource is held here so that it backs off like any other, but it is not reported.
+    private readonly Dictionary<ResourceKey, SaveRetry> _saveRetries = new();
+
+    /// <summary>
+    /// Whether the reported resources have changed since they were last cleared.
+    /// </summary>
+    public bool HasReportedChanges { get; private set; }
+
+    public void ClearReportedChanges()
+    {
+        HasReportedChanges = false;
+    }
+
+    /// <summary>
+    /// Whether the resource is waiting to be written again.
+    /// </summary>
+    public bool IsRetrying(ResourceKey resource)
+    {
+        return _saveRetries.ContainsKey(resource);
+    }
+
+    /// <summary>
+    /// Whether the resource is still waiting out the backoff from its last failed save.
+    /// </summary>
+    public bool IsWaiting(ResourceKey resource)
+    {
+        if (!_saveRetries.TryGetValue(resource, out var retry))
+        {
+            return false;
+        }
+
+        return retry.Remaining > 0;
+    }
+
+    /// <summary>
+    /// Starts the next wait for a resource whose save failed, doubling the previous wait up to the maximum.
+    /// Returns true when this attempt failed for a different reason than the one before it.
+    /// </summary>
+    public bool Schedule(ResourceKey resource, string reason)
+    {
+        var delay = SaveConstants.InitialRetryDelay;
+        var reasonChanged = true;
+        var isReported = false;
+
+        if (_saveRetries.TryGetValue(resource, out var previousRetry))
+        {
+            delay = Math.Min(previousRetry.Delay * 2, SaveConstants.MaximumRetryDelay);
+            reasonChanged = previousRetry.Reason != reason;
+            isReported = previousRetry.IsReported;
+        }
+
+        _saveRetries[resource] = new SaveRetry(delay, delay, reason, isReported);
+
+        return reasonChanged;
+    }
+
+    /// <summary>
+    /// Counts down the retry timer of every resource waiting to be written again.
+    /// </summary>
+    public void UpdateTimers(double deltaTime)
+    {
+        if (_saveRetries.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var resource in _saveRetries.Keys.ToList())
+        {
+            var retry = _saveRetries[resource];
+            _saveRetries[resource] = retry with { Remaining = retry.Remaining - deltaTime };
+        }
+    }
+
+    /// <summary>
+    /// Starts reporting a resource to the user. Returns false when it is already reported.
+    /// </summary>
+    public bool StartReporting(ResourceKey resource)
+    {
+        var retry = _saveRetries[resource];
+        if (retry.IsReported)
+        {
+            return false;
+        }
+
+        _saveRetries[resource] = retry with { IsReported = true };
+        HasReportedChanges = true;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Stops reporting a resource to the user, leaving its wait in place so it goes on backing off.
+    /// </summary>
+    public void StopReporting(ResourceKey resource)
+    {
+        if (!_saveRetries.TryGetValue(resource, out var retry) ||
+            !retry.IsReported)
+        {
+            return;
+        }
+
+        _saveRetries[resource] = retry with { IsReported = false };
+        HasReportedChanges = true;
+    }
+
+    /// <summary>
+    /// Drops everything held about a resource, so a later failure is reported and backs off afresh.
+    /// </summary>
+    public void Forget(ResourceKey resource)
+    {
+        if (_saveRetries.Remove(resource, out var retry) &&
+            retry.IsReported)
+        {
+            HasReportedChanges = true;
+        }
+    }
+
+    /// <summary>
+    /// Drops every resource that is not in the supplied set.
+    /// </summary>
+    public void ForgetAllExcept(IReadOnlyCollection<ResourceKey> resources)
+    {
+        if (_saveRetries.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var resource in _saveRetries.Keys.ToList())
+        {
+            if (!resources.Contains(resource))
+            {
+                Forget(resource);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Every resource that is reported to the user.
+    /// </summary>
+    public IReadOnlyList<ResourceKey> GetReported()
+    {
+        var reportedResources = new List<ResourceKey>();
+
+        foreach (var saveRetry in _saveRetries)
+        {
+            if (saveRetry.Value.IsReported)
+            {
+                reportedResources.Add(saveRetry.Key);
+            }
+        }
+
+        return reportedResources;
+    }
+}

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
@@ -34,6 +34,9 @@ public class WorkspaceItemSaver
     private readonly IMessengerService _messengerService;
     private readonly SaveRetryTracker _retries;
 
+    // The resources reported to the user as failing, as of the last save pass.
+    private readonly HashSet<ResourceKey> _reportedResources = new();
+
     public WorkspaceItemSaver(
         ILogger<WorkspaceItemSaver> logger,
         ICommandService commandService,
@@ -51,7 +54,7 @@ public class WorkspaceItemSaver
     /// </summary>
     public IReadOnlyList<ResourceKey> GetRetryingResources()
     {
-        return _retries.GetReported();
+        return _reportedResources.ToList();
     }
 
     /// <summary>
@@ -98,7 +101,6 @@ public class WorkspaceItemSaver
 
         int savedCount = 0;
         int pendingSaveCount = 0;
-        List<ResourceKey> newlyReportedResources = new();
         bool updateResourcesRequired = false;
 
         foreach (var item in items)
@@ -139,10 +141,8 @@ public class WorkspaceItemSaver
 
             var reasonChanged = _retries.Schedule(item.FileResource, saveResult.MessageChain);
 
-            // A non-writable item failing to save is expected, so the failure is not reported to the user.
             if (item.WritableState != WritableState.Writable)
             {
-                _retries.StopReporting(item.FileResource);
                 _logger.LogDebug($"Skipped save for non-writable workspace item: '{item.FileResource}'");
                 continue;
             }
@@ -160,11 +160,6 @@ public class WorkspaceItemSaver
             {
                 _logger.LogError($"Failed to save workspace item '{item.FileResource}'. {saveResult.MessageChain}");
             }
-
-            if (_retries.StartReporting(item.FileResource))
-            {
-                newlyReportedResources.Add(item.FileResource);
-            }
         }
 
         DropStateForClosedItems(items);
@@ -172,7 +167,7 @@ public class WorkspaceItemSaver
         var pendingSaveMessage = new PendingSaveCountMessage(pendingSaveCount);
         _messengerService.Send(pendingSaveMessage);
 
-        SendReportedRetriesIfChanged();
+        var newlyReportedResources = UpdateReportedResources(items);
 
         if (updateResourcesRequired)
         {
@@ -227,18 +222,45 @@ public class WorkspaceItemSaver
         }
     }
 
-    // Sends the reported resources whenever that set gains or loses one.
-    private void SendReportedRetriesIfChanged()
+    // Sends the reported resources whenever that set gains or loses one, and returns the resources that
+    // have just started being reported.
+    private List<ResourceKey> UpdateReportedResources(IReadOnlyList<IWorkspaceItem> items)
     {
-        if (!_retries.HasReportedChanges)
+        var reportedResources = CollectReportedResources(items);
+        if (_reportedResources.SetEquals(reportedResources))
         {
-            return;
+            return new List<ResourceKey>();
         }
 
-        _retries.ClearReportedChanges();
+        var newlyReportedResources = reportedResources
+            .Where(resource => !_reportedResources.Contains(resource))
+            .ToList();
 
-        var retriesChangedMessage = new WorkspaceItemSaveRetriesChangedMessage(_retries.GetReported());
+        _reportedResources.Clear();
+        _reportedResources.UnionWith(reportedResources);
+
+        var retriesChangedMessage = new WorkspaceItemSaveRetriesChangedMessage(reportedResources);
         _messengerService.Send(retriesChangedMessage);
+
+        return newlyReportedResources;
+    }
+
+    private List<ResourceKey> CollectReportedResources(IReadOnlyList<IWorkspaceItem> items)
+    {
+        var reportedResources = new List<ResourceKey>();
+
+        foreach (var item in items)
+        {
+            // A non-writable item failing to save is expected, and its editor already shows it as
+            // read-only, so it backs off without being reported.
+            if (_retries.IsRetrying(item.FileResource) &&
+                item.WritableState == WritableState.Writable)
+            {
+                reportedResources.Add(item.FileResource);
+            }
+        }
+
+        return reportedResources;
     }
 
     // Forgets the resources that are no longer open, so one that fails again after being reopened is

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
@@ -265,10 +265,10 @@ public class WorkspaceItemSaver
 
     // Forgets the resources that are no longer open, so one that fails again after being reopened is
     // reported again.
-    private void DropStateForClosedItems(IReadOnlyList<IWorkspaceItem> items)
+    private void DropStateForClosedItems(IReadOnlyList<IWorkspaceItem> openItems)
     {
         var openResources = new HashSet<ResourceKey>();
-        foreach (var item in items)
+        foreach (var item in openItems)
         {
             openResources.Add(item.FileResource);
         }

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
@@ -4,8 +4,8 @@ using Celbridge.Logging;
 namespace Celbridge.WorkspaceUI.Services;
 
 /// <summary>
-/// What is known about a resource whose last save failed: the current wait before the next attempt, how
-/// much of that wait is left, why the attempt failed, and whether the failure is reported to the user.
+/// What is known about a resource whose last save failed. Delay is the full wait before the next attempt,
+/// Remaining is how much of that wait is left.
 /// </summary>
 internal sealed record SaveFailure(double Delay, double Remaining, string Reason, bool IsReported);
 
@@ -18,9 +18,8 @@ public class WorkspaceItemSaver
     private readonly ICommandService _commandService;
     private readonly IMessengerService _messengerService;
 
-    // Every resource whose last save failed. A non-writable resource is held here so a locked file backs
-    // off on the same schedule as any other, but it is not reported, because its editor already shows it
-    // as read-only.
+    // Every resource whose last save failed. A non-writable resource is held here so that it backs off
+    // like any other, but it is not reported.
     private readonly Dictionary<ResourceKey, SaveFailure> _saveFailures = new();
 
     private bool _reportedFailuresChanged;
@@ -36,7 +35,7 @@ public class WorkspaceItemSaver
     }
 
     /// <summary>
-    /// The resources that cannot be written, for a caller that starts observing after they were reported.
+    /// The resources that cannot be written.
     /// </summary>
     public IReadOnlyList<ResourceKey> GetFailingResources()
     {
@@ -45,9 +44,8 @@ public class WorkspaceItemSaver
 
     /// <summary>
     /// Ticks each item's save timer, writes the ones that are due, and reports the items still waiting to
-    /// be written and those that cannot be. A write that fails is reported once, not again on the attempts
-    /// that follow it, and those attempts back off. Delta time is the time since this method was last
-    /// called.
+    /// be written and those that cannot be. A failed write is reported once and its retries back off.
+    /// Delta time is the time since this method was last called.
     /// </summary>
     public async Task<Result> SaveModifiedItemsAsync(
         IReadOnlyList<IWorkspaceItem> items,
@@ -64,8 +62,6 @@ public class WorkspaceItemSaver
         {
             if (!item.HasUnsavedChanges)
             {
-                // Whether a save wrote the item or a reload replaced its content, it holds nothing
-                // unwritten now, so any failure it was carrying is over.
                 ForgetFailure(item.FileResource);
                 continue;
             }
@@ -77,7 +73,7 @@ public class WorkspaceItemSaver
             if (!shouldSave)
             {
                 // An item that is only waiting for its timer is counted as saving. One whose last attempt
-                // failed is reported as failing instead, so the two states never read as each other.
+                // failed is reported as failing instead.
                 if (!_saveFailures.ContainsKey(item.FileResource))
                 {
                     pendingSaveCount++;
@@ -101,10 +97,7 @@ public class WorkspaceItemSaver
 
             var reasonChanged = ScheduleRetry(item.FileResource, saveResult.MessageChain);
 
-            // A non-writable item failing to save is expected, and reporting it would repeat what the
-            // editor already shows by dimming itself. One already reported stops being reported here, so a
-            // resource that turns non-writable ends up in the same state as one that was already
-            // non-writable when it was edited.
+            // A non-writable item failing to save is expected, so the failure is not reported to the user.
             if (item.WritableState != WritableState.Writable)
             {
                 StopReportingFailure(item.FileResource);
@@ -120,9 +113,7 @@ public class WorkspaceItemSaver
                 updateResourcesRequired = true;
             }
 
-            // MessageChain is the outer-first reason and is not localized, so it belongs in the log rather
-            // than in anything the user sees. A reason that differs from the last attempt's is logged
-            // again, so a file that starts failing for a second reason says so.
+            // Logged only when the reason changes, so a file that goes on failing does not fill the log.
             if (reasonChanged)
             {
                 _logger.LogError($"Failed to save workspace item '{item.FileResource}'. {saveResult.MessageChain}");

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
@@ -4,13 +4,34 @@ using Celbridge.Logging;
 namespace Celbridge.WorkspaceUI.Services;
 
 /// <summary>
+/// The backoff for a resource whose save failed: how long the current wait is, and how much of that wait
+/// is left before the next attempt.
+/// </summary>
+internal sealed record SaveRetry(double Delay, double Remaining);
+
+/// <summary>
 /// Flushes the workspace items that are due to be saved.
 /// </summary>
 public class WorkspaceItemSaver
 {
+    // How long a failed save waits before it is attempted again. The wait doubles with each failure up to
+    // the maximum, so an item that cannot be written settles into one attempt every fifteen seconds.
+    private const double InitialRetryDelay = 1.0;
+    private const double MaximumRetryDelay = 15.0;
+
     private readonly ILogger<WorkspaceItemSaver> _logger;
     private readonly ICommandService _commandService;
     private readonly IMessengerService _messengerService;
+
+    // The resources that cannot be written. A non-writable resource is left out, because its editor
+    // already shows it as read-only.
+    private readonly HashSet<ResourceKey> _failingResources = new();
+
+    // The wait before each resource whose save failed is attempted again. Held for non-writable resources
+    // too, so a locked file backs off on the same schedule.
+    private readonly Dictionary<ResourceKey, SaveRetry> _saveRetries = new();
+
+    private bool _failingResourcesChanged;
 
     public WorkspaceItemSaver(
         ILogger<WorkspaceItemSaver> logger,
@@ -23,22 +44,29 @@ public class WorkspaceItemSaver
     }
 
     /// <summary>
-    /// Ticks each item's save timer, writes the ones that are due, and reports how many are still waiting
-    /// for theirs. Delta time is the time since this method was last called.
+    /// Ticks each item's save timer, writes the ones that are due, and reports the items still waiting to
+    /// be written and those that cannot be. A write that fails is reported once, not again on the attempts
+    /// that follow it, and those attempts back off. Delta time is the time since this method was last
+    /// called.
     /// </summary>
-    public async Task<Result<int>> SaveModifiedItemsAsync(
+    public async Task<Result> SaveModifiedItemsAsync(
         IReadOnlyList<IWorkspaceItem> items,
         double deltaTime)
     {
+        AdvanceRetryWaits(deltaTime);
+
         int savedCount = 0;
         int pendingSaveCount = 0;
-        List<FailedResource> failedSaves = new();
+        List<FailedResource> newFailures = new();
         bool updateResourcesRequired = false;
 
         foreach (var item in items)
         {
             if (!item.HasUnsavedChanges)
             {
+                // Whether a save wrote the item or a reload replaced its content, it holds nothing
+                // unwritten now, so any failure it was carrying is over.
+                ForgetFailure(item.FileResource);
                 continue;
             }
 
@@ -48,7 +76,18 @@ public class WorkspaceItemSaver
             var shouldSave = updateResult.Value;
             if (!shouldSave)
             {
-                pendingSaveCount++;
+                // An item that is only waiting for its timer is counted as saving. One whose last attempt
+                // failed is reported as failing instead, so the two states never read as each other.
+                if (!_saveRetries.ContainsKey(item.FileResource))
+                {
+                    pendingSaveCount++;
+                }
+
+                continue;
+            }
+
+            if (IsWaitingToRetry(item.FileResource))
+            {
                 continue;
             }
 
@@ -56,19 +95,30 @@ public class WorkspaceItemSaver
             if (saveResult.IsSuccess)
             {
                 savedCount++;
+                ForgetFailure(item.FileResource);
                 continue;
             }
 
-            // A non-writable item failing to save is expected, and notifying would spam the user on every
-            // auto-save tick against a locked file with buffered changes.
+            ScheduleRetry(item.FileResource);
+
+            // A non-writable item failing to save is expected, and reporting it would repeat what the
+            // editor already shows by dimming itself.
             if (item.WritableState != WritableState.Writable)
             {
                 _logger.LogDebug($"Skipped save for non-writable workspace item: '{item.FileResource}'");
                 continue;
             }
 
-            // MessageChain is the outer-first reason.
-            failedSaves.Add(new FailedResource(item.FileResource, saveResult.MessageChain));
+            if (!_failingResources.Add(item.FileResource))
+            {
+                continue;
+            }
+
+            _failingResourcesChanged = true;
+
+            // MessageChain is the outer-first reason. It carries developer English, so the log is where
+            // it belongs.
+            newFailures.Add(new FailedResource(item.FileResource, saveResult.MessageChain));
 
             // A failed save against a cache that still reads Writable suggests an external attribute flip
             // slipped past the watcher. The rebuild below covers the project tree, so only a resource in it
@@ -79,6 +129,13 @@ public class WorkspaceItemSaver
             }
         }
 
+        DropStateForClosedItems(items);
+
+        var pendingSaveMessage = new PendingSaveCountMessage(pendingSaveCount);
+        _messengerService.Send(pendingSaveMessage);
+
+        SendFailingResourcesIfChanged();
+
         if (updateResourcesRequired)
         {
             // Debounced inside the resource service so a burst of failures from many open files collapses
@@ -86,23 +143,117 @@ public class WorkspaceItemSaver
             _commandService.Execute<IUpdateResourcesCommand>();
         }
 
-        if (failedSaves.Count > 0)
-        {
-            var failedResourceNames = failedSaves.Select(failedSave => failedSave.Resource.ToString());
-            var errorMessage = $"Failed to save the following workspace items: {string.Join(", ", failedResourceNames)}";
-            _logger.LogError(errorMessage);
-
-            var saveFailedMessage = new WorkspaceItemSaveFailedMessage(failedSaves);
-            _messengerService.Send(saveFailedMessage);
-
-            return Result<int>.Fail(errorMessage);
-        }
-
         if (savedCount > 0)
         {
             _logger.LogDebug($"Saved {savedCount} modified workspace items");
         }
 
-        return pendingSaveCount;
+        if (newFailures.Count == 0)
+        {
+            return Result.Ok();
+        }
+
+        // The reason for each failure appears here and nowhere else.
+        var failureDescriptions = newFailures.Select(newFailure => $"'{newFailure.Resource}' ({newFailure.Message})");
+        var errorMessage = $"Failed to save the following workspace items: {string.Join(", ", failureDescriptions)}";
+        _logger.LogError(errorMessage);
+
+        return Result.Fail(errorMessage);
+    }
+
+    // Sends the resources that cannot be written whenever that set gains or loses one.
+    private void SendFailingResourcesIfChanged()
+    {
+        if (!_failingResourcesChanged)
+        {
+            return;
+        }
+
+        _failingResourcesChanged = false;
+
+        var failingResources = new List<ResourceKey>(_failingResources);
+
+        var failuresChangedMessage = new WorkspaceItemSaveFailuresChangedMessage(failingResources);
+        _messengerService.Send(failuresChangedMessage);
+    }
+
+    // Counts down the wait before each resource whose save failed is attempted again.
+    private void AdvanceRetryWaits(double deltaTime)
+    {
+        if (_saveRetries.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var resource in _saveRetries.Keys.ToList())
+        {
+            var retry = _saveRetries[resource];
+            _saveRetries[resource] = retry with { Remaining = retry.Remaining - deltaTime };
+        }
+    }
+
+    // Whether the resource is still waiting out the backoff from its last failed save.
+    private bool IsWaitingToRetry(ResourceKey resource)
+    {
+        if (!_saveRetries.TryGetValue(resource, out var retry))
+        {
+            return false;
+        }
+
+        return retry.Remaining > 0;
+    }
+
+    // Starts the next wait for a resource whose save failed, doubling the previous wait up to the maximum.
+    private void ScheduleRetry(ResourceKey resource)
+    {
+        var delay = InitialRetryDelay;
+        if (_saveRetries.TryGetValue(resource, out var previousRetry))
+        {
+            delay = Math.Min(previousRetry.Delay * 2, MaximumRetryDelay);
+        }
+
+        _saveRetries[resource] = new SaveRetry(delay, delay);
+    }
+
+    // Forgets a resource that holds nothing unwritten, so a later failure is reported and backs off afresh.
+    private void ForgetFailure(ResourceKey resource)
+    {
+        if (_failingResources.Remove(resource))
+        {
+            _failingResourcesChanged = true;
+        }
+
+        _saveRetries.Remove(resource);
+    }
+
+    // Forgets the resources that are no longer open, so one that fails again after being reopened is
+    // reported again.
+    private void DropStateForClosedItems(IReadOnlyList<IWorkspaceItem> items)
+    {
+        if (_failingResources.Count == 0 &&
+            _saveRetries.Count == 0)
+        {
+            return;
+        }
+
+        var openResources = new HashSet<ResourceKey>();
+        foreach (var item in items)
+        {
+            openResources.Add(item.FileResource);
+        }
+
+        var closedFailureCount = _failingResources.RemoveWhere(resource => !openResources.Contains(resource));
+        if (closedFailureCount > 0)
+        {
+            _failingResourcesChanged = true;
+        }
+
+        foreach (var resource in _saveRetries.Keys.ToList())
+        {
+            if (!openResources.Contains(resource))
+            {
+                _saveRetries.Remove(resource);
+            }
+        }
     }
 }

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
@@ -27,7 +27,7 @@ public class WorkspaceItemSaver
     /// for theirs. Delta time is the time since this method was last called.
     /// </summary>
     public async Task<Result<int>> SaveModifiedItemsAsync(
-        IReadOnlyList<ISaveableWorkspaceItem> items,
+        IReadOnlyList<IWorkspaceItem> items,
         double deltaTime)
     {
         int savedCount = 0;

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
@@ -4,10 +4,25 @@ using Celbridge.Logging;
 namespace Celbridge.WorkspaceUI.Services;
 
 /// <summary>
-/// What is known about a resource whose last save failed. Delay is the full wait before the next attempt,
-/// Remaining is how much of that wait is left.
+/// Where a workspace item stands with writing its content to its file resource.
 /// </summary>
-internal sealed record SaveFailure(double Delay, double Remaining, string Reason, bool IsReported);
+internal enum SaveState
+{
+    /// <summary>
+    /// The item holds no content that has yet to be written.
+    /// </summary>
+    Saved,
+
+    /// <summary>
+    /// The item holds content that is waiting for its save timer to come due.
+    /// </summary>
+    Pending,
+
+    /// <summary>
+    /// The item's last write failed, so it is waiting to be attempted again.
+    /// </summary>
+    Retrying,
+}
 
 /// <summary>
 /// Flushes the workspace items that are due to be saved.
@@ -17,29 +32,26 @@ public class WorkspaceItemSaver
     private readonly ILogger<WorkspaceItemSaver> _logger;
     private readonly ICommandService _commandService;
     private readonly IMessengerService _messengerService;
-
-    // Every resource whose last save failed. A non-writable resource is held here so that it backs off
-    // like any other, but it is not reported.
-    private readonly Dictionary<ResourceKey, SaveFailure> _saveFailures = new();
-
-    private bool _reportedFailuresChanged;
+    private readonly SaveRetryTracker _retries;
 
     public WorkspaceItemSaver(
         ILogger<WorkspaceItemSaver> logger,
         ICommandService commandService,
-        IMessengerService messengerService)
+        IMessengerService messengerService,
+        SaveRetryTracker retries)
     {
         _logger = logger;
         _commandService = commandService;
         _messengerService = messengerService;
+        _retries = retries;
     }
 
     /// <summary>
-    /// The resources that cannot be written.
+    /// Every resource whose last write failed and is waiting to be attempted again.
     /// </summary>
-    public IReadOnlyList<ResourceKey> GetFailingResources()
+    public IReadOnlyList<ResourceKey> GetRetryingResources()
     {
-        return CollectReportedFailures();
+        return _retries.GetReported();
     }
 
     /// <summary>
@@ -82,7 +94,7 @@ public class WorkspaceItemSaver
         IReadOnlyList<IWorkspaceItem> items,
         double deltaTime)
     {
-        AdvanceRetryWaits(deltaTime);
+        _retries.UpdateTimers(deltaTime);
 
         int savedCount = 0;
         int pendingSaveCount = 0;
@@ -91,9 +103,10 @@ public class WorkspaceItemSaver
 
         foreach (var item in items)
         {
-            if (!item.HasUnsavedChanges)
+            var saveState = GetSaveState(item);
+            if (saveState == SaveState.Saved)
             {
-                ForgetFailure(item.FileResource);
+                _retries.Forget(item.FileResource);
                 continue;
             }
 
@@ -103,9 +116,7 @@ public class WorkspaceItemSaver
             var shouldSave = updateResult.Value;
             if (!shouldSave)
             {
-                // An item that is only waiting for its timer is counted as saving. One whose last attempt
-                // failed is reported as failing instead.
-                if (!_saveFailures.ContainsKey(item.FileResource))
+                if (saveState == SaveState.Pending)
                 {
                     pendingSaveCount++;
                 }
@@ -113,7 +124,7 @@ public class WorkspaceItemSaver
                 continue;
             }
 
-            if (IsWaitingToRetry(item.FileResource))
+            if (_retries.IsWaiting(item.FileResource))
             {
                 continue;
             }
@@ -122,16 +133,16 @@ public class WorkspaceItemSaver
             if (saveResult.IsSuccess)
             {
                 savedCount++;
-                ForgetFailure(item.FileResource);
+                _retries.Forget(item.FileResource);
                 continue;
             }
 
-            var reasonChanged = ScheduleRetry(item.FileResource, saveResult.MessageChain);
+            var reasonChanged = _retries.Schedule(item.FileResource, saveResult.MessageChain);
 
             // A non-writable item failing to save is expected, so the failure is not reported to the user.
             if (item.WritableState != WritableState.Writable)
             {
-                StopReportingFailure(item.FileResource);
+                _retries.StopReporting(item.FileResource);
                 _logger.LogDebug($"Skipped save for non-writable workspace item: '{item.FileResource}'");
                 continue;
             }
@@ -150,7 +161,7 @@ public class WorkspaceItemSaver
                 _logger.LogError($"Failed to save workspace item '{item.FileResource}'. {saveResult.MessageChain}");
             }
 
-            if (ReportFailure(item.FileResource))
+            if (_retries.StartReporting(item.FileResource))
             {
                 newlyReportedResources.Add(item.FileResource);
             }
@@ -161,7 +172,7 @@ public class WorkspaceItemSaver
         var pendingSaveMessage = new PendingSaveCountMessage(pendingSaveCount);
         _messengerService.Send(pendingSaveMessage);
 
-        SendReportedFailuresIfChanged();
+        SendReportedRetriesIfChanged();
 
         if (updateResourcesRequired)
         {
@@ -185,6 +196,23 @@ public class WorkspaceItemSaver
         return Result.Fail($"Failed to save the following workspace items: {string.Join(", ", resourceNames)}");
     }
 
+    // Where the item stands with writing. A resource waiting to be written again is Retrying rather than
+    // Pending, so the two never count the same item.
+    private SaveState GetSaveState(IWorkspaceItem item)
+    {
+        if (!item.HasUnsavedChanges)
+        {
+            return SaveState.Saved;
+        }
+
+        if (_retries.IsRetrying(item.FileResource))
+        {
+            return SaveState.Retrying;
+        }
+
+        return SaveState.Pending;
+    }
+
     // Writes the item, turning an exception into a failed result so one editor cannot stop the save pass.
     private async Task<Result> SaveItemAsync(IWorkspaceItem item)
     {
@@ -199,140 +227,30 @@ public class WorkspaceItemSaver
         }
     }
 
-    // Starts reporting a resource to the user. Returns false when it is already reported.
-    private bool ReportFailure(ResourceKey resource)
-    {
-        var failure = _saveFailures[resource];
-        if (failure.IsReported)
-        {
-            return false;
-        }
-
-        _saveFailures[resource] = failure with { IsReported = true };
-        _reportedFailuresChanged = true;
-
-        return true;
-    }
-
-    // Stops reporting a resource to the user, leaving its wait in place so it goes on backing off.
-    private void StopReportingFailure(ResourceKey resource)
-    {
-        if (!_saveFailures.TryGetValue(resource, out var failure) ||
-            !failure.IsReported)
-        {
-            return;
-        }
-
-        _saveFailures[resource] = failure with { IsReported = false };
-        _reportedFailuresChanged = true;
-    }
-
-    // Drops everything held about a resource, so a later failure is reported and backs off afresh.
-    private void ForgetFailure(ResourceKey resource)
-    {
-        if (_saveFailures.Remove(resource, out var failure) &&
-            failure.IsReported)
-        {
-            _reportedFailuresChanged = true;
-        }
-    }
-
     // Sends the reported resources whenever that set gains or loses one.
-    private void SendReportedFailuresIfChanged()
+    private void SendReportedRetriesIfChanged()
     {
-        if (!_reportedFailuresChanged)
+        if (!_retries.HasReportedChanges)
         {
             return;
         }
 
-        _reportedFailuresChanged = false;
+        _retries.ClearReportedChanges();
 
-        var failuresChangedMessage = new WorkspaceItemSaveFailuresChangedMessage(CollectReportedFailures());
-        _messengerService.Send(failuresChangedMessage);
-    }
-
-    private List<ResourceKey> CollectReportedFailures()
-    {
-        var reportedResources = new List<ResourceKey>();
-
-        foreach (var saveFailure in _saveFailures)
-        {
-            if (saveFailure.Value.IsReported)
-            {
-                reportedResources.Add(saveFailure.Key);
-            }
-        }
-
-        return reportedResources;
-    }
-
-    // Counts down the wait before each resource whose save failed is attempted again.
-    private void AdvanceRetryWaits(double deltaTime)
-    {
-        if (_saveFailures.Count == 0)
-        {
-            return;
-        }
-
-        foreach (var resource in _saveFailures.Keys.ToList())
-        {
-            var failure = _saveFailures[resource];
-            _saveFailures[resource] = failure with { Remaining = failure.Remaining - deltaTime };
-        }
-    }
-
-    // Whether the resource is still waiting out the backoff from its last failed save.
-    private bool IsWaitingToRetry(ResourceKey resource)
-    {
-        if (!_saveFailures.TryGetValue(resource, out var failure))
-        {
-            return false;
-        }
-
-        return failure.Remaining > 0;
-    }
-
-    // Starts the next wait for a resource whose save failed, doubling the previous wait up to the maximum.
-    // Returns true when this attempt failed for a different reason than the one before it.
-    private bool ScheduleRetry(ResourceKey resource, string reason)
-    {
-        var delay = SaveConstants.InitialRetryDelay;
-        var reasonChanged = true;
-        var isReported = false;
-
-        if (_saveFailures.TryGetValue(resource, out var previousFailure))
-        {
-            delay = Math.Min(previousFailure.Delay * 2, SaveConstants.MaximumRetryDelay);
-            reasonChanged = previousFailure.Reason != reason;
-            isReported = previousFailure.IsReported;
-        }
-
-        _saveFailures[resource] = new SaveFailure(delay, delay, reason, isReported);
-
-        return reasonChanged;
+        var retriesChangedMessage = new WorkspaceItemSaveRetriesChangedMessage(_retries.GetReported());
+        _messengerService.Send(retriesChangedMessage);
     }
 
     // Forgets the resources that are no longer open, so one that fails again after being reopened is
     // reported again.
     private void DropStateForClosedItems(IReadOnlyList<IWorkspaceItem> items)
     {
-        if (_saveFailures.Count == 0)
-        {
-            return;
-        }
-
         var openResources = new HashSet<ResourceKey>();
         foreach (var item in items)
         {
             openResources.Add(item.FileResource);
         }
 
-        foreach (var resource in _saveFailures.Keys.ToList())
-        {
-            if (!openResources.Contains(resource))
-            {
-                ForgetFailure(resource);
-            }
-        }
+        _retries.ForgetAllExcept(openResources);
     }
 }

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
@@ -4,34 +4,26 @@ using Celbridge.Logging;
 namespace Celbridge.WorkspaceUI.Services;
 
 /// <summary>
-/// The backoff for a resource whose save failed: how long the current wait is, and how much of that wait
-/// is left before the next attempt.
+/// What is known about a resource whose last save failed: the current wait before the next attempt, how
+/// much of that wait is left, why the attempt failed, and whether the failure is reported to the user.
 /// </summary>
-internal sealed record SaveRetry(double Delay, double Remaining);
+internal sealed record SaveFailure(double Delay, double Remaining, string Reason, bool IsReported);
 
 /// <summary>
 /// Flushes the workspace items that are due to be saved.
 /// </summary>
 public class WorkspaceItemSaver
 {
-    // How long a failed save waits before it is attempted again. The wait doubles with each failure up to
-    // the maximum, so an item that cannot be written settles into one attempt every fifteen seconds.
-    private const double InitialRetryDelay = 1.0;
-    private const double MaximumRetryDelay = 15.0;
-
     private readonly ILogger<WorkspaceItemSaver> _logger;
     private readonly ICommandService _commandService;
     private readonly IMessengerService _messengerService;
 
-    // The resources that cannot be written. A non-writable resource is left out, because its editor
-    // already shows it as read-only.
-    private readonly HashSet<ResourceKey> _failingResources = new();
+    // Every resource whose last save failed. A non-writable resource is held here so a locked file backs
+    // off on the same schedule as any other, but it is not reported, because its editor already shows it
+    // as read-only.
+    private readonly Dictionary<ResourceKey, SaveFailure> _saveFailures = new();
 
-    // The wait before each resource whose save failed is attempted again. Held for non-writable resources
-    // too, so a locked file backs off on the same schedule.
-    private readonly Dictionary<ResourceKey, SaveRetry> _saveRetries = new();
-
-    private bool _failingResourcesChanged;
+    private bool _reportedFailuresChanged;
 
     public WorkspaceItemSaver(
         ILogger<WorkspaceItemSaver> logger,
@@ -41,6 +33,14 @@ public class WorkspaceItemSaver
         _logger = logger;
         _commandService = commandService;
         _messengerService = messengerService;
+    }
+
+    /// <summary>
+    /// The resources that cannot be written, for a caller that starts observing after they were reported.
+    /// </summary>
+    public IReadOnlyList<ResourceKey> GetFailingResources()
+    {
+        return CollectReportedFailures();
     }
 
     /// <summary>
@@ -57,7 +57,7 @@ public class WorkspaceItemSaver
 
         int savedCount = 0;
         int pendingSaveCount = 0;
-        List<FailedResource> newFailures = new();
+        List<ResourceKey> newlyReportedResources = new();
         bool updateResourcesRequired = false;
 
         foreach (var item in items)
@@ -78,7 +78,7 @@ public class WorkspaceItemSaver
             {
                 // An item that is only waiting for its timer is counted as saving. One whose last attempt
                 // failed is reported as failing instead, so the two states never read as each other.
-                if (!_saveRetries.ContainsKey(item.FileResource))
+                if (!_saveFailures.ContainsKey(item.FileResource))
                 {
                     pendingSaveCount++;
                 }
@@ -91,7 +91,7 @@ public class WorkspaceItemSaver
                 continue;
             }
 
-            var saveResult = await item.SaveAsync();
+            var saveResult = await SaveItemAsync(item);
             if (saveResult.IsSuccess)
             {
                 savedCount++;
@@ -99,26 +99,18 @@ public class WorkspaceItemSaver
                 continue;
             }
 
-            ScheduleRetry(item.FileResource);
+            var reasonChanged = ScheduleRetry(item.FileResource, saveResult.MessageChain);
 
             // A non-writable item failing to save is expected, and reporting it would repeat what the
-            // editor already shows by dimming itself.
+            // editor already shows by dimming itself. One already reported stops being reported here, so a
+            // resource that turns non-writable ends up in the same state as one that was already
+            // non-writable when it was edited.
             if (item.WritableState != WritableState.Writable)
             {
+                StopReportingFailure(item.FileResource);
                 _logger.LogDebug($"Skipped save for non-writable workspace item: '{item.FileResource}'");
                 continue;
             }
-
-            if (!_failingResources.Add(item.FileResource))
-            {
-                continue;
-            }
-
-            _failingResourcesChanged = true;
-
-            // MessageChain is the outer-first reason. It carries developer English, so the log is where
-            // it belongs.
-            newFailures.Add(new FailedResource(item.FileResource, saveResult.MessageChain));
 
             // A failed save against a cache that still reads Writable suggests an external attribute flip
             // slipped past the watcher. The rebuild below covers the project tree, so only a resource in it
@@ -127,6 +119,19 @@ public class WorkspaceItemSaver
             {
                 updateResourcesRequired = true;
             }
+
+            // MessageChain is the outer-first reason and is not localized, so it belongs in the log rather
+            // than in anything the user sees. A reason that differs from the last attempt's is logged
+            // again, so a file that starts failing for a second reason says so.
+            if (reasonChanged)
+            {
+                _logger.LogError($"Failed to save workspace item '{item.FileResource}'. {saveResult.MessageChain}");
+            }
+
+            if (ReportFailure(item.FileResource))
+            {
+                newlyReportedResources.Add(item.FileResource);
+            }
         }
 
         DropStateForClosedItems(items);
@@ -134,7 +139,7 @@ public class WorkspaceItemSaver
         var pendingSaveMessage = new PendingSaveCountMessage(pendingSaveCount);
         _messengerService.Send(pendingSaveMessage);
 
-        SendFailingResourcesIfChanged();
+        SendReportedFailuresIfChanged();
 
         if (updateResourcesRequired)
         {
@@ -148,90 +153,148 @@ public class WorkspaceItemSaver
             _logger.LogDebug($"Saved {savedCount} modified workspace items");
         }
 
-        if (newFailures.Count == 0)
+        if (newlyReportedResources.Count == 0)
         {
             return Result.Ok();
         }
 
-        // The reason for each failure appears here and nowhere else.
-        var failureDescriptions = newFailures.Select(newFailure => $"'{newFailure.Resource}' ({newFailure.Message})");
-        var errorMessage = $"Failed to save the following workspace items: {string.Join(", ", failureDescriptions)}";
-        _logger.LogError(errorMessage);
+        var resourceNames = newlyReportedResources.Select(resource => $"'{resource}'");
 
-        return Result.Fail(errorMessage);
+        return Result.Fail($"Failed to save the following workspace items: {string.Join(", ", resourceNames)}");
     }
 
-    // Sends the resources that cannot be written whenever that set gains or loses one.
-    private void SendFailingResourcesIfChanged()
+    // Writes the item, turning an exception into a failed result so one editor cannot stop the save pass.
+    private async Task<Result> SaveItemAsync(IWorkspaceItem item)
     {
-        if (!_failingResourcesChanged)
+        try
+        {
+            return await item.SaveAsync();
+        }
+        catch (Exception exception)
+        {
+            return Result.Fail($"An exception occurred while saving workspace item: '{item.FileResource}'")
+                .WithException(exception);
+        }
+    }
+
+    // Starts reporting a resource to the user. Returns false when it is already reported.
+    private bool ReportFailure(ResourceKey resource)
+    {
+        var failure = _saveFailures[resource];
+        if (failure.IsReported)
+        {
+            return false;
+        }
+
+        _saveFailures[resource] = failure with { IsReported = true };
+        _reportedFailuresChanged = true;
+
+        return true;
+    }
+
+    // Stops reporting a resource to the user, leaving its wait in place so it goes on backing off.
+    private void StopReportingFailure(ResourceKey resource)
+    {
+        if (!_saveFailures.TryGetValue(resource, out var failure) ||
+            !failure.IsReported)
         {
             return;
         }
 
-        _failingResourcesChanged = false;
+        _saveFailures[resource] = failure with { IsReported = false };
+        _reportedFailuresChanged = true;
+    }
 
-        var failingResources = new List<ResourceKey>(_failingResources);
+    // Drops everything held about a resource, so a later failure is reported and backs off afresh.
+    private void ForgetFailure(ResourceKey resource)
+    {
+        if (_saveFailures.Remove(resource, out var failure) &&
+            failure.IsReported)
+        {
+            _reportedFailuresChanged = true;
+        }
+    }
 
-        var failuresChangedMessage = new WorkspaceItemSaveFailuresChangedMessage(failingResources);
+    // Sends the reported resources whenever that set gains or loses one.
+    private void SendReportedFailuresIfChanged()
+    {
+        if (!_reportedFailuresChanged)
+        {
+            return;
+        }
+
+        _reportedFailuresChanged = false;
+
+        var failuresChangedMessage = new WorkspaceItemSaveFailuresChangedMessage(CollectReportedFailures());
         _messengerService.Send(failuresChangedMessage);
+    }
+
+    private List<ResourceKey> CollectReportedFailures()
+    {
+        var reportedResources = new List<ResourceKey>();
+
+        foreach (var saveFailure in _saveFailures)
+        {
+            if (saveFailure.Value.IsReported)
+            {
+                reportedResources.Add(saveFailure.Key);
+            }
+        }
+
+        return reportedResources;
     }
 
     // Counts down the wait before each resource whose save failed is attempted again.
     private void AdvanceRetryWaits(double deltaTime)
     {
-        if (_saveRetries.Count == 0)
+        if (_saveFailures.Count == 0)
         {
             return;
         }
 
-        foreach (var resource in _saveRetries.Keys.ToList())
+        foreach (var resource in _saveFailures.Keys.ToList())
         {
-            var retry = _saveRetries[resource];
-            _saveRetries[resource] = retry with { Remaining = retry.Remaining - deltaTime };
+            var failure = _saveFailures[resource];
+            _saveFailures[resource] = failure with { Remaining = failure.Remaining - deltaTime };
         }
     }
 
     // Whether the resource is still waiting out the backoff from its last failed save.
     private bool IsWaitingToRetry(ResourceKey resource)
     {
-        if (!_saveRetries.TryGetValue(resource, out var retry))
+        if (!_saveFailures.TryGetValue(resource, out var failure))
         {
             return false;
         }
 
-        return retry.Remaining > 0;
+        return failure.Remaining > 0;
     }
 
     // Starts the next wait for a resource whose save failed, doubling the previous wait up to the maximum.
-    private void ScheduleRetry(ResourceKey resource)
+    // Returns true when this attempt failed for a different reason than the one before it.
+    private bool ScheduleRetry(ResourceKey resource, string reason)
     {
-        var delay = InitialRetryDelay;
-        if (_saveRetries.TryGetValue(resource, out var previousRetry))
+        var delay = SaveConstants.InitialRetryDelay;
+        var reasonChanged = true;
+        var isReported = false;
+
+        if (_saveFailures.TryGetValue(resource, out var previousFailure))
         {
-            delay = Math.Min(previousRetry.Delay * 2, MaximumRetryDelay);
+            delay = Math.Min(previousFailure.Delay * 2, SaveConstants.MaximumRetryDelay);
+            reasonChanged = previousFailure.Reason != reason;
+            isReported = previousFailure.IsReported;
         }
 
-        _saveRetries[resource] = new SaveRetry(delay, delay);
-    }
+        _saveFailures[resource] = new SaveFailure(delay, delay, reason, isReported);
 
-    // Forgets a resource that holds nothing unwritten, so a later failure is reported and backs off afresh.
-    private void ForgetFailure(ResourceKey resource)
-    {
-        if (_failingResources.Remove(resource))
-        {
-            _failingResourcesChanged = true;
-        }
-
-        _saveRetries.Remove(resource);
+        return reasonChanged;
     }
 
     // Forgets the resources that are no longer open, so one that fails again after being reopened is
     // reported again.
     private void DropStateForClosedItems(IReadOnlyList<IWorkspaceItem> items)
     {
-        if (_failingResources.Count == 0 &&
-            _saveRetries.Count == 0)
+        if (_saveFailures.Count == 0)
         {
             return;
         }
@@ -242,17 +305,11 @@ public class WorkspaceItemSaver
             openResources.Add(item.FileResource);
         }
 
-        var closedFailureCount = _failingResources.RemoveWhere(resource => !openResources.Contains(resource));
-        if (closedFailureCount > 0)
-        {
-            _failingResourcesChanged = true;
-        }
-
-        foreach (var resource in _saveRetries.Keys.ToList())
+        foreach (var resource in _saveFailures.Keys.ToList())
         {
             if (!openResources.Contains(resource))
             {
-                _saveRetries.Remove(resource);
+                ForgetFailure(resource);
             }
         }
     }

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceItemSaver.cs
@@ -43,6 +43,37 @@ public class WorkspaceItemSaver
     }
 
     /// <summary>
+    /// Writes every item that still holds unsaved changes, allowing each one the timeout in seconds to
+    /// write. An item that has not written by then is abandoned and its unsaved content is lost.
+    /// </summary>
+    public async Task FlushModifiedItemsAsync(IReadOnlyList<IWorkspaceItem> items, double timeout)
+    {
+        foreach (var item in items)
+        {
+            if (!item.HasUnsavedChanges)
+            {
+                continue;
+            }
+
+            var saveTask = SaveItemAsync(item);
+            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout));
+            var completedTask = await Task.WhenAny(saveTask, timeoutTask);
+
+            if (completedTask != saveTask)
+            {
+                _logger.LogError($"Workspace item did not write within {timeout}s, so its unsaved content was discarded: '{item.FileResource}'");
+                continue;
+            }
+
+            var saveResult = await saveTask;
+            if (saveResult.IsFailure)
+            {
+                _logger.LogError($"Failed to write unsaved content, so it was discarded: '{item.FileResource}'. {saveResult.DiagnosticReport}");
+            }
+        }
+    }
+
+    /// <summary>
     /// Ticks each item's save timer, writes the ones that are due, and reports the items still waiting to
     /// be written and those that cannot be. A failed write is reported once and its retries back off.
     /// Delta time is the time since this method was last called.

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
@@ -99,7 +99,7 @@ public class WorkspaceService : IWorkspaceService, IDisposable
         }
     }
 
-    public IReadOnlyList<ResourceKey> GetFailingSaveResources() => _workspaceItemSaver.GetFailingResources();
+    public IReadOnlyList<ResourceKey> GetRetryingResources() => _workspaceItemSaver.GetRetryingResources();
 
     public Task FlushModifiedItemsAsync()
     {

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
@@ -101,6 +101,20 @@ public class WorkspaceService : IWorkspaceService, IDisposable
 
     public IReadOnlyList<ResourceKey> GetFailingSaveResources() => _workspaceItemSaver.GetFailingResources();
 
+    public Task FlushModifiedItemsAsync()
+    {
+        return _workspaceItemSaver.FlushModifiedItemsAsync(CollectWorkspaceItems(), SaveConstants.UnloadFlushTimeout);
+    }
+
+    private List<IWorkspaceItem> CollectWorkspaceItems()
+    {
+        var workspaceItems = new List<IWorkspaceItem>();
+        workspaceItems.AddRange(DocumentsService.GetWorkspaceItems());
+        workspaceItems.AddRange(UtilityService.GetWorkspaceItems());
+
+        return workspaceItems;
+    }
+
     public async Task<Result> UpdateWorkspaceAsync(double deltaTime)
     {
         bool failed = false;
@@ -124,9 +138,7 @@ public class WorkspaceService : IWorkspaceService, IDisposable
             var savePassDelta = _timeSinceSavePass;
             _timeSinceSavePass = 0;
 
-            var workspaceItems = new List<IWorkspaceItem>();
-            workspaceItems.AddRange(DocumentsService.GetWorkspaceItems());
-            workspaceItems.AddRange(UtilityService.GetWorkspaceItems());
+            var workspaceItems = CollectWorkspaceItems();
 
             var saveItemsResult = await _workspaceItemSaver.SaveModifiedItemsAsync(workspaceItems, savePassDelta);
             if (saveItemsResult.IsFailure)

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
@@ -121,8 +121,6 @@ public class WorkspaceService : IWorkspaceService, IDisposable
         _timeSinceSavePass += deltaTime;
         if (_timeSinceSavePass >= SaveConstants.SavePassInterval)
         {
-            // The pass is given the time accumulated since it last ran, so save timers and retry waits
-            // count real time.
             var savePassDelta = _timeSinceSavePass;
             _timeSinceSavePass = 0;
 

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
@@ -114,13 +114,13 @@ public class WorkspaceService : IWorkspaceService, IDisposable
             }
         }
 
-        var saveableItems = new List<ISaveableWorkspaceItem>();
-        saveableItems.AddRange(DocumentsService.GetSaveableItems());
-        saveableItems.AddRange(UtilityService.GetSaveableItems());
+        var workspaceItems = new List<IWorkspaceItem>();
+        workspaceItems.AddRange(DocumentsService.GetWorkspaceItems());
+        workspaceItems.AddRange(UtilityService.GetWorkspaceItems());
 
         int pendingSaveCount = 0;
 
-        var saveItemsResult = await _workspaceItemSaver.SaveModifiedItemsAsync(saveableItems, deltaTime);
+        var saveItemsResult = await _workspaceItemSaver.SaveModifiedItemsAsync(workspaceItems, deltaTime);
         if (saveItemsResult.IsFailure)
         {
             failed = true;

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
@@ -11,10 +11,6 @@ namespace Celbridge.WorkspaceUI.Services;
 
 public class WorkspaceService : IWorkspaceService, IDisposable
 {
-    // How often the save pass runs. Item save delays are measured in seconds, so this is the precision a
-    // save lands with.
-    private const double SavePassInterval = 0.1;
-
     private readonly ILogger<WorkspaceService> _logger;
     private readonly IMessengerService _messengerService;
     private readonly WorkspaceItemSaver _workspaceItemSaver;
@@ -103,6 +99,8 @@ public class WorkspaceService : IWorkspaceService, IDisposable
         }
     }
 
+    public IReadOnlyList<ResourceKey> GetFailingSaveResources() => _workspaceItemSaver.GetFailingResources();
+
     public async Task<Result> UpdateWorkspaceAsync(double deltaTime)
     {
         bool failed = false;
@@ -121,7 +119,7 @@ public class WorkspaceService : IWorkspaceService, IDisposable
         }
 
         _timeSinceSavePass += deltaTime;
-        if (_timeSinceSavePass >= SavePassInterval)
+        if (_timeSinceSavePass >= SaveConstants.SavePassInterval)
         {
             // The pass is given the time accumulated since it last ran, so save timers and retry waits
             // count real time.

--- a/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/Services/WorkspaceService.cs
@@ -11,6 +11,10 @@ namespace Celbridge.WorkspaceUI.Services;
 
 public class WorkspaceService : IWorkspaceService, IDisposable
 {
+    // How often the save pass runs. Item save delays are measured in seconds, so this is the precision a
+    // save lands with.
+    private const double SavePassInterval = 0.1;
+
     private readonly ILogger<WorkspaceService> _logger;
     private readonly IMessengerService _messengerService;
     private readonly WorkspaceItemSaver _workspaceItemSaver;
@@ -32,6 +36,8 @@ public class WorkspaceService : IWorkspaceService, IDisposable
     public IDocumentsPanel DocumentsPanel { get; private set; } = null!;
 
     private bool _workspaceStateIsDirty;
+
+    private double _timeSinceSavePass;
 
     public WorkspaceService(
         IServiceProvider serviceProvider,
@@ -114,25 +120,25 @@ public class WorkspaceService : IWorkspaceService, IDisposable
             }
         }
 
-        var workspaceItems = new List<IWorkspaceItem>();
-        workspaceItems.AddRange(DocumentsService.GetWorkspaceItems());
-        workspaceItems.AddRange(UtilityService.GetWorkspaceItems());
-
-        int pendingSaveCount = 0;
-
-        var saveItemsResult = await _workspaceItemSaver.SaveModifiedItemsAsync(workspaceItems, deltaTime);
-        if (saveItemsResult.IsFailure)
+        _timeSinceSavePass += deltaTime;
+        if (_timeSinceSavePass >= SavePassInterval)
         {
-            failed = true;
-            _logger.LogError($"Failed to save modified workspace items. {saveItemsResult.DiagnosticReport}");
-        }
-        else
-        {
-            pendingSaveCount = saveItemsResult.Value;
-        }
+            // The pass is given the time accumulated since it last ran, so save timers and retry waits
+            // count real time.
+            var savePassDelta = _timeSinceSavePass;
+            _timeSinceSavePass = 0;
 
-        var pendingSaveMessage = new PendingSaveCountMessage(pendingSaveCount);
-        _messengerService.Send(pendingSaveMessage);
+            var workspaceItems = new List<IWorkspaceItem>();
+            workspaceItems.AddRange(DocumentsService.GetWorkspaceItems());
+            workspaceItems.AddRange(UtilityService.GetWorkspaceItems());
+
+            var saveItemsResult = await _workspaceItemSaver.SaveModifiedItemsAsync(workspaceItems, savePassDelta);
+            if (saveItemsResult.IsFailure)
+            {
+                failed = true;
+                _logger.LogError($"Failed to save modified workspace items. {saveItemsResult.DiagnosticReport}");
+            }
+        }
 
         // Flush any pending Workspace-scope setting writes (panel sizes, search
         // options, last new-file extension). These are set on the UI thread but

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspaceToastViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspaceToastViewModel.cs
@@ -67,7 +67,7 @@ public partial class WorkspaceToastViewModel : ObservableObject
         _messengerService.Register<ProjectLoadNotificationMessage>(this, OnProjectLoadNotification);
         _messengerService.Register<ResourceOperationFailedMessage>(this, OnResourceOperationFailed);
         _messengerService.Register<EditorNotificationMessage>(this, OnEditorNotification);
-        _messengerService.Register<WorkspaceItemSaveFailedMessage>(this, OnWorkspaceItemSaveFailed);
+        _messengerService.Register<WorkspaceItemSaveDiscardedMessage>(this, OnWorkspaceItemSaveDiscarded);
     }
 
     private void OnProjectLoadNotification(object recipient, ProjectLoadNotificationMessage message)
@@ -81,10 +81,10 @@ public partial class WorkspaceToastViewModel : ObservableObject
         _dispatcher.TryEnqueue(() => Show(ComposeOperationNotification(message)));
     }
 
-    private void OnWorkspaceItemSaveFailed(object recipient, WorkspaceItemSaveFailedMessage message)
+    private void OnWorkspaceItemSaveDiscarded(object recipient, WorkspaceItemSaveDiscardedMessage message)
     {
-        // Raised from the workspace update loop, which does not run on the UI thread.
-        _dispatcher.TryEnqueue(() => Show(ComposeSaveFailureNotification(message)));
+        // Raised from the document close path, which does not always run on the UI thread.
+        _dispatcher.TryEnqueue(() => Show(ComposeSaveDiscardedNotification(message)));
     }
 
     private void OnEditorNotification(object recipient, EditorNotificationMessage message)
@@ -104,28 +104,13 @@ public partial class WorkspaceToastViewModel : ObservableObject
         };
     }
 
-    private WorkspaceNotification ComposeSaveFailureNotification(WorkspaceItemSaveFailedMessage message)
+    private WorkspaceNotification ComposeSaveDiscardedNotification(WorkspaceItemSaveDiscardedMessage message)
     {
-        var failedItems = message.FailedItems;
-
-        if (failedItems.Count == 1)
-        {
-            var failedItem = failedItems[0];
-            var reason = ToSingleLine(failedItem.Message);
-
-            return Compose(
-                ReportSeverity.Error,
-                "Toast_SaveFailed_Single",
-                action: null,
-                failedItem.Resource.ResourceName,
-                reason);
-        }
-
         return Compose(
             ReportSeverity.Error,
-            "Toast_SaveFailed_Multiple",
+            "Toast_SaveDiscarded",
             action: null,
-            failedItems.Count);
+            message.Resource.ResourceName);
     }
 
     private WorkspaceNotification ComposeLoadNotification(ProjectLoadReportSummary summary)

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspaceViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspaceViewModel.cs
@@ -65,6 +65,10 @@ public partial class WorkspaceViewModel : ObservableObject
             // Save editor states before closing documents, while editors are still alive.
             await _workspaceService.DocumentsService.StoreDocumentEditorStates();
 
+            // Write anything the save tick has not reached. The tick stops with the workspace and closing
+            // a document does not write it, so this is the last chance to get the content to disk.
+            await _workspaceService.DocumentsService.FlushModifiedDocumentsAsync();
+
             // Close all open documents and clean up their WebView2 resources.
             _workspaceService.DocumentsPanel.Shutdown();
 

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspaceViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspaceViewModel.cs
@@ -66,7 +66,7 @@ public partial class WorkspaceViewModel : ObservableObject
             await _workspaceService.DocumentsService.StoreDocumentEditorStates();
 
             // Write anything the save tick has not reached.
-            await _workspaceService.DocumentsService.FlushModifiedDocumentsAsync();
+            await _workspaceService.FlushModifiedItemsAsync();
 
             // Close all open documents and clean up their WebView2 resources.
             _workspaceService.DocumentsPanel.Shutdown();

--- a/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspaceViewModel.cs
+++ b/Source/Workspace/Celbridge.WorkspaceUI/ViewModels/WorkspaceViewModel.cs
@@ -65,8 +65,7 @@ public partial class WorkspaceViewModel : ObservableObject
             // Save editor states before closing documents, while editors are still alive.
             await _workspaceService.DocumentsService.StoreDocumentEditorStates();
 
-            // Write anything the save tick has not reached. The tick stops with the workspace and closing
-            // a document does not write it, so this is the last chance to get the content to disk.
+            // Write anything the save tick has not reached.
             await _workspaceService.DocumentsService.FlushModifiedDocumentsAsync();
 
             // Close all open documents and clean up their WebView2 resources.


### PR DESCRIPTION
This pull request refactors and improves the workspace save model and its UI feedback mechanisms. The changes focus on generalizing the workspace item interface, enhancing save failure reporting, and updating the UI to clearly indicate save issues to users. It also introduces new constants for save timings and improves testability.

**Workspace Save Model Refactor:**

* Renamed `ISaveableWorkspaceItem` to `IWorkspaceItem`, generalizing the concept to include both documents and utilities, and updated all related interfaces (`IDocumentView`, `IDocumentsPanel`, `IDocumentsService`, `IUtilityService`) to use the new interface and method names (`GetWorkspaceItems` instead of `GetSaveableItems`). (`[[1]](diffhunk://#diff-0711766fd5130cbce3976876695851a1302e986ce75bd763a4a15fa203ed1f73L4-R15)`, `[[2]](diffhunk://#diff-d81765e486b48333db1b53e1f8ca37952ad2911d240e61d37a185c3244f2f555L8-R8)`, `[[3]](diffhunk://#diff-4d87ca2764d41165ff0c656c66c177602c093e241b283b8485b2fc0b81f2c0a8L107-R109)`, `[[4]](diffhunk://#diff-885a7fa89647091156cd906fe17275f21caa03a90c001a539e7971e30e5cfdd1L97-R99)`, `[[5]](diffhunk://#diff-0754556c715b188323f7d9b17e523f8dec8632e49874379841d2f9a4aef7ed8aL66-R68)`)
* Added new methods to `IWorkspaceService` for flushing unsaved items and retrieving resources with failed saves (`FlushModifiedItemsAsync`, `GetRetryingResources`). (`[Source/Core/Celbridge.Foundation/Workspace/IWorkspaceService.csR91-R101](diffhunk://#diff-68ff8becaa7d36bb6943db981c547b2a77e0ecb40a17600a395f6f1c6faca429R91-R101)`)
* Introduced `SaveConstants` containing timing values for save operations, retries, and timeouts. (`[Source/Core/Celbridge.Foundation/Workspace/SaveConstants.csR1-R34](diffhunk://#diff-531d160abec9e6bf6689090500f3418705d26c347c1119a84d479df51bbe27b2R1-R34)`)

**Save Failure Handling and Messaging:**

* Replaced `WorkspaceItemSaveFailedMessage` with `WorkspaceItemSaveRetriesChangedMessage` to track resources pending save retries, and added `WorkspaceItemSaveDiscardedMessage` for when unsaved changes are lost. (`[Source/Core/Celbridge.Foundation/Workspace/WorkspaceMessages.csL9-R18](diffhunk://#diff-6230d4b6eb07ddb329c10b33eefee42a5f58bd2537e409f634894ab7bf841da1L9-R18)`)
* Updated logic in `WebViewDocumentViewModel` to ensure `HasUnsavedChanges` is set correctly on failed saves. (`[[1]](diffhunk://#diff-23dacb4340b04aa493ce2d4b2cda13558dafb55a1cf9a5b919e0e02543be1842L496-R496)`, `[[2]](diffhunk://#diff-23dacb4340b04aa493ce2d4b2cda13558dafb55a1cf9a5b919e0e02543be1842L510-R516)`)

**User Interface Enhancements:**

* Refactored `TitleBarViewModel` to display a warning icon and tooltip when there are save failures, using localized messages for single and multiple failures. Registered for new workspace save retry messages and updated state accordingly. (`[[1]](diffhunk://#diff-9b2e920cb6b4aa0f28537b1323952e8ab8fe87c5ee493ed131976f4f02c6a588R2)`, `[[2]](diffhunk://#diff-9b2e920cb6b4aa0f28537b1323952e8ab8fe87c5ee493ed131976f4f02c6a588R13-R42)`, `[[3]](diffhunk://#diff-9b2e920cb6b4aa0f28537b1323952e8ab8fe87c5ee493ed131976f4f02c6a588R60-R89)`)
* Updated `ApplicationToolbar.xaml` to show a warning icon and tooltip next to the save icon when there are save retries, improving user awareness of save issues. (`[Source/Core/Celbridge.UserInterface/Views/Controls/ApplicationToolbar.xamlL47-R69](diffhunk://#diff-b41216e863c55dc08f39efaaf757a8b6437e7a4c0deb20119eaef9acf755c5bdL47-R69)`)
* Added new localized strings for save failure and discard scenarios. (`[Source/Celbridge/Resources/Strings/en-US/Resources.reswL216-R231](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40L216-R231)`)

**Testing Improvements:**

* Updated tests to use the new interfaces and provide a mock `IStringLocalizer` for verifying localized save failure messages. (`[[1]](diffhunk://#diff-81e6b5acebfd7c44e3d567ea88ee5ef2a5fbc67bc874741ec7df36ce24b65b30R7)`, `[[2]](diffhunk://#diff-81e6b5acebfd7c44e3d567ea88ee5ef2a5fbc67bc874741ec7df36ce24b65b30R27-R28)`, `[[3]](diffhunk://#diff-81e6b5acebfd7c44e3d567ea88ee5ef2a5fbc67bc874741ec7df36ce24b65b30L54-R71)`, `[[4]](diffhunk://#diff-81e6b5acebfd7c44e3d567ea88ee5ef2a5fbc67bc874741ec7df36ce24b65b30L76-R94)`)

**Error Handling:**

* Added a try/catch block around application update logic in `CommandService` to ensure exceptions are logged and do not go unobserved. (`[Source/Core/Celbridge.Commands/Services/CommandService.csR226-R238](diffhunk://#diff-addcfac80523aa5425f093dbbd8919112371479d838e11497d7564b6662202a0R226-R238)`)