### PR TITLE
Rename 'Select File' to 'Reveal in Explorer' and update visibility

### DIFF
--- a/Source/Celbridge/Resources/Strings/en-US/Resources.resw
+++ b/Source/Celbridge/Resources/Strings/en-US/Resources.resw
@@ -557,7 +557,7 @@ This file could not be saved</value>
     <value>File Explorer</value>
   </data>
   <data name="ResourceTree_OpenApplication" xml:space="preserve">
-    <value>Open with Application</value>
+    <value>Open in Application</value>
   </data>
   <data name="WebView_UrlBar_BackTooltip" xml:space="preserve">
     <value>Go Back</value>
@@ -855,14 +855,14 @@ Open with default application instead?</value>
   <data name="DocumentTab_UnsplitAll" xml:space="preserve">
     <value>Unsplit All</value>
   </data>
-  <data name="DocumentTab_SelectFile" xml:space="preserve">
-    <value>Select File</value>
-  </data>
   <data name="DocumentTab_CopyResourceKey" xml:space="preserve">
     <value>Copy Resource Key</value>
   </data>
   <data name="DocumentTab_CopyFilePath" xml:space="preserve">
     <value>Copy File Path</value>
+  </data>
+  <data name="DocumentTab_RevealInExplorer" xml:space="preserve">
+    <value>Reveal in Explorer</value>
   </data>
   <data name="DocumentTab_OpenFileManager" xml:space="preserve">
     <value>Open in {0}</value>
@@ -1111,7 +1111,7 @@ Open with default application instead?</value>
     <value>Open the manifest file</value>
   </data>
   <data name="ProjectSettings_RevealManifestTooltip" xml:space="preserve">
-    <value>Show the manifest file in the Explorer</value>
+    <value>Reveal in Explorer</value>
   </data>
   <data name="ProjectSettings_ContributionType_Document" xml:space="preserve">
     <value>Document Editor</value>

--- a/Source/Tests/Documents/DocumentTabViewModelTests.cs
+++ b/Source/Tests/Documents/DocumentTabViewModelTests.cs
@@ -9,9 +9,9 @@ using Microsoft.Extensions.Localization;
 namespace Celbridge.Tests.Documents;
 
 /// <summary>
-/// Tests for DocumentTabViewModel close-path behaviour. The save-failure tolerance is
-/// load-bearing for locked or otherwise read-only documents, where the save will never
-/// succeed and the close path must still complete.
+/// Tests for DocumentTabViewModel close-path behaviour and the menu predicates derived from its file
+/// resource. The save-failure tolerance is load-bearing for locked or otherwise read-only documents,
+/// where the save will never succeed and the close path must still complete.
 /// </summary>
 [TestFixture]
 public class DocumentTabViewModelTests
@@ -299,6 +299,24 @@ public class DocumentTabViewModelTests
         viewModel.TabTooltip.Should()
             .StartWith("DocumentTab_Tooltip_SaveFailed(")
             .And.Contain("C:/project/locked.md");
+    }
+
+    [Test]
+    public void CanRevealInExplorer_IsTrue_ForProjectResource()
+    {
+        var viewModel = CreateViewModel(new ResourceKey("docs/notes.md"));
+
+        viewModel.CanRevealInExplorer.Should().BeTrue();
+    }
+
+    [Test]
+    public void CanRevealInExplorer_IsFalse_ForNonProjectRoot()
+    {
+        // The Explorer shows the project tree, so a document opened from any other root has nothing to
+        // reveal and the menu option is hidden.
+        var viewModel = CreateViewModel(new ResourceKey("temp:community.webview"));
+
+        viewModel.CanRevealInExplorer.Should().BeFalse();
     }
 
     private static IDocumentView CreateUnwritableDocumentView()

--- a/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs
@@ -97,6 +97,12 @@ public partial class DocumentTabViewModel : ObservableObject
     public string FileName => FileResource.ResourceName;
 
     /// <summary>
+    /// True when this tab's file can be revealed in the Explorer. The Explorer shows the project tree, so
+    /// a document opened from any other resource root has nothing to reveal.
+    /// </summary>
+    public bool CanRevealInExplorer => FileResource.Root == ResourceKey.DefaultRoot;
+
+    /// <summary>
     /// Tooltip text for the tab. A utility tab shows its manifest description, falling back to its title
     /// when none is declared. An ordinary tab shows its file path plus the editor name when multiple
     /// editors are available. A tab whose file cannot be written says so below that.

--- a/Source/Workspace/Celbridge.Documents/ViewModels/WorkspacePanelViewModel.cs
+++ b/Source/Workspace/Celbridge.Documents/ViewModels/WorkspacePanelViewModel.cs
@@ -202,7 +202,7 @@ public partial class WorkspacePanelViewModel : ObservableObject
         return resourceRegistry.ResolveResourcePath(fileResource);
     }
 
-    public void SelectFileForTab(ResourceKey fileResource)
+    public void RevealInExplorerForTab(ResourceKey fileResource)
     {
         _commandService.Execute<ISelectResourceCommand>(command =>
         {

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml
@@ -28,12 +28,11 @@
             <MenuFlyoutItem x:Name="MoveToPrimarySectionMenuItem" Click="ContextMenu_MoveToPrimarySection" />
             <MenuFlyoutItem x:Name="MoveToSecondarySectionMenuItem" Click="ContextMenu_MoveToSecondarySection" />
             <MenuFlyoutItem x:Name="UnsplitAreaMenuItem" Click="ContextMenu_UnsplitArea" />
-            <MenuFlyoutSeparator x:Name="SelectFileSeparator" />
-            <MenuFlyoutItem x:Name="SelectFileMenuItem" Click="ContextMenu_SelectFile" />
             <MenuFlyoutSeparator x:Name="CopySeparator" />
             <MenuFlyoutItem x:Name="CopyResourceKeyMenuItem" Click="ContextMenu_CopyResourceKey" />
             <MenuFlyoutItem x:Name="CopyFilePathMenuItem" Click="ContextMenu_CopyFilePath" />
             <MenuFlyoutSeparator x:Name="OpenSeparator" />
+            <MenuFlyoutItem x:Name="RevealInExplorerMenuItem" Click="ContextMenu_RevealInExplorer" />
             <MenuFlyoutItem x:Name="OpenFileExplorerMenuItem" Click="ContextMenu_OpenFileExplorer" />
             <MenuFlyoutItem x:Name="OpenApplicationMenuItem" Click="ContextMenu_OpenApplication" />
             <MenuFlyoutSeparator x:Name="RestoreChromeSeparator" />

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
@@ -378,9 +378,13 @@ public partial class DocumentTab : TabViewItem
         CopyResourceKeyMenuItem.Visibility = fileActionsVisibility;
         CopyFilePathMenuItem.Visibility = fileActionsVisibility;
         OpenSeparator.Visibility = fileActionsVisibility;
-        RevealInExplorerMenuItem.Visibility = fileActionsVisibility;
         OpenFileExplorerMenuItem.Visibility = fileActionsVisibility;
         OpenApplicationMenuItem.Visibility = fileActionsVisibility;
+
+        // A document opened from a resource root the Explorer does not show cannot be revealed there. The
+        // rest of the group still resolves to a real path, so only this option goes.
+        bool canReveal = !isUtility && ViewModel.CanRevealInExplorer;
+        RevealInExplorerMenuItem.Visibility = canReveal ? Visibility.Visible : Visibility.Collapsed;
 
         // A view that has hidden the chrome carrying its own controls has no way back, so the shared menu
         // offers one. The view supplies the text, so this menu never names a particular kind of chrome.

--- a/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs
@@ -26,7 +26,7 @@ public enum DocumentTabMenuAction
     UnsplitArea,
     CopyResourceKey,
     CopyFilePath,
-    SelectFile,
+    RevealInExplorer,
     OpenFileExplorer,
     OpenApplication,
     RestoreChrome,
@@ -150,7 +150,7 @@ public partial class DocumentTab : TabViewItem
         ApplyMoveMenuLabels();
         CopyResourceKeyMenuItem.Text = _stringLocalizer.GetString("DocumentTab_CopyResourceKey");
         CopyFilePathMenuItem.Text = _stringLocalizer.GetString("DocumentTab_CopyFilePath");
-        SelectFileMenuItem.Text = _stringLocalizer.GetString("DocumentTab_SelectFile");
+        RevealInExplorerMenuItem.Text = _stringLocalizer.GetString("DocumentTab_RevealInExplorer");
         string fileManagerName = _stringLocalizer.GetString(_platformInfo.FileManagerNameStringKey);
         OpenFileExplorerMenuItem.Text = _stringLocalizer.GetString("DocumentTab_OpenFileManager", fileManagerName);
         OpenApplicationMenuItem.Text = _stringLocalizer.GetString("DocumentTab_OpenApplication");
@@ -278,9 +278,9 @@ public partial class DocumentTab : TabViewItem
         ContextMenuActionRequested?.Invoke(this, DocumentTabMenuAction.UnsplitArea);
     }
 
-    private void ContextMenu_SelectFile(object sender, RoutedEventArgs e)
+    private void ContextMenu_RevealInExplorer(object sender, RoutedEventArgs e)
     {
-        ContextMenuActionRequested?.Invoke(this, DocumentTabMenuAction.SelectFile);
+        ContextMenuActionRequested?.Invoke(this, DocumentTabMenuAction.RevealInExplorer);
     }
 
     private void ContextMenu_CopyResourceKey(object sender, RoutedEventArgs e)
@@ -374,12 +374,11 @@ public partial class DocumentTab : TabViewItem
         // backing file. The close and move options remain.
         bool isUtility = ViewModel.IsDockedUtility;
         var fileActionsVisibility = isUtility ? Visibility.Collapsed : Visibility.Visible;
-        SelectFileSeparator.Visibility = fileActionsVisibility;
-        SelectFileMenuItem.Visibility = fileActionsVisibility;
         CopySeparator.Visibility = fileActionsVisibility;
         CopyResourceKeyMenuItem.Visibility = fileActionsVisibility;
         CopyFilePathMenuItem.Visibility = fileActionsVisibility;
         OpenSeparator.Visibility = fileActionsVisibility;
+        RevealInExplorerMenuItem.Visibility = fileActionsVisibility;
         OpenFileExplorerMenuItem.Visibility = fileActionsVisibility;
         OpenApplicationMenuItem.Visibility = fileActionsVisibility;
 

--- a/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.TabMenu.cs
+++ b/Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.TabMenu.cs
@@ -43,8 +43,8 @@ public sealed partial class WorkspacePanel
             case DocumentTabMenuAction.CopyFilePath:
                 CopyFilePathForTab(tab);
                 break;
-            case DocumentTabMenuAction.SelectFile:
-                SelectFileForTab(tab);
+            case DocumentTabMenuAction.RevealInExplorer:
+                RevealInExplorerForTab(tab);
                 break;
             case DocumentTabMenuAction.OpenFileExplorer:
                 OpenFileExplorerForTab(tab);
@@ -230,9 +230,9 @@ public sealed partial class WorkspacePanel
         }
     }
 
-    private void SelectFileForTab(DocumentTab tab)
+    private void RevealInExplorerForTab(DocumentTab tab)
     {
-        ViewModel.SelectFileForTab(tab.ViewModel.FileResource);
+        ViewModel.RevealInExplorerForTab(tab.ViewModel.FileResource);
     }
 
     private void CopyResourceKeyForTab(DocumentTab tab)


### PR DESCRIPTION
This pull request updates the document tab context menu by replacing the "Select File" action with a new "Reveal in Explorer" action. The new action only appears when the file is part of the project root, aligning the UI and behavior with the Explorer's capabilities. The changes update resource strings, menu logic, and related tests to support this new action.

**Document Tab Context Menu Improvements:**

* Replaced the "Select File" menu item with "Reveal in Explorer" in the document tab context menu, including updating the menu item name, click handler, and visibility logic to only show the option for files under the project root. (`Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml`, `Source/Workspace/Celbridge.Documents/Views/DocumentTab.xaml.cs`, `Source/Workspace/Celbridge.Documents/ViewModels/DocumentTabViewModel.cs`, [[1]](diffhunk://#diff-1bf3e290fbf0c21992e36fbb4c71f091898b973e0820d664620d3c609b0b041bL31-R35) [[2]](diffhunk://#diff-a3fe39a3ebffeb9d3edc17011c85edf3b29f769023710a3f3d0e01202d3ce21fL29-R29) [[3]](diffhunk://#diff-a3fe39a3ebffeb9d3edc17011c85edf3b29f769023710a3f3d0e01202d3ce21fL153-R153) [[4]](diffhunk://#diff-a3fe39a3ebffeb9d3edc17011c85edf3b29f769023710a3f3d0e01202d3ce21fL281-R283) [[5]](diffhunk://#diff-a3fe39a3ebffeb9d3edc17011c85edf3b29f769023710a3f3d0e01202d3ce21fL377-R388) [[6]](diffhunk://#diff-89343289f4b70273474ab65f3e08eb7df78f4b22339a22634af01869d98eedbdR99-R104)
* Updated the context menu action dispatch and handler to use `RevealInExplorer` instead of `SelectFile`, and renamed the corresponding methods in the tab menu code and view model. (`Source/Workspace/Celbridge.Documents/Views/WorkspacePanel.TabMenu.cs`, `Source/Workspace/Celbridge.Documents/ViewModels/WorkspacePanelViewModel.cs`, [[1]](diffhunk://#diff-895f486804524a3e612daa8bbddfe841771d38ff6d0b57f195091e1843214be3L46-R47) [[2]](diffhunk://#diff-895f486804524a3e612daa8bbddfe841771d38ff6d0b57f195091e1843214be3L233-R235) [[3]](diffhunk://#diff-6bf6c29471937fb73fedf071b0ee9799d37912079bc56f583395b7b9973e970bL205-R205)

**Resource and Localization Updates:**

* Updated resource strings to add `DocumentTab_RevealInExplorer` and removed `DocumentTab_SelectFile`. Also unified similar labels to "Reveal in Explorer" for consistency. (`Source/Celbridge/Resources/Strings/en-US/Resources.resw`, [[1]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40L560-R560) [[2]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40L858-R866) [[3]](diffhunk://#diff-91f42510ce5a4870413290895d9e917f6e596be4fdc46575f9675b4844692f40L1114-R1114)

**Testing Enhancements:**

* Added new tests to verify the visibility logic for the "Reveal in Explorer" menu item, ensuring it only appears for files under the project root. (`Source/Tests/Documents/DocumentTabViewModelTests.cs`, [[1]](diffhunk://#diff-81e6b5acebfd7c44e3d567ea88ee5ef2a5fbc67bc874741ec7df36ce24b65b30L12-R14) [[2]](diffhunk://#diff-81e6b5acebfd7c44e3d567ea88ee5ef2a5fbc67bc874741ec7df36ce24b65b30R304-R321)